### PR TITLE
Prevents errors when token price is zero

### DIFF
--- a/apps/mobile/src/screens/Transaction/components/HistoryItemTokenPrice.tsx
+++ b/apps/mobile/src/screens/Transaction/components/HistoryItemTokenPrice.tsx
@@ -46,7 +46,7 @@ export const HistoryItemTokenPrice = ({
 
   return (
     <View>
-      {singlePrice && (
+      {Boolean(singlePrice) && (
         <Text style={style}>{`≈${formatUsdValue(singlePrice * amount)}`}</Text>
       )}
     </View>


### PR DESCRIPTION
Addresses an issue where a zero value for the token single price could lead to errors in the UI.

Ensures that the price calculation and display logic correctly handles cases where `singlePrice` is zero by explicitly casting `singlePrice` to a boolean.