### PR TITLE
fix: configure redirect parameter for walletconnect

### DIFF
--- a/apps/mobile/ios/RabbyMobile/Info.plist
+++ b/apps/mobile/ios/RabbyMobile/Info.plist
@@ -20,6 +20,19 @@
 	<string>0.1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+  <key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.debank.rabbymobile</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>rabbymobile</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/apps/mobile/src/utils/wc.ts
+++ b/apps/mobile/src/utils/wc.ts
@@ -12,6 +12,9 @@ export const GET_WALLETCONNECT_CONFIG = () => {
         'https://static-assets.rabby.io/files/122da969-da58-42e9-ab39-0a8dd38d94b8.png',
       ],
       name: 'Rabby',
+      redirect: {
+        native: 'rabbymobile://',
+      },
     },
     projectId: 'ed21a1293590bdc995404dff7e033f04',
     v2Whitelist: [


### PR DESCRIPTION
Only iOS < 17 supports redirect, refer to https://github.com/WalletConnect/modal-react-native/issues/86#issuecomment-1734213401.

Currently only bitget is supported.