### PR TITLE
feat: add ERC-681 URI support for payment requests

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -45,6 +45,12 @@
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="ethereum" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="http" />
         <data android:scheme="https" />
         <data android:host="rabby.io" />

--- a/apps/mobile/ios/RabbyMobile/Info.plist
+++ b/apps/mobile/ios/RabbyMobile/Info.plist
@@ -38,6 +38,12 @@
 				<string>rabby</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>ethereum</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>

--- a/apps/mobile/src/AppNavigation.tsx
+++ b/apps/mobile/src/AppNavigation.tsx
@@ -90,6 +90,8 @@ import { GlobalMiniApproval } from './components/Approval/components/MiniSignTx/
 import { EVENT_ROUTE_CHANGE, eventBus } from './utils/events';
 // import { BrowserManageScreen } from './screens/Browser/BrowserManageScreen';
 import { useOpenedActiveDappState } from './screens/Dapps/hooks/useDappView';
+import { setupDeepLinkListener } from './utils/deeplink';
+import { useSendRoutes } from './hooks/useSendRoutes';
 
 const RootStack = createNativeStackNavigator<RootStackParamsList>();
 const HomeHiddenTabStack = createBottomTabNavigator<any>();
@@ -191,6 +193,29 @@ function useDetermineExitAppOnPressBack() {
     return () => backHandler.remove();
   }, [getBackRestCount, setBackStage]);
 }
+
+// Component to handle deep links inside NavigationContainer
+const DeepLinkHandler = () => {
+  const { isAppUnlocked } = useAppUnlocked();
+  const { navigateToSendPolyScreen } = useSendRoutes();
+
+  React.useEffect(() => {
+    if (isAppUnlocked) {
+      const unsubscribe = setupDeepLinkListener(result => {
+        if (result.handled && result.navigation) {
+          if (result.navigation.screen === 'SendERC681') {
+            // Navigate to send screen with pre-filled data
+            navigateToSendPolyScreen(true, result.navigation.params);
+          }
+        }
+      });
+
+      return unsubscribe;
+    }
+  }, [isAppUnlocked, navigateToSendPolyScreen]);
+
+  return null;
+};
 
 const StackMain = () => {
   const { mergeScreenOptions } = useStackScreenConfig();
@@ -351,7 +376,6 @@ export default function AppNavigation({
   const { setNavigationReady } = useSetNavigationReady();
 
   const { setCurrentRouteName } = useSetCurrentRouteName();
-
   const onRouteChange = useCallback(
     (currentRouteName?: string) => {
       currentRouteName =
@@ -463,6 +487,7 @@ export default function AppNavigation({
         independent
         // linking={LinkingConfiguration}
         theme={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+        <DeepLinkHandler />
         <DuplicateAddressModal />
         <AliasNameEditModal />
         <QrCodeModal />

--- a/apps/mobile/src/LinkingConfig.ts
+++ b/apps/mobile/src/LinkingConfig.ts
@@ -22,7 +22,7 @@ const getLinkingConfig = () => {
   };
 
   return {
-    prefixes: ['rabby://', 'rabbymobile://', 'ethereum:'],
+    prefixes: ['rabby://', 'ethereum:'],
     config: {
       screens: screens,
     },

--- a/apps/mobile/src/LinkingConfig.ts
+++ b/apps/mobile/src/LinkingConfig.ts
@@ -14,18 +14,26 @@ const getLinkingConfig = () => {
       screens: {
         [RootNames.Buy]: RootNames.Buy.toLowerCase(),
         [RootNames.MultiBuy]: RootNames.MultiBuy.toLowerCase(),
+        [RootNames.Send]: 'send',
+        [RootNames.SendTo]: 'sendto',
       },
     },
     NotFound: '*',
   };
 
   return {
-    prefixes: ['rabby://'],
+    prefixes: ['rabby://', 'rabbymobile://', 'ethereum:'],
     config: {
       screens: screens,
     },
 
     getStateFromPath: (path: string, options: any) => {
+      // Handle ethereum: URIs separately as they don't follow standard navigation paths
+      if (path.startsWith('ethereum:')) {
+        // Return undefined to let the app handle it through Linking events
+        return undefined;
+      }
+
       const newPath = path.replace('mobile-redirect/', '')?.toLowerCase();
 
       if (

--- a/apps/mobile/src/hooks/useSendRoutes.ts
+++ b/apps/mobile/src/hooks/useSendRoutes.ts
@@ -48,7 +48,7 @@ export const useSendRoutes = () => {
     (mergedParams: { [key: string]: any }, isForSingleAddress: boolean) => {
       const targetScreen = getTargetScreen(mergedParams, isForSingleAddress);
 
-      navigation.push(RootNames.StackTransaction, {
+      navigation.navigate(RootNames.StackTransaction, {
         screen: targetScreen,
         params: mergedParams,
       } as NavigatorScreenParams<TransactionNavigatorParamList>);
@@ -101,7 +101,7 @@ export const useSendRoutes = () => {
         }
         return;
       }
-      navigation.push(RootNames.StackTransaction, {
+      navigation.navigate(RootNames.StackTransaction, {
         screen: RootNames.SendTo,
       });
     },

--- a/apps/mobile/src/screens/Send/Send.tsx
+++ b/apps/mobile/src/screens/Send/Send.tsx
@@ -128,12 +128,22 @@ function SendScreen({
         toAddress?: string;
         addressBrandName?: string;
         addrDesc?: AddrDescResponse['desc'];
+        amount?: string;
+        rawAmount?: string;
+        isRawAmount?: boolean;
+        gasLimit?: string;
+        gasPrice?: string;
       }
     | {
         safeInfo: { nonce: number; chainId: number };
         toAddress?: string;
         addressBrandName?: string;
         addrDesc?: AddrDescResponse['desc'];
+        amount?: string;
+        rawAmount?: string;
+        isRawAmount?: boolean;
+        gasLimit?: string;
+        gasPrice?: string;
       }
     | undefined;
 
@@ -142,6 +152,7 @@ function SendScreen({
   const [addrDesc, setAddrDesc] = useState<
     AddrDescResponse['desc'] | undefined
   >(navParams?.addrDesc || getInitDescWithCexLocalCache(navParams?.toAddress));
+
   useEffect(() => {
     if (addrDesc || !navParams?.toAddress) {
       return;
@@ -247,6 +258,9 @@ function SendScreen({
     isForMultipleAddress: isForMultipleAddress,
     disableItemCheck,
     currentAccount: currentAccount!,
+    initialAmount: navParams?.isRawAmount ? undefined : navParams?.amount,
+    gasLimit: navParams?.gasLimit,
+    gasPrice: navParams?.gasPrice,
   });
 
   const { fetchOrderedChainList } = useLoadMatteredChainBalances({
@@ -366,13 +380,30 @@ function SendScreen({
       //   }
       // }
       await Promise.race([
-        await loadCurrentToken(
+        loadCurrentToken(
           targetToken.id,
           targetToken.chain,
           currentAccount!.address,
         ),
         sleep(5000),
       ]);
+
+      // After token is loaded, convert raw amount if needed
+      if (navParams?.isRawAmount && navParams?.rawAmount) {
+        // Get the loaded token info
+        const loadedToken = await openapi.getToken(
+          currentAccount!.address,
+          targetToken.chain,
+          targetToken.id,
+        );
+
+        if (loadedToken?.decimals !== undefined) {
+          const convertedAmount = new BigNumber(navParams.rawAmount)
+            .dividedBy(new BigNumber(10).pow(loadedToken.decimals))
+            .toFixed();
+          handleFieldChange('amount', convertedAmount);
+        }
+      }
     } finally {
       hideLoading();
       isShowLoadingRef.current = true;

--- a/apps/mobile/src/utils/__tests__/erc681.test.ts
+++ b/apps/mobile/src/utils/__tests__/erc681.test.ts
@@ -1,0 +1,161 @@
+import {
+  parseERC681URI,
+  getRecipientAddress,
+  getTransferAmount,
+} from '../erc681';
+
+describe('ERC-681 Parser', () => {
+  describe('parseERC681URI', () => {
+    it('should parse simple ETH transfer', () => {
+      const uri =
+        'ethereum:0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7?value=1000000000000000000';
+      const result = parseERC681URI(uri);
+
+      expect(result.isValid).toBe(true);
+      expect(result.target_address).toBe(
+        '0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7',
+      );
+      expect(result.amount).toBe('1000000000000000000');
+      expect(result.isERC20Transfer).toBe(false);
+    });
+
+    it('should parse ETH transfer with chain ID', () => {
+      const uri =
+        'ethereum:0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7@1?value=2300000000000000000';
+      const result = parseERC681URI(uri);
+
+      expect(result.isValid).toBe(true);
+      expect(result.target_address).toBe(
+        '0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7',
+      );
+      expect(result.chain_id).toBe(1);
+      expect(result.amount).toBe('2300000000000000000');
+    });
+
+    it('should parse ERC20 transfer', () => {
+      const uri =
+        'ethereum:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/transfer?address=0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7&uint256=100000000';
+      const result = parseERC681URI(uri);
+
+      expect(result.isValid).toBe(true);
+      expect(result.target_address).toBe(
+        '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      );
+      expect(result.function_name).toBe('transfer');
+      expect(result.isERC20Transfer).toBe(true);
+      expect(result.tokenAddress).toBe(
+        '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      );
+      expect(result.parameters?.address).toBe(
+        '0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7',
+      );
+      expect(result.parameters?.uint256).toBe('100000000');
+      expect(result.amount).toBe('100000000');
+    });
+
+    it('should parse with pay- prefix', () => {
+      const uri =
+        'ethereum:pay-0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7?value=1000000000000000000';
+      const result = parseERC681URI(uri);
+
+      expect(result.isValid).toBe(true);
+      expect(result.target_address).toBe(
+        '0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7',
+      );
+    });
+
+    it('should parse with gas parameters', () => {
+      const uri =
+        'ethereum:0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7?value=1000000000000000000&gas=21000&gasPrice=20000000000';
+      const result = parseERC681URI(uri);
+
+      expect(result.isValid).toBe(true);
+      expect(result.gasLimit).toBe('21000');
+      expect(result.gasPrice).toBe('20000000000');
+    });
+
+    it('should handle custom function calls', () => {
+      const uri =
+        'ethereum:0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7/someFunction?uint256=123&address=0x0000000000000000000000000000000000000000';
+      const result = parseERC681URI(uri);
+
+      expect(result.isValid).toBe(true);
+      expect(result.function_name).toBe('someFunction');
+      expect(result.parameters?.uint256).toBe('123');
+      expect(result.parameters?.address).toBe(
+        '0x0000000000000000000000000000000000000000',
+      );
+    });
+
+    it('should handle invalid addresses', () => {
+      const uri = 'ethereum:invalidaddress?value=1000000000000000000';
+      const result = parseERC681URI(uri);
+
+      expect(result.isValid).toBe(false);
+    });
+
+    it('should handle non-ethereum URIs', () => {
+      const uri = 'bitcoin:1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+      const result = parseERC681URI(uri);
+
+      expect(result.isValid).toBe(false);
+    });
+  });
+
+  describe('getRecipientAddress', () => {
+    it('should return target address for ETH transfers', () => {
+      const parsed = {
+        isValid: true,
+        target_address: '0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7',
+        isERC20Transfer: false,
+      };
+
+      expect(getRecipientAddress(parsed)).toBe(
+        '0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7',
+      );
+    });
+
+    it('should return recipient from parameters for ERC20 transfers', () => {
+      const parsed = {
+        isValid: true,
+        target_address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        isERC20Transfer: true,
+        parameters: {
+          address: '0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7',
+        },
+      };
+
+      expect(getRecipientAddress(parsed)).toBe(
+        '0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7',
+      );
+    });
+  });
+
+  describe('getTransferAmount', () => {
+    it('should convert wei to ether', () => {
+      const parsed = {
+        isValid: true,
+        amount: '1000000000000000000',
+      };
+
+      expect(getTransferAmount(parsed)).toBe('1.0');
+    });
+
+    it('should handle undefined amount', () => {
+      const parsed = {
+        isValid: true,
+      };
+
+      expect(getTransferAmount(parsed)).toBeUndefined();
+    });
+
+    it('should handle invalid amount', () => {
+      const parsed = {
+        isValid: true,
+        amount: 'invalid',
+      };
+
+      expect(getTransferAmount(parsed)).toBe('invalid');
+    });
+  });
+});

--- a/apps/mobile/src/utils/deeplink.ts
+++ b/apps/mobile/src/utils/deeplink.ts
@@ -50,6 +50,15 @@ export async function handleDeepLink(
         // For ERC20 transfers, we need to set the token
         // Token ID format in Rabby is "address" only, chain is handled separately
         params.tokenId = parsed.tokenAddress.toLowerCase();
+      } else {
+        // For ETH transfers, we need to set the native token
+        // Get the native token address for the chain
+        if (chainEnum) {
+          const chain = findChainByID(parsed.chain_id!);
+          if (chain) {
+            params.tokenId = chain.nativeTokenAddress;
+          }
+        }
       }
 
       if (parsed.isERC20Transfer && parsed.parameters?.uint256) {

--- a/apps/mobile/src/utils/deeplink.ts
+++ b/apps/mobile/src/utils/deeplink.ts
@@ -1,0 +1,120 @@
+import { Linking } from 'react-native';
+import {
+  parseERC681URI,
+  getRecipientAddress,
+  getTransferAmount,
+} from './erc681';
+import { findChainByID } from '@/utils/chain';
+import { CHAINS_ENUM } from '@/constant/chains';
+
+export interface DeepLinkHandlerResult {
+  handled: boolean;
+  navigation?: {
+    screen: string;
+    params?: any;
+  };
+}
+
+export async function handleDeepLink(
+  url: string,
+): Promise<DeepLinkHandlerResult> {
+  try {
+    // Handle ERC-681 ethereum: URIs
+    if (url.startsWith('ethereum:')) {
+      const parsed = parseERC681URI(url);
+
+      if (!parsed.isValid) {
+        return { handled: false };
+      }
+
+      const recipientAddress = getRecipientAddress(parsed);
+      const amount = getTransferAmount(parsed);
+
+      // Determine chain
+      let chainEnum: CHAINS_ENUM | undefined;
+      if (parsed.chain_id) {
+        const chain = findChainByID(parsed.chain_id);
+        chainEnum = chain?.enum;
+      }
+
+      // Prepare navigation params
+      const params: any = {
+        toAddress: recipientAddress,
+      };
+
+      if (chainEnum) {
+        params.chainEnum = chainEnum;
+      }
+
+      if (parsed.isERC20Transfer && parsed.tokenAddress) {
+        // For ERC20 transfers, we need to set the token
+        // Token ID format in Rabby is "address" only, chain is handled separately
+        params.tokenId = parsed.tokenAddress.toLowerCase();
+      }
+
+      if (parsed.isERC20Transfer && parsed.parameters?.uint256) {
+        // For ERC20 tokens, we pass a special marker to indicate raw amount
+        // The Send screen needs to convert this based on token decimals
+        params.rawAmount = parsed.parameters.uint256;
+        params.isRawAmount = true;
+      } else if (amount) {
+        // For ETH transfers, amount is already converted to ether in getTransferAmount
+        params.amount = amount;
+      }
+
+      if (parsed.gasLimit) {
+        params.gasLimit = parsed.gasLimit;
+      }
+
+      if (parsed.gasPrice) {
+        params.gasPrice = parsed.gasPrice;
+      }
+
+      // Store any additional parameters for the transaction
+      if (parsed.function_name && parsed.function_name !== 'transfer') {
+        // For custom function calls, we'll need to handle this differently
+        params.customFunction = {
+          name: parsed.function_name,
+          parameters: parsed.parameters,
+        };
+      }
+
+      return {
+        handled: true,
+        navigation: {
+          screen: 'SendERC681',
+          params,
+        },
+      };
+    }
+
+    // Handle other deep link types here in the future
+
+    return { handled: false };
+  } catch (error) {
+    console.error('Error handling deep link:', error);
+    return { handled: false };
+  }
+}
+
+export function setupDeepLinkListener(
+  onDeepLink: (result: DeepLinkHandlerResult) => void,
+) {
+  // Handle initial URL (app opened from deep link)
+  Linking.getInitialURL().then(url => {
+    if (url) {
+      handleDeepLink(url).then(onDeepLink);
+    }
+  });
+
+  // Handle URLs when app is already open
+  const subscription = Linking.addEventListener('url', event => {
+    if (event.url) {
+      handleDeepLink(event.url).then(onDeepLink);
+    }
+  });
+
+  return () => {
+    subscription.remove();
+  };
+}

--- a/apps/mobile/src/utils/erc681.ts
+++ b/apps/mobile/src/utils/erc681.ts
@@ -1,0 +1,179 @@
+import { ethers } from 'ethers';
+import { isAddress } from 'viem';
+
+export interface ERC681ParsedData {
+  isValid: boolean;
+  target_address?: string;
+  chain_id?: number;
+  function_name?: string;
+  parameters?: Record<string, any>;
+  amount?: string;
+  gasLimit?: string;
+  gasPrice?: string;
+  value?: string;
+  isERC20Transfer?: boolean;
+  tokenAddress?: string;
+}
+
+export function parseERC681URI(uri: string): ERC681ParsedData {
+  try {
+    // ERC-681 format: ethereum:[pay-]<target_address>[@<chain_id>][/<function_name>]?[<parameters>]
+
+    // Check if it's an ethereum URI
+    if (!uri.startsWith('ethereum:')) {
+      return { isValid: false };
+    }
+
+    // Remove the ethereum: prefix
+    const withoutPrefix = uri.substring(9);
+
+    // Split by ? to separate the path from parameters
+    const [pathPart, queryPart] = withoutPrefix.split('?');
+
+    // Parse the path part
+    let target_address = '';
+    let chain_id: number | undefined;
+    let function_name: string | undefined;
+
+    // Check for pay- prefix
+    const isPay = pathPart.startsWith('pay-');
+    const addressPart = isPay ? pathPart.substring(4) : pathPart;
+
+    // Split by / to separate address from function
+    const [addressChainPart, functionPart] = addressPart.split('/');
+
+    // Split by @ to separate address from chain
+    const [addressOnly, chainPart] = addressChainPart.split('@');
+
+    target_address = addressOnly;
+
+    // Validate address
+    if (!isAddress(target_address)) {
+      return { isValid: false };
+    }
+
+    // Parse chain ID if present
+    if (chainPart) {
+      chain_id = parseInt(chainPart, 10);
+      if (isNaN(chain_id)) {
+        return { isValid: false };
+      }
+    }
+
+    // Parse function name if present
+    if (functionPart) {
+      function_name = functionPart;
+    }
+
+    // Parse query parameters
+    const parameters: Record<string, any> = {};
+    let amount: string | undefined;
+    let gasLimit: string | undefined;
+    let gasPrice: string | undefined;
+    let value: string | undefined;
+
+    if (queryPart) {
+      const params = new URLSearchParams(queryPart);
+
+      for (const [key, val] of params.entries()) {
+        if (key === 'value') {
+          // Value is in wei, convert to ether for display
+          value = val;
+          if (!function_name || function_name === 'transfer') {
+            amount = val;
+          }
+        } else if (key === 'gas') {
+          gasLimit = val;
+        } else if (key === 'gasPrice') {
+          gasPrice = val;
+        } else {
+          // Handle different parameter types
+          if (key.endsWith('[address]') || key === 'address' || key === 'to') {
+            // Address parameter
+            const paramName = key.replace('[address]', '');
+            parameters[paramName] = val;
+          } else if (key.endsWith('[uint256]') || key.endsWith('[uint]')) {
+            // Uint parameter
+            const paramName = key.replace(/\[(uint256|uint)\]/, '');
+            parameters[paramName] = val;
+          } else if (key.endsWith('[bytes]') || key.endsWith('[bytes32]')) {
+            // Bytes parameter
+            const paramName = key.replace(/\[(bytes|bytes32)\]/, '');
+            parameters[paramName] = val;
+          } else if (key.endsWith('[bool]')) {
+            // Boolean parameter
+            const paramName = key.replace('[bool]', '');
+            parameters[paramName] = val === 'true';
+          } else {
+            // Default to string
+            parameters[key] = val;
+          }
+        }
+      }
+    }
+
+    // Check if this is an ERC20 transfer
+    const isERC20Transfer =
+      function_name === 'transfer' &&
+      parameters.address &&
+      isAddress(parameters.address as string);
+
+    // For ERC20 transfers, the target_address is the token contract
+    // and parameters.address is the recipient
+    let tokenAddress: string | undefined;
+    if (isERC20Transfer) {
+      tokenAddress = target_address;
+      // The actual recipient is in parameters.address
+      // Amount for ERC20 is in parameters.uint256 or parameters.amount
+      amount = parameters.uint256 || parameters.amount || parameters.value;
+    }
+
+    return {
+      isValid: true,
+      target_address,
+      chain_id,
+      function_name,
+      parameters,
+      amount,
+      gasLimit,
+      gasPrice,
+      value,
+      isERC20Transfer,
+      tokenAddress,
+    };
+  } catch (error) {
+    console.error('Error parsing ERC-681 URI:', error);
+    return { isValid: false };
+  }
+}
+
+export function isERC681URI(uri: string): boolean {
+  return uri.startsWith('ethereum:');
+}
+
+// Helper to get recipient address from parsed data
+export function getRecipientAddress(
+  parsedData: ERC681ParsedData,
+): string | undefined {
+  if (parsedData.isERC20Transfer) {
+    // For ERC20 transfers, recipient is in parameters
+    return parsedData.parameters?.address || parsedData.parameters?.to;
+  } else {
+    // For ETH transfers, recipient is the target address
+    return parsedData.target_address;
+  }
+}
+
+// Helper to get transfer amount in human-readable format
+export function getTransferAmount(
+  parsedData: ERC681ParsedData,
+): string | undefined {
+  if (!parsedData.amount) return undefined;
+
+  try {
+    // Amount is in wei, convert to ether
+    return ethers.utils.formatEther(parsedData.amount);
+  } catch {
+    return parsedData.amount;
+  }
+}


### PR DESCRIPTION
Implements support for [ERC-681](https://eips.ethereum.org/EIPS/eip-681) standard URIs (ethereum:) to enable payment requests from external apps and websites. I wanted to add this so Rabby Mobile supports FreePay (https://x.com/timjrobinson/status/1940331404627411261) which sends an ERC-681 URL via an Intent. 

I've tested this on Android and it works correctly with USDC and ETH on Base chain. Haven't tested on iOS. 

A lot of this code was written by Claude. I am a developer and have checked it, Claude just made it easier to work in an unfamiliar codebase. 

Key features:
- Parse ERC-681 URIs for both ETH and ERC20 token transfers
- Support chain specification (e.g., @8453 for Base chain)
- Handle token decimals correctly (e.g., USDC with 6 decimals)
- Pre-fill Send screen with recipient, amount, and token
- Add deep link handling for ethereum: scheme
- Update Android and iOS manifests for URI scheme support

Example supported URIs:
- ethereum:0x123...abc@1/transfer?address=0x456...def&uint256=1000000
- ethereum:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913@8453/transfer?address=0xaD66946538E4B03B1910DadE713feBb8B59Cff60&uint256=30036