### PR TITLE
fix: update check-nodeengines command to be future proof

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
     "lint:commit:fix": "eslint ./src --quiet --fix --ext .js,.jsx,.ts,.tsx --max-warnings=-1",
     "lint:fix": "eslint ./src --fix --ext .js,.jsx,.ts,.tsx",
-    "check-nodeengines": "node -v | grep -E '^v(22|24)' > /dev/null || (echo \"Error: Node.js v22 or higher is required. Current version: $(node -v)\"; exit 1)",
+    "check-nodeengines": "node -v | grep -E '^v(2[2-9]|[3-9][0-9])' > /dev/null || (echo \"Error: Node.js v22 or higher is required. Current version: $(node -v)\"; exit 1)",
     "restart": "yarn start --reset-cache",
     "start": "yarn check-nodeengines && yarn ensure-git-hooks && yarn build:deps && yarn build-inpage && cross-env NODE_OPTIONS=--max_old_space_size=16384 react-native start",
     "start:thrifty": "yarn check-nodeengines && yarn ensure-git-hooks && yarn build:deps && yarn build-inpage && cross-env NODE_OPTIONS=--max_old_space_size=8192 react-native start",


### PR DESCRIPTION
Update the `check-nodeengines`  command to support the latest node version 25.