### PR TITLE
Improves transaction history handling and Introduces source_type

### DIFF
--- a/apps/mobile/src/core/services/transactionHistory.ts
+++ b/apps/mobile/src/core/services/transactionHistory.ts
@@ -105,7 +105,7 @@ export class TransactionHistoryService {
   preferenceService?: import('./preference').PreferenceService;
 
   private _signingTxList: TransactionSigningItem[] = [];
-  private _txHistoryLimit = 100;
+  private _txHistoryLimit = 500;
 
   constructor(
     options?: StorageAdapaterOptions & {
@@ -726,7 +726,7 @@ export class TransactionHistoryService {
     }
   };
   /**
-   * @description clear expired txs, keep this.txHistoryLimit 100 compoleted transactions
+   * @description clear expired txs, keep this.txHistoryLimit 500 compoleted transactions
    */
   clearAllExpiredTxs() {
     const groups = this.getTransactionGroups();

--- a/apps/mobile/src/core/services/transactionHistory.ts
+++ b/apps/mobile/src/core/services/transactionHistory.ts
@@ -726,7 +726,7 @@ export class TransactionHistoryService {
     }
   };
   /**
-   * @description clear expired txs, keep this.txHistoryLimit 500 compoleted transactions
+   * @description clear expired txs, keep this.txHistoryLimit 500 completed transactions
    */
   clearAllExpiredTxs() {
     const groups = this.getTransactionGroups();

--- a/apps/mobile/src/databases/entities/localhistoryItem.ts
+++ b/apps/mobile/src/databases/entities/localhistoryItem.ts
@@ -16,7 +16,10 @@ import { prepareAppDataSource } from '../imports';
 import BigNumber from 'bignumber.js';
 import { findChain } from '@/utils/chain';
 import { TransactionHistoryItem } from '@/core/services/transactionHistory';
-import { HistoryItemCateType } from '@/screens/Transaction/components/type';
+import {
+  HistoryItemCateType,
+  TransactionSourceType,
+} from '@/screens/Transaction/components/type';
 
 @Entity('cache_localhistoryitem')
 export class LocalHistoryItemEntity extends EntityAddressAssetBase {
@@ -108,6 +111,9 @@ export class LocalHistoryItemEntity extends EntityAddressAssetBase {
   @Column('text', { default: '' })
   historyItemCateType?: HistoryItemCateType = HistoryItemCateType.UnKnown;
 
+  @Column('text', { default: '' })
+  source_type?: string = '';
+
   makeDbId(): string {
     return (this._db_id = `${this.owner_addr}-${[this.chain, this.txHash]
       .filter(Boolean)
@@ -184,6 +190,7 @@ export class LocalHistoryItemEntity extends EntityAddressAssetBase {
     e.tx_usd_gas_fee = input.gasUSDValue ?? 0;
     e.tx_eth_gas_fee = input.gasTokenCount ?? 0;
     e.historyItemCateType = HistoryItemCateType.Send;
+    e.source_type = input.$ctx?.ga?.source ?? '';
 
     e.makeDbId();
   }
@@ -259,53 +266,6 @@ export class LocalHistoryItemEntity extends EntityAddressAssetBase {
       .take(count || 10000); // limit
 
     const res = await queryBuilder.getMany();
-    return res;
-  }
-
-  static async getTokenHistoryItemSortedByTime(
-    owner_addrs: string[],
-    tokenId: string,
-    chain: string,
-    count?: number,
-  ) {
-    await prepareAppDataSource();
-
-    const repo = this.getRepository();
-    const currentTime = new Date().getTime();
-    const ninetyDaysAgo = Math.floor(currentTime / 1000) - 90 * 24 * 60 * 60;
-    console.log('getTokenHistoryItemSortedByTime exec');
-
-    const queryBuilder = repo
-      .createQueryBuilder('historyitem')
-      .where('historyitem.owner_addr IN (:...owner_addrs)', { owner_addrs })
-      .andWhere('historyitem.chain = :chain', { chain })
-      .andWhere('historyitem.time_at >= :ninetyDaysAgo', { ninetyDaysAgo })
-      .andWhere(
-        new Brackets(qb => {
-          qb.where(
-            `EXISTS (
-                SELECT 1
-                FROM json_each(json_extract(historyitem.receives, '$')) AS json_each
-                WHERE json_each.value ->> 'token_id' = :tokenId
-              )`,
-          ).orWhere(
-            `EXISTS (
-                SELECT 1
-                FROM json_each(json_extract(historyitem.sends, '$')) AS json_each
-                WHERE json_each.value ->> 'token_id' = :tokenId
-              )`,
-          );
-        }),
-        { tokenId },
-      )
-      .orderBy('historyitem.time_at', 'DESC')
-      .take(count || 10000); // limit
-
-    const res = await queryBuilder.getMany();
-    console.log(
-      'getTokenHistoryItemSortedByTime exec done',
-      new Date().getTime() - currentTime,
-    );
     return res;
   }
 

--- a/apps/mobile/src/databases/migrations/20250418.ts
+++ b/apps/mobile/src/databases/migrations/20250418.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm/browser';
+import { APP_DB_PREFIX } from '../constant';
+
+const historyTableName = `${APP_DB_PREFIX}cache_localhistoryitem`;
+
+async function checkIfTableExists(queryRunner: QueryRunner, tableName: string) {
+  const tableExists = await queryRunner.query(
+    `
+    SELECT 1 FROM sqlite_master WHERE type='table' AND name=?;
+  `,
+    [tableName],
+  );
+
+  return tableExists.length > 0;
+}
+
+export class UpdateHistoryTableAddSourceType1744873800025
+  implements MigrationInterface
+{
+  transaction = false;
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    const tableExists = await checkIfTableExists(queryRunner, historyTableName);
+    if (tableExists) {
+      await queryRunner.query(
+        `ALTER TABLE '${historyTableName}' ADD COLUMN source_type TEXT DEFAULT ''`,
+      );
+    }
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    const tableExists = await checkIfTableExists(queryRunner, historyTableName);
+    if (tableExists) {
+      await queryRunner.query(
+        `ALTER TABLE '${historyTableName}' DROP COLUMN source_type`,
+      );
+    }
+  }
+}

--- a/apps/mobile/src/databases/migrations/index.ts
+++ b/apps/mobile/src/databases/migrations/index.ts
@@ -3,6 +3,7 @@ import { UpdateBuyTableAddPayCurrency1740378323012 } from './20250224';
 import { UpdateHistoryTableRestart1742289471888 } from './20250321';
 import { UpdateTokenItemAddCreditScore1741862198677 } from './20250313';
 import { UpdateTokenItemAddCexIds1743518329613 } from './20250401';
+import { UpdateHistoryTableAddSourceType1744873800025 } from './20250418';
 
 export function getMigrations() {
   return [
@@ -11,5 +12,6 @@ export function getMigrations() {
     UpdateHistoryTableRestart1742289471888,
     UpdateTokenItemAddCreditScore1741862198677,
     UpdateTokenItemAddCexIds1743518329613,
+    UpdateHistoryTableAddSourceType1744873800025,
   ];
 }


### PR DESCRIPTION
Increases the transaction history limit and adds source tracking for transactions.

- Expands the transaction history limit from 100 to 500 entries, providing users with a more comprehensive record of their activities.
- Introduces source tracking for transaction history items, allowing for better analytics and debugging.
- Adds a database migration to include the source_type column in the local history table.