### PR TITLE
feat: improve performance of token selectors

### DIFF
--- a/apps/mobile/src/components/AccountSwitcher/AccountsPanel.tsx
+++ b/apps/mobile/src/components/AccountSwitcher/AccountsPanel.tsx
@@ -27,6 +27,7 @@ import { ScreenWithAccountSwitcherLayouts } from '@/constant/layout';
 import { useTranslation } from 'react-i18next';
 import { IS_ANDROID } from '@/core/native/utils';
 import { WalletIcon } from '@/components2024/WalletIcon/WalletIcon';
+import { useCreationWithShallowCompare } from '@/hooks/common/useMemozied';
 const SectionCollapsableNav = function ({
   isCollapsed = false,
   title,
@@ -462,7 +463,7 @@ AccountSwitcherAopProps<{
     changeCollapsed,
   ]);
 
-  const myAddressesList = useMemo(() => {
+  const myAddressesList = useCreationWithShallowCompare(() => {
     return isSceneSupportAllAccounts ? myAddresses.slice(0, 10) : myAddresses;
   }, [myAddresses, isSceneSupportAllAccounts]);
 

--- a/apps/mobile/src/components/Token/TokenSelectorSheetModal.tsx
+++ b/apps/mobile/src/components/Token/TokenSelectorSheetModal.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useState,
   useRef,
+  useImperativeHandle,
 } from 'react';
 import {
   View,
@@ -29,13 +30,13 @@ import useDebounce from 'react-use/lib/useDebounce';
 import { CHAINS_ENUM, Chain } from '@/constant/chains';
 import { TokenItem } from '@rabby-wallet/rabby-api/dist/types';
 import { AppBottomSheetModal } from '../customized/BottomSheet';
-import { useSheetModal } from '@/hooks/useSheetModal';
+import { SheetModalShowType, useSheetModal } from '@/hooks/useSheetModal';
 import { createGetStyles2024 } from '@/utils/styles';
 import { useTheme2024 } from '@/hooks/theme';
 import {
-  DisplayedTokenWithOwner,
   getTokenSymbol,
-  TokenItemFromAbstractPortfolioToken,
+  type DisplayedTokenWithOwner,
+  type TokenItemFromAbstractPortfolioToken,
 } from '@/utils/token';
 import { formatAmount, formatPrice } from '@/utils/number';
 import { formatNetworth } from '@/utils/math';
@@ -63,6 +64,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import RcIconFavorite from '@/assets2024/icons/home/favorite.svg';
 import {
   CompositeScreenProps,
+  useFocusEffect,
   useIsFocused,
   useRoute,
 } from '@react-navigation/native';
@@ -98,6 +100,8 @@ import {
   useSharedValue,
 } from 'react-native-reanimated';
 import { PanGestureHandler } from 'react-native-gesture-handler';
+import { useRefState } from '@/hooks/common/useRefState';
+import { useHandleBackPressClosable } from '@/hooks/useAppGesture';
 
 type SwapRouteProps = CompositeScreenProps<
   NativeStackScreenProps<TransactionNavigatorParamList, 'Swap'>,
@@ -154,6 +158,7 @@ export type TokenItemForRender = {
 export interface TokenSelectorProps<
   T extends TokenSelectType = TokenSelectType,
 > {
+  // visibleRef: SharedValue<boolean>;
   visible: boolean;
   list: TokenItemMaybeWithOwner[];
   foldTokensList?: TokenItemMaybeWithOwner[];
@@ -202,9 +207,67 @@ const screenHeight = Dimensions.get('window').height;
 const modalHeight = screenHeight - 120;
 const snapPoints = [modalHeight];
 
-type TokenSelectorInst = {};
+export function useTokenSelectorModalVisible(options?: {
+  onVisibleChanged?: (visible: boolean) => void;
+}) {
+  const {
+    state: visible,
+    stateRef: visibleRef,
+    setRefState: setVisible,
+  } = useRefState(false);
+
+  const { onVisibleChanged } = options || {};
+  const onVisibleChangedRef = useRef(onVisibleChanged);
+  useEffect(() => {
+    onVisibleChangedRef.current = onVisibleChanged;
+  }, [onVisibleChanged]);
+
+  const tokenSelectorModalRef = useRef<TokenSelectorSheetModalInst>(null);
+  const setTokenSelectorVisible = useCallback(
+    (
+      visible: boolean,
+      options?: {
+        delayShowModal?: number;
+        delaySetState?: number;
+        noTriggerRerender?: boolean;
+      },
+    ) => {
+      onVisibleChangedRef.current?.(visible);
+
+      const {
+        delayShowModal = 0,
+        delaySetState = 100,
+        noTriggerRerender = false,
+      } = options || {};
+      if (delayShowModal) {
+        setTimeout(() => {
+          tokenSelectorModalRef.current?.toggleShow(visible);
+        }, delayShowModal);
+      } else {
+        tokenSelectorModalRef.current?.toggleShow(visible);
+      }
+
+      // setVisible(visible, !noTriggerRerender);
+      const delayMs = Math.max(delaySetState, 100);
+      setTimeout(() => {
+        setVisible(visible, !noTriggerRerender);
+      }, delayMs);
+    },
+    [onVisibleChangedRef, setVisible],
+  );
+
+  return {
+    visible,
+    visibleRef,
+    setTokenSelectorVisible,
+    tokenSelectorModalRef,
+  };
+}
+export type TokenSelectorSheetModalInst = {
+  toggleShow: (nextShown: SheetModalShowType) => void;
+};
 export const TokenSelectorSheetModal = React.forwardRef<
-  TokenSelectorInst,
+  TokenSelectorSheetModalInst,
   RNViewProps & TokenSelectorProps
 >(
   (
@@ -236,16 +299,22 @@ export const TokenSelectorSheetModal = React.forwardRef<
       onFavoriteFilterChange,
       disableSort = false,
     },
-    _ref,
+    ref,
   ) => {
-    const { sheetModalRef: tokenSelectorModal, toggleShowSheetModal } =
+    const { sheetModalRef: tokenSelectorModalRef, toggleShowSheetModal } =
       useSheetModal();
     const [isFromBack, setIsFromBack] = useAtom(isFromBackAtom);
 
-    // 记录组件最初渲染的页面，用于判断是否还在原页面
+    useImperativeHandle(ref, () => {
+      return {
+        toggleShow: nextShown => {
+          toggleShowSheetModal(nextShown);
+        },
+      };
+    });
+
     const initialRouteRef = useRef<string | undefined>();
-    React.useEffect(() => {
-      // 组件挂载时记录当前页面
+    useEffect(() => {
       if (!initialRouteRef.current && visible) {
         initialRouteRef.current = getLatestNavigationName();
       }
@@ -260,13 +329,13 @@ export const TokenSelectorSheetModal = React.forwardRef<
     const isSend = type === 'send';
 
     useEffect(() => {
-      toggleShowSheetModal(visible ? true : false);
       if (!visible) {
         setIsInputActive(false);
         setFold(true);
         setIsScamFold(true);
+        setQuery('');
       }
-    }, [visible, toggleShowSheetModal]);
+    }, [visible]);
 
     const handleShowExcludeTips = useMemoizedFn(() => {
       const modalId = createGlobalBottomSheetModal2024({
@@ -327,17 +396,14 @@ export const TokenSelectorSheetModal = React.forwardRef<
     ) {
       toggleShowSheetModal('destroy');
     }
-    // 监听当前路由变化
-    const currentRoute = getLatestNavigationName();
     const isInInitialRoute = useMemo(() => {
       if (!visible || !initialRouteRef.current) {
         return true;
       }
-      return currentRoute === initialRouteRef.current;
-    }, [currentRoute, visible]);
+      return getLatestNavigationName() === initialRouteRef.current;
+    }, [visible]);
 
     useEffect(() => {
-      // 如果不是从返回按钮进入的，则关闭弹窗
       if (!isFromBack && visible) {
         toggleShowSheetModal('destroy');
         setIsFromBack(false);
@@ -375,12 +441,6 @@ export const TokenSelectorSheetModal = React.forwardRef<
     const handleInputBlur = () => {
       setIsInputActive(false);
     };
-
-    useEffect(() => {
-      if (!visible) {
-        setQuery('');
-      }
-    }, [visible]);
 
     const displayList = useMemo(() => {
       if (isBridgeTo || isSend) {
@@ -949,7 +1009,9 @@ export const TokenSelectorSheetModal = React.forwardRef<
                 trade_volume_level: tmpX?.trade_volume_level,
                 $origin: x as
                   | TokenItemForRender
-                  | (TokenItemFromAbstractPortfolioToken & { group?: string }),
+                  | (TokenItemFromAbstractPortfolioToken & {
+                      group?: string;
+                    }),
               };
             }),
           })),
@@ -958,6 +1020,7 @@ export const TokenSelectorSheetModal = React.forwardRef<
           },
         ];
       }
+
       return [
         {
           data: tokens,
@@ -993,7 +1056,8 @@ export const TokenSelectorSheetModal = React.forwardRef<
         hideChainFilter,
         showFavoriteFilter,
       ]);
-    // 用于防止重复触发的状态
+
+    // Used to prevent repeated triggering
     const hasTriggered = useSharedValue(false);
 
     const onGestureEvent = useAnimatedGestureHandler({
@@ -1004,7 +1068,7 @@ export const TokenSelectorSheetModal = React.forwardRef<
         if (!onFavoriteFilterChange || hasTriggered.value) {
           return;
         }
-        // 设置阈值，超过阈值就触发
+        // Set threshold, trigger if exceeded
         const threshold = 50;
         if (Math.abs(event.translationX) > Math.abs(event.translationY)) {
           if (event.translationX > threshold) {
@@ -1018,16 +1082,24 @@ export const TokenSelectorSheetModal = React.forwardRef<
       },
     });
 
+    const { onHardwareBackHandler } = useHandleBackPressClosable(
+      useCallback(() => {
+        onCancel();
+        return !visible;
+      }, [onCancel, visible]),
+    );
+
+    useFocusEffect(onHardwareBackHandler);
+
     return (
       <AppBottomSheetModal
-        ref={tokenSelectorModal}
+        ref={tokenSelectorModalRef}
         snapPoints={snapPoints}
         enableContentPanningGesture
+        // enableDismissOnClose={false}
         enableDismissOnClose
         onChange={idx => {
-          if (idx < 0) {
-            onCancel();
-          }
+          if (idx < 0) onCancel();
         }}
         {...{
           containerStyle:
@@ -1224,6 +1296,8 @@ export const TokenSelectorSheetModal = React.forwardRef<
               }
               extraData={isLoading}
               initialNumToRender={20}
+              maxToRenderPerBatch={20}
+              onEndReachedThreshold={0.3}
               renderItem={renderItemRenderComponent}
             />
           </PanGestureHandler>

--- a/apps/mobile/src/components/Token/TokenSelectorSheetModal.tsx
+++ b/apps/mobile/src/components/Token/TokenSelectorSheetModal.tsx
@@ -396,12 +396,14 @@ export const TokenSelectorSheetModal = React.forwardRef<
     ) {
       toggleShowSheetModal('destroy');
     }
+
+    const currentRoute = getLatestNavigationName();
     const isInInitialRoute = useMemo(() => {
       if (!visible || !initialRouteRef.current) {
         return true;
       }
-      return getLatestNavigationName() === initialRouteRef.current;
-    }, [visible]);
+      return currentRoute === initialRouteRef.current;
+    }, [currentRoute, visible]);
 
     useEffect(() => {
       if (!isFromBack && visible) {

--- a/apps/mobile/src/core/apis/balance.ts
+++ b/apps/mobile/src/core/apis/balance.ts
@@ -64,15 +64,22 @@ export const getAddressBalance = async (
   return getTotalBalanceCached(address, force);
 };
 
-export const getAddressCacheBalance = async (
+export const getAddressCacheBalanceSync = (
   address: string | undefined,
   isTestnet = false,
-) => {
+): EvmTotalBalanceResponse | null => {
   if (!address) {
     return null;
   }
   if (isTestnet) {
-    return await preferenceService.getTestnetAddressBalance(address);
+    return preferenceService.getTestnetAddressBalance(address);
   }
-  return await preferenceService.getAddressBalance(address);
+  return preferenceService.getAddressBalance(address);
+};
+
+export const getAddressCacheBalance = async (
+  address: string | undefined,
+  isTestnet = false,
+) => {
+  return getAddressCacheBalanceSync(address, isTestnet);
 };

--- a/apps/mobile/src/core/services/preference.ts
+++ b/apps/mobile/src/core/services/preference.ts
@@ -998,18 +998,9 @@ export class PreferenceService {
     }
   };
 
+  /** @deprecated use getUserTokenSettingsSync as possible */
   getUserTokenSettings = async () => {
-    return {
-      foldTokens: this.store.foldTokens || [],
-      unfoldTokens: this.store.unfoldTokens || [],
-      includeDefiAndTokens: this.store.includeDefiAndTokens || [],
-      excludeDefiAndTokens: this.store.excludeDefiAndTokens || [],
-      pinedQueue: this.store.pinedQueue || [],
-      foldNfts: this.store.foldNfts || [],
-      unfoldNfts: this.store.unFoldNfts || [],
-      foldDefis: this.store.foldDefis || [],
-      unFoldDefis: this.store.unFoldDefis || [],
-    };
+    return this.getUserTokenSettingsSync();
   };
 
   getUserTokenSettingsSync = () => {

--- a/apps/mobile/src/databases/entities/tokenitem.ts
+++ b/apps/mobile/src/databases/entities/tokenitem.ts
@@ -231,7 +231,7 @@ export class TokenItemEntity extends EntityAddressAssetBase {
     return res;
   }
 
-  static async batchMultAddressTokens(
+  static async batchMultiAddressTokens(
     addresses: string[],
     core?: boolean,
     maxLength?: number,

--- a/apps/mobile/src/databases/imports.ts
+++ b/apps/mobile/src/databases/imports.ts
@@ -6,7 +6,13 @@ const appDataSourceInitRef = {
   current: null as null | Promise<DataSource>,
 };
 
-export async function initializeAppDataSource(dbOptions?: DataSourceOptions) {
+export async function initializeAppDataSource(
+  /**
+   * @description when no dbOptions are provided, will not initialize the app data source but
+   * try to use the pre-existing one
+   */
+  dbOptions?: DataSourceOptions,
+) {
   if (dbOptions) {
     const appDataSource = new DataSource({ ...dbOptions });
 
@@ -40,6 +46,9 @@ export async function initializeAppDataSource(dbOptions?: DataSourceOptions) {
           console.error('[initializeAppDataSource] error', error);
           throw error;
         }
+
+        // enable WAL mode
+        appDataSource.query('PRAGMA journal_mode=WAL');
 
         return as;
       },

--- a/apps/mobile/src/databases/sync/_task.ts
+++ b/apps/mobile/src/databases/sync/_task.ts
@@ -80,7 +80,7 @@ export async function batchSaveWithPQueueAndTransaction<
   }
 
   const thisTickUpsertQueue = (keyVaryUpsertQueue[taskKey] = new PQueue({
-    concurrency: 1,
+    concurrency: 20,
   }));
 
   const repo = entityCls.getRepository();

--- a/apps/mobile/src/databases/sync/utils.ts
+++ b/apps/mobile/src/databases/sync/utils.ts
@@ -1,6 +1,6 @@
+import { RefLikeObject } from '@/utils/type';
 import { NFTItemEntity } from '../entities/nftItem';
 import { PortocolItemEntity } from '../entities/portocolItem';
-import { TokenItemEntity } from '../entities/tokenitem';
 
 export const updateExpiredTime = async (_address: string, offest?: number) => {
   const address = _address.toLowerCase();
@@ -14,3 +14,79 @@ export const updateExpiredTime = async (_address: string, offest?: number) => {
     console.log('update expired', error);
   }
 };
+
+const labelCounter: Record<string, number> = {};
+function incByLabel(label: string) {
+  labelCounter[label] = (labelCounter[label] || 0) + 1;
+  return labelCounter[label];
+}
+const abortControllersByLabel: Record<string, AbortController | null> = {};
+export function wrapAbortableFn({
+  fn,
+  label: labelOrList,
+  externalControllerRef,
+  onFinally,
+}: {
+  fn: (signal: AbortSignal) => Promise<void>;
+  label: string | string[];
+  externalControllerRef?: RefLikeObject<AbortController | null>;
+  onFinally?: (signal: AbortSignal) => void;
+}) {
+  const label = Array.isArray(labelOrList)
+    ? labelOrList.join('-')
+    : labelOrList;
+  const logPrefix = [
+    '[abortableFn]',
+    label ? `[${label}::${incByLabel(label)}] ` : '',
+  ].join('');
+
+  const run = async () => {
+    const onExternalAborted = () => {
+      console.debug(
+        `${logPrefix}Request was aborted due to external controller`,
+      );
+      abortControllersByLabel[label]?.abort();
+      externalControllerRef?.current?.signal.removeEventListener(
+        'abort',
+        onExternalAborted,
+      );
+    };
+    externalControllerRef?.current?.signal.addEventListener(
+      'abort',
+      onExternalAborted,
+    );
+    // abort previous
+    if (abortControllersByLabel[label]) abortControllersByLabel[label].abort();
+    abortControllersByLabel[label] = new AbortController();
+
+    const { signal } = abortControllersByLabel[label];
+
+    const p = signal.aborted
+      ? Promise.resolve()
+      : fn(signal)
+          .then(res => {
+            console.log(`${logPrefix}Request succeeded:`, res);
+            return res;
+          })
+          .catch(error => {
+            console.error(`${logPrefix}Request failed:`, error);
+          });
+
+    return p.finally(() => {
+      onFinally?.(signal);
+      if (signal.aborted) {
+        console.debug(`${logPrefix}Request was aborted`);
+      }
+    });
+  };
+
+  const abort = () => {
+    abortControllersByLabel[label]?.abort();
+  };
+
+  const getAbortController = () => {
+    return abortControllersByLabel[label];
+  };
+
+  return { run, abort, getAbortController };
+}

--- a/apps/mobile/src/hooks/account.ts
+++ b/apps/mobile/src/hooks/account.ts
@@ -15,7 +15,6 @@ import {
 } from '@/core/services';
 import { removeAddress } from '@/core/apis/address';
 import { Account, IPinAddress } from '@/core/services/preference';
-import { addressUtils } from '@rabby-wallet/base-utils';
 import { getWalletIcon } from '@/utils/walletInfo';
 import { TotalBalanceResponse } from '@rabby-wallet/rabby-api/dist/types';
 import {
@@ -31,10 +30,11 @@ import { useAtomicRequest } from './common/useAtomicAction';
 import { appServiceEvents } from '@/core/services/_utils';
 import { isSameAddress } from '@rabby-wallet/base-utils/dist/isomorphic/address';
 import { deleteDBResourceForAddress } from '@/databases/sync/assets';
-import { filterMyAccounts } from '@/utils/account';
-import { unionBy } from 'lodash';
+import { filterMyAccounts, stableSortByAddress } from '@/utils/account';
+import { isEqual, unionBy } from 'lodash';
 import { BalanceEntity } from '@/databases/entities/balance';
 import { useHistoryTokenDict } from './historyTokenDict';
+import { useCreationWithShallowCompare } from './common/useMemozied';
 
 export type KeyringAccountWithAlias = KeyringAccount & {
   aliasName?: string;
@@ -59,6 +59,11 @@ pinAddressesAtom.onMount = setAtom => {
   setAtom(addresses);
 };
 
+/**
+ * @description if new fetched accounts are same from the existing ones, return the existing ones
+ * to keep same ref to avoid later re-renders on React Hooks
+ */
+const existedAccountsRef = { current: [] as KeyringAccountWithAlias[] };
 async function fetchAllAccounts() {
   let nextAccounts: KeyringAccountWithAlias[] = [];
   try {
@@ -88,7 +93,11 @@ async function fetchAllAccounts() {
   } catch (err) {
     Sentry.captureException(err);
   } finally {
-    return nextAccounts;
+    if (!isEqual(existedAccountsRef.current, nextAccounts)) {
+      existedAccountsRef.current = nextAccounts;
+    }
+
+    return existedAccountsRef.current;
   }
 }
 
@@ -100,7 +109,11 @@ export function useAccounts(opts?: { disableAutoFetch?: boolean }) {
 
   const doFetchAccounts = useCallback(async () => {
     const nextAccounts = await fetchAllAccounts();
-    setAccounts(nextAccounts);
+    setAccounts(prev => {
+      if (isEqual(prev, nextAccounts)) return prev;
+
+      return nextAccounts;
+    });
   }, [setAccounts]);
 
   const { fetchAction: fetchAccounts } = useAtomicRequest({
@@ -114,10 +127,12 @@ export function useAccounts(opts?: { disableAutoFetch?: boolean }) {
     }
   }, [disableAutoFetch, fetchAccounts]);
 
+  const stableAccounts = useCreationWithShallowCompare(() => {
+    return accounts;
+  }, [accounts]);
+
   return {
-    accounts: useMemo(() => {
-      return [...accounts];
-    }, [accounts]),
+    accounts: stableAccounts,
     fetchAccounts,
   };
 }

--- a/apps/mobile/src/hooks/account.ts
+++ b/apps/mobile/src/hooks/account.ts
@@ -30,7 +30,7 @@ import { useAtomicRequest } from './common/useAtomicAction';
 import { appServiceEvents } from '@/core/services/_utils';
 import { isSameAddress } from '@rabby-wallet/base-utils/dist/isomorphic/address';
 import { deleteDBResourceForAddress } from '@/databases/sync/assets';
-import { filterMyAccounts, stableSortByAddress } from '@/utils/account';
+import { filterMyAccounts } from '@/utils/account';
 import { isEqual, unionBy } from 'lodash';
 import { BalanceEntity } from '@/databases/entities/balance';
 import { useHistoryTokenDict } from './historyTokenDict';

--- a/apps/mobile/src/hooks/common/useMemozied.ts
+++ b/apps/mobile/src/hooks/common/useMemozied.ts
@@ -1,0 +1,56 @@
+import { isEqual } from 'lodash';
+import { useRef } from 'react';
+
+function depsAreSame(oldDeps: any[], deps: any[]) {
+  if (oldDeps.length !== deps.length) return false;
+  for (let i = 0; i < oldDeps.length; i++) {
+    if (!Object.is(oldDeps[i], deps[i])) return false;
+  }
+  return true;
+}
+
+export function useCreationWithShallowCompare<T = any>(
+  factory: () => T,
+  deps: any[],
+) {
+  const current = useRef({
+    deps: deps,
+    obj: undefined as undefined | T,
+    initialized: false,
+  }).current;
+
+  if (current.initialized === false || !depsAreSame(current.deps, deps)) {
+    current.deps = deps;
+    current.obj = factory();
+    current.initialized = true;
+  }
+
+  return current.obj as T;
+}
+
+function deepDepsAreSame(oldDeps: any[], deps: any[]) {
+  if (oldDeps.length !== deps.length) return false;
+  for (let i = 0; i < oldDeps.length; i++) {
+    if (!isEqual(oldDeps[i], deps[i])) return false;
+  }
+  return true;
+}
+
+export function useCreationWithDeepCompare<T = any>(
+  factory: () => T,
+  deps: any[],
+) {
+  const current = useRef({
+    deps: deps,
+    obj: undefined as undefined | T,
+    initialized: false,
+  }).current;
+
+  if (current.initialized === false || !deepDepsAreSame(current.deps, deps)) {
+    current.deps = deps;
+    current.obj = factory();
+    current.initialized = true;
+  }
+
+  return current.obj as T;
+}

--- a/apps/mobile/src/hooks/useSheetModal.ts
+++ b/apps/mobile/src/hooks/useSheetModal.ts
@@ -13,29 +13,22 @@ export function useSheetModal(
   const sheetModalRef = existingSheetModalRef || internalRef;
 
   const toggleShowSheetModal = React.useCallback(
-    async (
-      shownType: SheetModalShowType,
-      animationConfigs?: WithSpringConfig | WithTimingConfig,
-    ) => {
-      let finalAc: typeof animationConfigs;
-      if (animationConfigs) {
-        finalAc = { ...animationConfigs };
-      }
+    async (shownType: SheetModalShowType) => {
       switch (shownType) {
         case 'destroy':
-          sheetModalRef.current?.dismiss(finalAc);
+          sheetModalRef.current?.dismiss();
           return;
         case 'collapse':
-          sheetModalRef.current?.collapse(finalAc);
+          sheetModalRef.current?.collapse();
           return;
         case true:
           sheetModalRef.current?.present();
           return;
         case false:
-          sheetModalRef.current?.close(finalAc);
+          sheetModalRef.current?.close();
           return;
         default:
-          sheetModalRef.current?.snapToIndex(shownType, finalAc);
+          sheetModalRef.current?.snapToIndex(shownType);
           return;
       }
     },
@@ -72,19 +65,19 @@ export function useSheetModals<T extends string>(
       }
       switch (shownType) {
         case 'destroy':
-          sheetModalRefs[type]?.current?.dismiss(finalAc);
+          sheetModalRefs[type]?.current?.dismiss();
           return;
         case 'collapse':
-          sheetModalRefs[type]?.current?.collapse(finalAc);
+          sheetModalRefs[type]?.current?.collapse();
           return;
         case true:
           sheetModalRefs[type]?.current?.present();
           return;
         case false:
-          sheetModalRefs[type]?.current?.close(finalAc);
+          sheetModalRefs[type]?.current?.close();
           return;
         default:
-          sheetModalRefs[type]?.current?.snapToIndex(shownType, finalAc);
+          sheetModalRefs[type]?.current?.snapToIndex(shownType);
           return;
       }
     },

--- a/apps/mobile/src/hooks/useSheetModal.ts
+++ b/apps/mobile/src/hooks/useSheetModal.ts
@@ -3,7 +3,7 @@ import React from 'react';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { WithSpringConfig, WithTimingConfig } from 'react-native-reanimated';
 
-type ShowType = boolean | 'destroy' | 'collapse' | number;
+export type SheetModalShowType = boolean | 'destroy' | 'collapse' | number;
 
 export function useSheetModal(
   existingSheetModalRef?: React.RefObject<BottomSheetModal> | null,
@@ -13,22 +13,29 @@ export function useSheetModal(
   const sheetModalRef = existingSheetModalRef || internalRef;
 
   const toggleShowSheetModal = React.useCallback(
-    async (shownType: ShowType) => {
+    async (
+      shownType: SheetModalShowType,
+      animationConfigs?: WithSpringConfig | WithTimingConfig,
+    ) => {
+      let finalAc: typeof animationConfigs;
+      if (animationConfigs) {
+        finalAc = { ...animationConfigs };
+      }
       switch (shownType) {
         case 'destroy':
-          sheetModalRef.current?.dismiss();
+          sheetModalRef.current?.dismiss(finalAc);
           return;
         case 'collapse':
-          sheetModalRef.current?.collapse();
+          sheetModalRef.current?.collapse(finalAc);
           return;
         case true:
           sheetModalRef.current?.present();
           return;
         case false:
-          sheetModalRef.current?.close();
+          sheetModalRef.current?.close(finalAc);
           return;
         default:
-          sheetModalRef.current?.snapToIndex(shownType);
+          sheetModalRef.current?.snapToIndex(shownType, finalAc);
           return;
       }
     },
@@ -54,7 +61,7 @@ export function useSheetModals<T extends string>(
   const toggleShowSheetModal = React.useCallback(
     async (
       type: T,
-      shownType: ShowType,
+      shownType: SheetModalShowType,
       animationConfigs?: WithSpringConfig | WithTimingConfig,
     ) => {
       let finalAc: typeof animationConfigs;
@@ -65,19 +72,19 @@ export function useSheetModals<T extends string>(
       }
       switch (shownType) {
         case 'destroy':
-          sheetModalRefs[type]?.current?.dismiss();
+          sheetModalRefs[type]?.current?.dismiss(finalAc);
           return;
         case 'collapse':
-          sheetModalRefs[type]?.current?.collapse();
+          sheetModalRefs[type]?.current?.collapse(finalAc);
           return;
         case true:
           sheetModalRefs[type]?.current?.present();
           return;
         case false:
-          sheetModalRefs[type]?.current?.close();
+          sheetModalRefs[type]?.current?.close(finalAc);
           return;
         default:
-          sheetModalRefs[type]?.current?.snapToIndex(shownType);
+          sheetModalRefs[type]?.current?.snapToIndex(shownType, finalAc);
           return;
       }
     },

--- a/apps/mobile/src/screens/Address/components/MultiAssets/hooks/index.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/hooks/index.tsx
@@ -4,7 +4,6 @@ import { useSortAddressList } from '@/screens/Address/useSortAddressList';
 import { filterMyAccounts } from '@/utils/account';
 import { isSameAddress } from '@rabby-wallet/base-utils/dist/isomorphic/address';
 import { KEYRING_CLASS } from '@rabby-wallet/keyring-utils';
-import { useCreation } from 'ahooks';
 import React, { useMemo } from 'react';
 
 export const isTabsSwiping = {

--- a/apps/mobile/src/screens/Address/components/MultiAssets/hooks/index.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/hooks/index.tsx
@@ -1,7 +1,7 @@
 import { useAccounts } from '@/hooks/account';
 import { useCreationWithDeepCompare } from '@/hooks/common/useMemozied';
 import { useSortAddressList } from '@/screens/Address/useSortAddressList';
-import { filterMyAccounts, stableSortByAddress } from '@/utils/account';
+import { filterMyAccounts } from '@/utils/account';
 import { isSameAddress } from '@rabby-wallet/base-utils/dist/isomorphic/address';
 import { KEYRING_CLASS } from '@rabby-wallet/keyring-utils';
 import { useCreation } from 'ahooks';
@@ -68,7 +68,7 @@ export const useAccountInfo = () => {
   }, [notTop10Addresses, gnosisAccounts, watchAccounts]);
 
   const top10Addresses = useCreationWithDeepCompare(() => {
-    return stableSortByAddress(top10AddressesOrig);
+    return top10AddressesOrig;
   }, [top10AddressesOrig]);
 
   return {

--- a/apps/mobile/src/screens/Address/components/MultiAssets/hooks/index.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/hooks/index.tsx
@@ -1,8 +1,10 @@
 import { useAccounts } from '@/hooks/account';
+import { useCreationWithDeepCompare } from '@/hooks/common/useMemozied';
 import { useSortAddressList } from '@/screens/Address/useSortAddressList';
-import { filterMyAccounts } from '@/utils/account';
+import { filterMyAccounts, stableSortByAddress } from '@/utils/account';
 import { isSameAddress } from '@rabby-wallet/base-utils/dist/isomorphic/address';
 import { KEYRING_CLASS } from '@rabby-wallet/keyring-utils';
+import { useCreation } from 'ahooks';
 import React, { useMemo } from 'react';
 
 export const isTabsSwiping = {
@@ -27,7 +29,7 @@ export const useAccountInfo = () => {
     return accounts.some(account => account.type === KEYRING_CLASS.GNOSIS);
   }, [accounts]);
   const {
-    addresses: top10Addresses,
+    addresses: top10AddressesOrig,
     totalBalance: top10Balance,
     totalEvmBalance: top10EvmBalance,
     notTop10Addresses,
@@ -64,6 +66,10 @@ export const useAccountInfo = () => {
   const notMatterAccounts = useMemo(() => {
     return [...notTop10Addresses, ...gnosisAccounts, ...watchAccounts];
   }, [notTop10Addresses, gnosisAccounts, watchAccounts]);
+
+  const top10Addresses = useCreationWithDeepCompare(() => {
+    return stableSortByAddress(top10AddressesOrig);
+  }, [top10AddressesOrig]);
 
   return {
     top10Addresses,

--- a/apps/mobile/src/screens/Address/components/MultiAssets/index.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/index.tsx
@@ -43,8 +43,7 @@ export const MultiAssets = ({
 
   const top10Balance = useMemo(() => {
     return getTotalBalance(top10Addresses);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [top10Addresses.join(','), getTotalBalance]);
+  }, [top10Addresses, getTotalBalance]);
 
   const { combineData, isLoadingNew: isLoadingCurve } = useMultiCurve(
     top10Addresses,

--- a/apps/mobile/src/screens/Address/useSortAddressList.tsx
+++ b/apps/mobile/src/screens/Address/useSortAddressList.tsx
@@ -1,13 +1,13 @@
 import { KeyringAccountWithAlias, usePinAddresses } from '@/hooks/account';
 import { sortAccountList } from '@/utils/sortAccountList';
-import { useMemo } from 'react';
+import { useCreationWithShallowCompare } from '@/hooks/common/useMemozied';
 
 export const useSortAddressList = (accounts: KeyringAccountWithAlias[]) => {
   const { pinAddresses: highlightedAddresses } = usePinAddresses({
     disableAutoFetch: true,
   });
 
-  const list = useMemo(() => {
+  const list = useCreationWithShallowCompare(() => {
     return sortAccountList(accounts, {
       highlightedAddresses,
     });

--- a/apps/mobile/src/screens/Bridge/components/BridgeToTokenSelect.tsx
+++ b/apps/mobile/src/screens/Bridge/components/BridgeToTokenSelect.tsx
@@ -26,6 +26,7 @@ import { useSceneAccountInfo } from '@/hooks/accountsSwitcher';
 import { FavoriteFilterType } from '@/components/Token/FavoriteFilterItem';
 import { useUserTokenSettings } from '@/hooks/useTokenSettings';
 import { useFocusEffect } from '@react-navigation/native';
+import { useTokenSelectorModalVisible } from '@/components/Token/TokenSelectorSheetModal';
 
 interface BridgeToTokenSelectProps {
   // allowClearAccountFilter?: boolean;
@@ -58,7 +59,15 @@ const BridgeToTokenSelect = ({
   });
 
   const bridgeSupportedChains = useBridgeSupportedChains();
-  const [tokenSelectorVisible, setTokenSelectorVisible] = useState(false);
+  const {
+    visible: tokenSelectorVisible,
+    tokenSelectorModalRef,
+    setTokenSelectorVisible,
+  } = useTokenSelectorModalVisible({
+    onVisibleChanged: useMemoizedFn(visible => {
+      if (!visible) return;
+    }),
+  });
 
   const { finalSceneCurrentAccount: currentAccount } = useSceneAccountInfo({
     forScene: 'MakeTransactionAbout',
@@ -226,6 +235,7 @@ const BridgeToTokenSelect = ({
       </TouchableOpacity>
 
       <TokenSelectorSheetModal
+        ref={tokenSelectorModalRef}
         visible={tokenSelectorVisible}
         list={displayTokenList}
         onConfirm={handleCurrentTokenChange}

--- a/apps/mobile/src/screens/Home/hooks/useSortTokens.ts
+++ b/apps/mobile/src/screens/Home/hooks/useSortTokens.ts
@@ -9,37 +9,36 @@ import { apiBalance } from '@/core/apis';
 import { AbstractPortfolioToken } from '../types';
 import { Account } from '@/core/services/preference';
 
+const sortByChainBalance = <T extends TokenItem | AbstractPortfolioToken>(
+  list: T[],
+  currentAddress?: Account['address'] | null,
+) => {
+  if (currentAddress) {
+    const cache = apiBalance.getAddressCacheBalanceSync(currentAddress);
+    if (cache) {
+      list.sort((a, b) => {
+        const chain1 = cache.chain_list.find(chain => chain.id === a.chain);
+        const chain2 = cache.chain_list.find(chain => chain.id === b.chain);
+        if (chain1 && chain2) {
+          if (chain1.usd_value <= 0 && chain2.usd_value <= 0) {
+            return (chain2.born_at || 0) - (chain1.born_at || 0);
+          }
+          return chain2.usd_value - chain1.usd_value;
+        }
+        return 0;
+      });
+    }
+  }
+  return list;
+};
+
 const useSortToken = <T extends TokenItem | AbstractPortfolioToken>(
   list: T[],
   account?: Account | null,
 ) => {
-  const currentAccount = account;
-  const [result, setResult] = useState<T[]>([]);
+  const result = useMemo(() => {
+    if (!list) return [];
 
-  const sortByChainBalance = async (list: T[]) => {
-    if (currentAccount) {
-      const cache = await apiBalance.getAddressCacheBalance(
-        currentAccount.address,
-      );
-      if (cache) {
-        list.sort((a, b) => {
-          const chain1 = cache.chain_list.find(chain => chain.id === a.chain);
-          const chain2 = cache.chain_list.find(chain => chain.id === b.chain);
-          if (chain1 && chain2) {
-            if (chain1.usd_value <= 0 && chain2.usd_value <= 0) {
-              return (chain2.born_at || 0) - (chain1.born_at || 0);
-            }
-            return chain2.usd_value - chain1.usd_value;
-          }
-          return 0;
-        });
-      }
-    }
-    return list;
-  };
-
-  useEffect(() => {
-    if (!list) return;
     const hasUsdValue: T[] = [];
     const hasAmount: T[] = [];
     const others: T[] = [];
@@ -77,11 +76,13 @@ const useSortToken = <T extends TokenItem | AbstractPortfolioToken>(
       }
       return bWorth - aWorth;
     });
-    sortByChainBalance(others).then(list => {
-      setResult([...hasUsdValue, ...hasAmount, ...list]);
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [list]);
+
+    return [
+      ...hasUsdValue,
+      ...hasAmount,
+      ...sortByChainBalance(others, account?.address),
+    ];
+  }, [list, account?.address]);
 
   return result;
 };

--- a/apps/mobile/src/screens/Search/useAssets.ts
+++ b/apps/mobile/src/screens/Search/useAssets.ts
@@ -229,7 +229,7 @@ export const useAssets = ({
         return;
       }
       setLoading(true);
-      const cachedTokens = await TokenItemEntity.batchMultAddressTokens(
+      const cachedTokens = await TokenItemEntity.batchMultiAddressTokens(
         addresses,
         options?.core,
         options?.maxLength,

--- a/apps/mobile/src/screens/Swap/components/TokenSelect.tsx
+++ b/apps/mobile/src/screens/Swap/components/TokenSelect.tsx
@@ -159,7 +159,9 @@ const TokenSelect = forwardRef<TokenSelectInst, TokenSelectProps>(
     // fetch tokens
     useEffect(() => {
       (async () => {
+        tokenSelectorVisible;
         useSwapTokenList;
+
         if (!existedTokens) {
           if (type === 'send') {
             currentAccount?.address &&
@@ -176,6 +178,7 @@ const TokenSelect = forwardRef<TokenSelectInst, TokenSelectProps>(
         }
       })();
     }, [
+      tokenSelectorVisible,
       currentAccount?.address,
       useSwapTokenList,
       loadToken,

--- a/apps/mobile/src/screens/Swap/components/TokenSelect.tsx
+++ b/apps/mobile/src/screens/Swap/components/TokenSelect.tsx
@@ -149,8 +149,6 @@ const TokenSelect = forwardRef<TokenSelectInst, TokenSelectProps>(
       type: type,
     });
 
-    const isSwapTo = type === 'swapTo';
-
     useImperativeHandle(ref, () => ({
       openTokenModal: conds => {
         setQueryConds(prev => ({ ...prev, ...conds }));
@@ -178,7 +176,6 @@ const TokenSelect = forwardRef<TokenSelectInst, TokenSelectProps>(
         }
       })();
     }, [
-      // tokenSelectorVisible,
       currentAccount?.address,
       useSwapTokenList,
       loadToken,
@@ -188,20 +185,21 @@ const TokenSelect = forwardRef<TokenSelectInst, TokenSelectProps>(
       type,
     ]);
 
+    const currentAddress = currentAccount?.address;
     // swap token list
     const { value: swapTokenList, loading: swapTokenListLoading } =
       useAsync(async () => {
-        if (!currentAccount || !useSwapTokenList || !tokenSelectorVisible) {
+        if (!currentAddress || !useSwapTokenList || !tokenSelectorVisible) {
           return [];
         }
         const list = await openapi.getSwapTokenList(
-          currentAccount.address,
+          currentAddress,
           queryConds.chainServerId ? queryConds.chainServerId : undefined,
         );
         return list;
       }, [
         queryConds.chainServerId,
-        currentAccount,
+        currentAddress,
         useSwapTokenList,
         tokenSelectorVisible,
       ]);
@@ -210,7 +208,7 @@ const TokenSelect = forwardRef<TokenSelectInst, TokenSelectProps>(
 
     const searchedLocalTokensWithOwner = useMemo(
       () =>
-        (isSwapTo || type === 'bridgeFrom' || type === 'swapFrom') &&
+        (type === 'swapTo' || type === 'bridgeFrom' || type === 'swapFrom') &&
         queryConds.keyword
           ? tokens
           : tokens.map(
@@ -221,7 +219,7 @@ const TokenSelect = forwardRef<TokenSelectInst, TokenSelectProps>(
                     'ownerAccount' in e ? e.ownerAccount : undefined,
                 } as TokenItemMaybeWithOwner),
             ),
-      [isSwapTo, queryConds.keyword, tokens, type],
+      [type, queryConds.keyword, tokens],
     );
 
     const { isSearchLoading, allTokens, searchedTokenByQuery, allTokenItems } =

--- a/apps/mobile/src/screens/Swap/components/TokenSelect.tsx
+++ b/apps/mobile/src/screens/Swap/components/TokenSelect.tsx
@@ -15,7 +15,10 @@ import { trigger } from 'react-native-haptic-feedback';
 import { uniqBy } from 'lodash';
 import { TokenItem } from '@rabby-wallet/rabby-api/dist/types';
 import { TokenSelectorSheetModal } from '@/components/Token';
-import { ITokenCheck } from '@/components/Token/TokenSelectorSheetModal';
+import {
+  ITokenCheck,
+  useTokenSelectorModalVisible,
+} from '@/components/Token/TokenSelectorSheetModal';
 import useAsync from 'react-use/lib/useAsync';
 import { useSortToken } from '@/hooks/chainAndToken/useToken';
 import {
@@ -112,25 +115,35 @@ const TokenSelect = forwardRef<TokenSelectInst, TokenSelectProps>(
       chainServerId: chainId,
     });
 
-    const [tokenSelectorVisible, setTokenSelectorVisible] = useState(false);
-    const [updateNonce, setUpdateNonce] = useState(0);
+    const [, setUpdateNonce] = useState(0);
     const [favoriteFilterValue, setFavoriteFilterValue] =
       useState<FavoriteFilterType>('all');
 
     const [_, setLongPressToken] = useLongPressTokenAtom();
     const queryConds = useDebounceValue(_queryConds, 250);
-    const timeRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const currentAccount = queryConds.account;
+
+    const {
+      visible: tokenSelectorVisible,
+      tokenSelectorModalRef,
+      setTokenSelectorVisible,
+    } = useTokenSelectorModalVisible({
+      onVisibleChanged: visible => {
+        loadOnVisibleChanged(visible);
+      },
+    });
+
     const {
       tokens,
-      getCacheTop10Tokens,
+      existedTokens,
       getCacheTokens,
       checkIsExpireAndUpdate,
       loadToken,
+      loadOnVisibleChanged,
       isLoading: isLoadingAllTokens,
     } = useSelectTokens({
       currentAccount,
-      visible: tokenSelectorVisible,
+      noNeedTokens: !tokenSelectorVisible,
       keyword: queryConds.keyword,
       chain_server_id: queryConds.chainServerId,
       type: type,
@@ -141,45 +154,39 @@ const TokenSelect = forwardRef<TokenSelectInst, TokenSelectProps>(
     useImperativeHandle(ref, () => ({
       openTokenModal: conds => {
         setQueryConds(prev => ({ ...prev, ...conds }));
-        setTokenSelectorVisible(true);
+        setTokenSelectorVisible(true, { noTriggerRerender: false });
       },
     }));
 
     // fetch tokens
     useEffect(() => {
       (async () => {
-        if (timeRef.current) {
-          clearTimeout(timeRef.current);
-          timeRef.current = null;
-        }
-        if (!tokenSelectorVisible) {
-          return;
-        }
-        const existedTokens = !!tokens.length;
+        useSwapTokenList;
         if (!existedTokens) {
           if (type === 'send') {
             currentAccount?.address &&
               (await getCacheTokens([currentAccount.address]));
           } else {
-            await getCacheTop10Tokens();
+            await getCacheTokens([], { isTop10: true });
           }
         }
-        timeRef.current = setTimeout(() => {
-          if (currentAccount?.address) {
-            loadToken(currentAccount.address, true);
-          } else {
-            checkIsExpireAndUpdate();
-          }
-        }, 500);
+
+        if (currentAccount?.address) {
+          loadToken(currentAccount.address, true);
+        } else {
+          checkIsExpireAndUpdate();
+        }
       })();
-      return () => {
-        if (timeRef.current) {
-          clearTimeout(timeRef.current);
-          timeRef.current = null;
-        }
-      };
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [tokenSelectorVisible, currentAccount?.address, useSwapTokenList]);
+    }, [
+      // tokenSelectorVisible,
+      currentAccount?.address,
+      useSwapTokenList,
+      loadToken,
+      checkIsExpireAndUpdate,
+      getCacheTokens,
+      existedTokens,
+      type,
+    ]);
 
     // swap token list
     const { value: swapTokenList, loading: swapTokenListLoading } =
@@ -354,7 +361,7 @@ const TokenSelect = forwardRef<TokenSelectInst, TokenSelectProps>(
         onTokenChange(t);
         setTokenSelectorVisible(false);
       },
-      [onChange, onTokenChange],
+      [onChange, onTokenChange, setTokenSelectorVisible],
     );
 
     const handleTokenSelectorClose = useCallback(() => {
@@ -362,7 +369,7 @@ const TokenSelect = forwardRef<TokenSelectInst, TokenSelectProps>(
       setTimeout(() => {
         setTokenSelectorVisible(false);
       }, 0);
-    }, []);
+    }, [setTokenSelectorVisible]);
 
     const resetQueryConds = useCallback(() => {
       setQueryConds(prev => ({
@@ -374,12 +381,12 @@ const TokenSelect = forwardRef<TokenSelectInst, TokenSelectProps>(
 
     const handleSelectToken = useCallback(() => {
       if (allTokenItems.length > 0) {
-        setUpdateNonce(updateNonce + 1);
+        setUpdateNonce(prev => prev + 1);
       }
 
       resetQueryConds();
       setTokenSelectorVisible(true);
-    }, [allTokenItems, updateNonce, resetQueryConds]);
+    }, [allTokenItems, resetQueryConds, setTokenSelectorVisible]);
 
     useEffect(() => {
       setQueryConds(prev => ({ ...prev, chainServerId: chainId }));
@@ -548,6 +555,7 @@ const TokenSelect = forwardRef<TokenSelectInst, TokenSelectProps>(
 
         <TokenSelectorSheetModal
           searchPlaceholder={searchPlaceholder}
+          ref={tokenSelectorModalRef}
           visible={tokenSelectorVisible}
           unshiftList={[]}
           list={selectedTab === 'testnet' ? testnetTokenList : list}

--- a/apps/mobile/src/screens/Swap/hooks/useSelectTokens.ts
+++ b/apps/mobile/src/screens/Swap/hooks/useSelectTokens.ts
@@ -310,8 +310,6 @@ export const useSelectTokens = ({
     return resTokens;
   }, [currentAddress, tokensMap]);
 
-  // const existedTokensInMemory = !!tokensInMemory.length;
-
   // filter tokens
   const tokens = useMemo(() => {
     if (noNeedTokens) return [];
@@ -464,7 +462,7 @@ export const useSelectTokens = ({
   return {
     tokensMap,
     tokens: tokenWithOwner,
-    existedTokens: !!tokenWithOwner.length,
+    existedTokens: !!tokensInMemory.length,
     isLoading: isLoading || swapToTokenSearchResultLoading,
     getCacheTokens,
     loadUserTokenSettings,

--- a/apps/mobile/src/screens/Swap/hooks/useSelectTokens.ts
+++ b/apps/mobile/src/screens/Swap/hooks/useSelectTokens.ts
@@ -1,37 +1,95 @@
-import { useSafeState } from '@/hooks/useSafeState';
-import { useMyAccounts } from '@/hooks/account';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import _, { add } from 'lodash';
+import { isAddress } from 'viem';
+import BigNumber from 'bignumber.js';
+import * as Sentry from '@sentry/react-native';
+import useAsync from 'react-use/lib/useAsync';
+
+import { useRefState } from '@/hooks/common/useRefState';
+import { useMyAccounts } from '@/hooks/account';
 import { syncTokens } from '@/databases/hooks/assets';
 import { TokenItemEntity } from '@/databases/entities/tokenitem';
-import _ from 'lodash';
 import { TokenItem } from '@rabby-wallet/rabby-api/dist/types';
 import { isSameAddress } from '@rabby-wallet/base-utils/dist/isomorphic/address';
 import { tokenItem2AbstractTokenWithOwner } from '@/utils/token';
 import { tagTokenItem } from '@/screens/Home/utils/token';
 import { preferenceService } from '@/core/services';
-import useAsync from 'react-use/lib/useAsync';
 import { TokenSelectType } from '@/components/Token/TokenSelectorSheetModal';
 import { openapi } from '@/core/request';
 import { AbstractPortfolioToken } from '@/screens/Home/types';
 import { Account } from '@/core/services/preference';
-import { isAddress } from 'viem';
-import BigNumber from 'bignumber.js';
 import { formatUsdValue } from '@/utils/number';
 import { formatAmount } from '@/utils/math';
 import { useAccountInfo } from '@/screens/Address/components/MultiAssets/hooks';
+import useDebounceValue from '@/hooks/common/useDebounceValue';
+import { wrapAbortableFn } from '@/databases/sync/utils';
+import { atomByMMKV } from '@/core/storage/mmkv';
+import { useAtom } from 'jotai';
 
 type LocalDBTokenItem = TokenItem & {
   _db_id?: TokenItemEntity['_db_id'];
   owner_addr: TokenItemEntity['owner_addr'];
 };
-export const useTokenAssetsMap = () => {
+
+const tokensByAddrAtom = atomByMMKV<Record<string, LocalDBTokenItem[]>>(
+  '@TokenSelectorByAddr',
+  {},
+);
+function useTokensByAddr() {
+  const [tokensByAddr, setTokensByAddr] = useAtom(tokensByAddrAtom);
+
+  const cacheTokensByAddr = useCallback(
+    (address: string, tokens: LocalDBTokenItem[]) => {
+      const addr = address.toLowerCase();
+
+      setTokensByAddr(prev => {
+        return {
+          ...prev,
+          [addr]: tokens,
+        };
+      });
+
+      return tokens;
+    },
+    [setTokensByAddr],
+  );
+
+  const getTokensByAddr = useCallback(
+    (address: string) => {
+      return tokensByAddr[address.toLowerCase()] || [];
+    },
+    [tokensByAddr],
+  );
+
+  return {
+    cacheTokensByAddr,
+    getTokensByAddr,
+  };
+}
+
+export const useSelectTokens = ({
+  currentAccount: _currentAccount,
+  noNeedTokens = false,
+  keyword,
+  chain_server_id,
+  type,
+}: {
+  currentAccount?: Account | null;
+  noNeedTokens?: boolean;
+  keyword?: string;
+  chain_server_id?: string;
+  type?: TokenSelectType;
+}) => {
+  const { accounts } = useMyAccounts({ disableAutoFetch: true });
+  const [isFirstFetch, setIsFirstFetch] = useState(true);
+
   const [tokensMap, setTokensMap] = useState<{
     [address: string]: LocalDBTokenItem[];
   }>({});
+
   // ref tag if address has tokens
-  const addressHasTokensRef = useRef<{
-    [address: string]: boolean;
-  }>({});
+  const addressHasTokensRef = useRef<{ [address: string]: boolean }>({});
 
   const updateTokens = useCallback(
     ({
@@ -48,39 +106,14 @@ export const useTokenAssetsMap = () => {
           [lowerAddress]: newTokens,
         };
       });
+      addressHasTokensRef.current[lowerAddress] = !!newTokens.length;
     },
     [],
   );
-  useEffect(() => {
-    Object.keys(tokensMap).forEach(address => {
-      addressHasTokensRef.current[address] = !!tokensMap[address]?.length;
-    });
-  }, [tokensMap]);
-  return { tokensMap, setTokensMap, updateTokens, addressHasTokensRef };
-};
 
-export const useSelectTokens = ({
-  currentAccount,
-  visible,
-  keyword,
-  chain_server_id,
-  type,
-}: {
-  currentAccount?: Account | null;
-  visible?: boolean;
-  keyword?: string;
-  chain_server_id?: string;
-  type?: TokenSelectType;
-}) => {
-  const [isLoading, setLoading] = useSafeState(false);
-  const { accounts } = useMyAccounts({
-    disableAutoFetch: true,
-  });
-  const [isFirstFetch, setIsFirstFetch] = useState(true);
-  const { tokensMap, setTokensMap, updateTokens, addressHasTokensRef } =
-    useTokenAssetsMap();
   const [userTokenSettings, setUserTokenSettings] = useState({});
-  const currentAddress = currentAccount?.address;
+  const currentAccount = useDebounceValue(_currentAccount, 100);
+
   const { top10Addresses, fetchAccounts } = useAccountInfo();
 
   const enableSearchTokensV2 = useMemo(
@@ -92,6 +125,9 @@ export const useSelectTokens = ({
       ),
     [keyword, type],
   );
+
+  const currentAddress = currentAccount?.address || _currentAccount?.address;
+
   const {
     value: swapToTokenSearchResult,
     loading: swapToTokenSearchResultLoading,
@@ -158,119 +194,173 @@ export const useSelectTokens = ({
         });
     }
     return [];
-  }, [enableSearchTokensV2, keyword, chain_server_id, currentAccount?.address]);
+  }, [
+    enableSearchTokensV2,
+    currentAddress,
+    top10Addresses,
+    keyword,
+    chain_server_id,
+  ]);
 
-  useEffect(() => {
-    if (visible && Object.keys(userTokenSettings).length === 0) {
-      preferenceService
-        .getUserTokenSettings()
-        .then(res => res || {})
-        .then(setUserTokenSettings);
-    }
-  }, [userTokenSettings, visible]);
+  const loadUserTokenSettings = useCallback(() => {
+    setUserTokenSettings(prev => {
+      if (Object.keys(prev).length > 0) return prev;
 
+      return preferenceService.getUserTokenSettingsSync();
+    });
+  }, []);
+
+  const [isLoadingToken, setIsLoadingToken] = useState(false);
   const loadToken = useCallback(
     async (_address: string, force?: boolean) => {
       const address = _address.toLowerCase();
-      if (!address) {
-        return;
-      }
+      if (!address) return;
+
       try {
         const tokensExisted = addressHasTokensRef.current[address];
-        if (!tokensExisted) {
-          setLoading(true);
-        }
-        // if token exist and not expired, don't sync to store
-        const tokenRes = await syncTokens(address, force, tokensExisted);
-        if (!tokenRes.length) {
-          setLoading(false);
-          return;
-        }
-        updateTokens({
-          address,
-          newTokens: tokenRes || [],
-        });
+        setIsLoadingToken(true);
+        // if (!tokensExisted) setIsLoadingToken(true);
+        await wrapAbortableFn({
+          label: `loadToken-${address}`,
+          fn: async signal => {
+            // if token exist and not expired, don't sync to store
+            const tokenRes = await syncTokens(address, force, tokensExisted);
+            if (signal.aborted) return;
+            if (!tokenRes.length) return;
+
+            updateTokens({
+              address,
+              newTokens: tokenRes || [],
+            });
+          },
+        }).run();
       } catch (error) {
+        console.error('loadToken error', error);
+        Sentry.captureException(error);
       } finally {
-        setLoading(false);
+        setIsLoadingToken(false);
       }
     },
-    [addressHasTokensRef, setLoading, updateTokens],
+    [updateTokens],
   );
 
-  const batchLoadCacheTokens = useCallback(
-    async (_addresses: string[]) => {
-      if (!_addresses.length) {
-        return;
-      }
-      const addresses = _addresses.map(i => i.toLowerCase());
-      setLoading(true);
-      const cachedTokens = await TokenItemEntity.batchMultAddressTokens(
-        addresses,
-      );
-      const assestGroup = _.groupBy(cachedTokens, 'owner_addr');
-      setTokensMap(_pre => {
-        const curr = { ...(_pre || {}) };
-        Object.keys(assestGroup).forEach(address => {
-          curr[address] = assestGroup[address];
-        });
-        return curr;
-      });
-      setTimeout(() => {
-        setLoading(false);
-      }, 0);
-    },
-    [setLoading, setTokensMap],
-  );
+  const [isLoadingCacheToken, setIsLoadingCacheToken] = useState(false);
+  const loadCacheTokenCRef = useRef<AbortController | null>(null);
+  const batchLoadCacheTokens = useCallback(async (_addresses: string[]) => {
+    if (!_addresses.length) return;
 
+    const addresses = _addresses.map(i => i.toLowerCase());
+    setIsLoadingCacheToken(true);
+    try {
+      loadCacheTokenCRef.current?.abort();
+      loadCacheTokenCRef.current = new AbortController();
+      await wrapAbortableFn({
+        label: 'batchLoadCacheTokens',
+        externalControllerRef: loadCacheTokenCRef,
+        fn: async signal => {
+          const cachedTokens = await TokenItemEntity.batchMultiAddressTokens(
+            addresses,
+          );
+          if (signal.aborted) return;
+
+          const assestGroup = _.groupBy(cachedTokens, 'owner_addr');
+          if (signal.aborted) return;
+          setTokensMap(_pre => {
+            const curr = { ...(_pre || {}) };
+            Object.keys(assestGroup).forEach(address => {
+              curr[address] = assestGroup[address];
+            });
+            return curr;
+          });
+        },
+        onFinally: () => (loadCacheTokenCRef.current = null),
+      }).run();
+    } catch (error) {
+      console.error('batchLoadCacheTokens:: error', error);
+    } finally {
+      setIsLoadingCacheToken(false);
+    }
+  }, []);
+
+  const [isCheckingExpire, setIsCheckingExpire] = useState(false);
+  const checkingExpireCRef = useRef<AbortController | null>(null);
   const checkIsExpireAndUpdate = useCallback(
     async (force?: boolean) => {
       try {
-        for (const address of top10Addresses) {
-          try {
-            await loadToken(address, force);
-          } catch (error) {
-            console.error(
-              `Error fetching data for ${address.slice(-4)}:`,
-              error,
-            );
-          }
-        }
-        await new Promise(resolve => setTimeout(resolve, 0));
+        setIsCheckingExpire(true);
+
+        checkingExpireCRef.current?.abort();
+        checkingExpireCRef.current = new AbortController();
+        await wrapAbortableFn({
+          label: 'checkIsExpireAndUpdate',
+          externalControllerRef: checkingExpireCRef,
+          fn: async signal => {
+            for (const address of top10Addresses) {
+              if (signal.aborted) return;
+              try {
+                await loadToken(address, force);
+              } catch (error) {
+                console.error(
+                  `Error fetching data for ${address.slice(-4)}:`,
+                  error,
+                );
+              }
+            }
+            await new Promise(resolve => setTimeout(resolve, 0));
+          },
+          onFinally: () => (checkingExpireCRef.current = null),
+        }).run();
+      } catch (error) {
+        console.error('checkIsExpireAndUpdate error', error);
       } finally {
+        setIsCheckingExpire(false);
         setIsFirstFetch(false);
       }
     },
     [loadToken, top10Addresses],
   );
 
+  /** @deprecated */
   const getCacheTop10Tokens = useCallback(async () => {
     const emptyTokenAddresses = top10Addresses.filter(
-      addr => !tokensMap[addr]?.length,
+      addr => !addressHasTokensRef.current[addr],
     );
     await batchLoadCacheTokens(emptyTokenAddresses);
-  }, [batchLoadCacheTokens, tokensMap, top10Addresses]);
+  }, [batchLoadCacheTokens, top10Addresses]);
 
   const getCacheTokens = useCallback(
-    (addrresses: string[]) => {
-      return batchLoadCacheTokens(addrresses);
+    async (addresses: string[], options?: { isTop10?: boolean }) => {
+      if (options?.isTop10) {
+        const emptyTokenAddresses = top10Addresses.filter(
+          addr => !addressHasTokensRef.current[addr],
+        );
+        await batchLoadCacheTokens(emptyTokenAddresses);
+      }
+      await batchLoadCacheTokens(addresses);
     },
-    [batchLoadCacheTokens],
+    [top10Addresses, batchLoadCacheTokens],
   );
 
-  // filter tokens
-  const tokens = useMemo(() => {
+  const tokensInMemory = useMemo(() => {
     let resTokens: LocalDBTokenItem[] = [];
-    if (!visible) {
-      return [];
-    }
     if (currentAddress) {
       resTokens = tokensMap[currentAddress?.toLowerCase()] || [];
     } else {
       resTokens = Object.values(tokensMap).flat();
     }
+    return resTokens;
+  }, [currentAddress, tokensMap]);
+
+  const existedTokens = !!tokensInMemory.length;
+
+  // filter tokens
+  const tokens = useMemo(() => {
+    if (noNeedTokens) return [];
+    let resTokens: LocalDBTokenItem[] = Array.from(tokensInMemory);
     if (chain_server_id) {
-      resTokens = resTokens.filter(token => token.chain === chain_server_id);
+      resTokens = tokensInMemory.filter(
+        token => token.chain === chain_server_id,
+      );
     }
     if (keyword) {
       resTokens = resTokens
@@ -357,7 +447,7 @@ export const useSelectTokens = ({
     }
 
     return resTokens;
-  }, [chain_server_id, currentAddress, keyword, tokensMap, visible]);
+  }, [noNeedTokens, tokensInMemory, chain_server_id, keyword]);
 
   const tokenWithOwner = useMemo(() => {
     if (enableSearchTokensV2 && keyword) {
@@ -400,20 +490,33 @@ export const useSelectTokens = ({
     userTokenSettings,
   ]);
 
-  useEffect(() => {
-    if (visible) {
+  const loadOnVisibleChanged = useCallback(
+    (nextVisible = false) => {
+      if (!nextVisible) {
+        loadCacheTokenCRef.current?.abort();
+        checkingExpireCRef.current?.abort();
+        return;
+      }
+
       fetchAccounts();
-    }
-  }, [visible, fetchAccounts]);
+      loadUserTokenSettings();
+    },
+    [fetchAccounts, loadUserTokenSettings],
+  );
+
+  const isLoading = isLoadingToken || isCheckingExpire || isLoadingCacheToken;
 
   return {
     tokensMap,
     tokens: tokenWithOwner,
+    existedTokens,
     isLoading: isLoading || swapToTokenSearchResultLoading,
     getCacheTop10Tokens,
     getCacheTokens,
+    loadUserTokenSettings,
     checkIsExpireAndUpdate,
     loadToken,
     refreshing: !!isLoading && !isFirstFetch,
+    loadOnVisibleChanged,
   };
 };

--- a/apps/mobile/src/screens/Swap/hooks/useSelectTokens.ts
+++ b/apps/mobile/src/screens/Swap/hooks/useSelectTokens.ts
@@ -24,49 +24,11 @@ import { formatAmount } from '@/utils/math';
 import { useAccountInfo } from '@/screens/Address/components/MultiAssets/hooks';
 import useDebounceValue from '@/hooks/common/useDebounceValue';
 import { wrapAbortableFn } from '@/databases/sync/utils';
-import { atomByMMKV } from '@/core/storage/mmkv';
-import { useAtom } from 'jotai';
 
 type LocalDBTokenItem = TokenItem & {
   _db_id?: TokenItemEntity['_db_id'];
   owner_addr: TokenItemEntity['owner_addr'];
 };
-
-const tokensByAddrAtom = atomByMMKV<Record<string, LocalDBTokenItem[]>>(
-  '@TokenSelectorByAddr',
-  {},
-);
-function useTokensByAddr() {
-  const [tokensByAddr, setTokensByAddr] = useAtom(tokensByAddrAtom);
-
-  const cacheTokensByAddr = useCallback(
-    (address: string, tokens: LocalDBTokenItem[]) => {
-      const addr = address.toLowerCase();
-
-      setTokensByAddr(prev => {
-        return {
-          ...prev,
-          [addr]: tokens,
-        };
-      });
-
-      return tokens;
-    },
-    [setTokensByAddr],
-  );
-
-  const getTokensByAddr = useCallback(
-    (address: string) => {
-      return tokensByAddr[address.toLowerCase()] || [];
-    },
-    [tokensByAddr],
-  );
-
-  return {
-    cacheTokensByAddr,
-    getTokensByAddr,
-  };
-}
 
 export const useSelectTokens = ({
   currentAccount: _currentAccount,

--- a/apps/mobile/src/screens/Swap/hooks/useSelectTokens.ts
+++ b/apps/mobile/src/screens/Swap/hooks/useSelectTokens.ts
@@ -24,6 +24,7 @@ import { formatAmount } from '@/utils/math';
 import { useAccountInfo } from '@/screens/Address/components/MultiAssets/hooks';
 import useDebounceValue from '@/hooks/common/useDebounceValue';
 import { wrapAbortableFn } from '@/databases/sync/utils';
+import { stableSortByAddress } from '@/utils/account';
 
 type LocalDBTokenItem = TokenItem & {
   _db_id?: TokenItemEntity['_db_id'];
@@ -183,11 +184,15 @@ export const useSelectTokens = ({
         setIsLoadingToken(true);
         // if (!tokensExisted) setIsLoadingToken(true);
         await wrapAbortableFn({
-          label: `loadToken-${address}`,
+          label: [
+            `loadToken`,
+            `${address}`,
+            `${force ? 'force' : 'normal'}`,
+            tokensExisted ? 'onlysync' : 'syncandupdate',
+          ],
           fn: async signal => {
             // if token exist and not expired, don't sync to store
             const tokenRes = await syncTokens(address, force, tokensExisted);
-            if (signal.aborted) return;
             if (!tokenRes.length) return;
 
             updateTokens({
@@ -217,7 +222,7 @@ export const useSelectTokens = ({
       loadCacheTokenCRef.current?.abort();
       loadCacheTokenCRef.current = new AbortController();
       await wrapAbortableFn({
-        label: 'batchLoadCacheTokens',
+        label: ['batchLoadCacheTokens', ...stableSortByAddress(addresses)],
         externalControllerRef: loadCacheTokenCRef,
         fn: async signal => {
           const cachedTokens = await TokenItemEntity.batchMultiAddressTokens(
@@ -254,7 +259,7 @@ export const useSelectTokens = ({
         checkingExpireCRef.current?.abort();
         checkingExpireCRef.current = new AbortController();
         await wrapAbortableFn({
-          label: 'checkIsExpireAndUpdate',
+          label: ['checkIsExpireAndUpdate', force ? 'force' : 'normal'],
           externalControllerRef: checkingExpireCRef,
           fn: async signal => {
             for (const address of top10Addresses) {
@@ -282,14 +287,6 @@ export const useSelectTokens = ({
     [loadToken, top10Addresses],
   );
 
-  /** @deprecated */
-  const getCacheTop10Tokens = useCallback(async () => {
-    const emptyTokenAddresses = top10Addresses.filter(
-      addr => !addressHasTokensRef.current[addr],
-    );
-    await batchLoadCacheTokens(emptyTokenAddresses);
-  }, [batchLoadCacheTokens, top10Addresses]);
-
   const getCacheTokens = useCallback(
     async (addresses: string[], options?: { isTop10?: boolean }) => {
       if (options?.isTop10) {
@@ -313,7 +310,7 @@ export const useSelectTokens = ({
     return resTokens;
   }, [currentAddress, tokensMap]);
 
-  const existedTokens = !!tokensInMemory.length;
+  // const existedTokensInMemory = !!tokensInMemory.length;
 
   // filter tokens
   const tokens = useMemo(() => {
@@ -454,11 +451,7 @@ export const useSelectTokens = ({
 
   const loadOnVisibleChanged = useCallback(
     (nextVisible = false) => {
-      if (!nextVisible) {
-        loadCacheTokenCRef.current?.abort();
-        checkingExpireCRef.current?.abort();
-        return;
-      }
+      if (!nextVisible) return;
 
       fetchAccounts();
       loadUserTokenSettings();
@@ -471,9 +464,8 @@ export const useSelectTokens = ({
   return {
     tokensMap,
     tokens: tokenWithOwner,
-    existedTokens,
+    existedTokens: !!tokenWithOwner.length,
     isLoading: isLoading || swapToTokenSearchResultLoading,
-    getCacheTop10Tokens,
     getCacheTokens,
     loadUserTokenSettings,
     checkIsExpireAndUpdate,

--- a/apps/mobile/src/utils/account.ts
+++ b/apps/mobile/src/utils/account.ts
@@ -86,3 +86,30 @@ export const isAccountSupportDirectSign = (type?: string) => {
     [KEYRING_CLASS.MNEMONIC, KEYRING_CLASS.PRIVATE_KEY] as string[]
   ).includes(type);
 };
+
+export function stableSortByAddress<T extends { address: string }[] | string[]>(
+  accounts: T,
+) {
+  return accounts.sort((a, b) => {
+    const aAddr = typeof a === 'string' ? a : a.address;
+    const bAddr = typeof b === 'string' ? b : b.address;
+    return aAddr.localeCompare(bAddr);
+  }) as T;
+}
+
+export function stableSerializeAccounts<T extends KeyringAccountWithAlias[]>(
+  accounts: T,
+) {
+  return JSON.stringify(
+    accounts.sort((a, b) => a.address.localeCompare(b.address)),
+    null,
+    0,
+  );
+}
+
+export function stableSerializeItems<
+  T extends any[],
+  Sorter extends (a: T[number], b: T[number]) => number,
+>(items: T, sorter: Sorter) {
+  return JSON.stringify(items.sort(sorter), null, 0);
+}

--- a/apps/mobile/src/utils/type.ts
+++ b/apps/mobile/src/utils/type.ts
@@ -3,3 +3,5 @@ export type IExtractFromPromise<T> = T extends Promise<infer U> ? U : T;
 export type ObjectMirror<T> = {
   [K in keyof T]: T[K];
 };
+
+export type RefLikeObject<T> = { current: T };


### PR DESCRIPTION
-----
performance improvements on base:
- enable wal mode for sqlite
- for some hooks about `accounts` & `addresses`, use proper mechanism to determine if it should be memoized, see usages of `useCreationWithDeepCompare`, `useCreationWithShallowCompare`

performance improvements on token selector:
- use `AbortController` to cancel unnecessary token-load actions, see `wrapAbortableFn`
- replace Inappropriate `useEffect` with `useMemo` in `useSortToken` (in that case, it's weired to update on state with `useEffect`, we can just get derived data with `useMemo`