### PR TITLE
fix: harden friday tmp branch workflow

### DIFF
--- a/.github/workflows/create_tmp_friday_branch.yml
+++ b/.github/workflows/create_tmp_friday_branch.yml
@@ -2,13 +2,23 @@ name: Create Friday Tmp Branch
 
 on:
   workflow_dispatch:
+    inputs:
+      force_run:
+        description: Force a manual run even when today is not Friday
+        required: false
+        type: boolean
+        default: false
+      branch_name_override:
+        description: Optional branch name override for manual testing, must start with tmp/
+        required: false
+        type: string
   schedule:
     # 00:10 Asia/Shanghai
     - cron: '10 16 * * *'
 
 defaults:
   run:
-    shell: bash -ieol pipefail {0}
+    shell: bash --noprofile --norc -eo pipefail {0}
 
 concurrency:
   group: create-friday-tmp-branch
@@ -33,51 +43,81 @@ jobs:
 
       - name: Prepare branch info
         id: prepare
+        env:
+          FORCE_RUN: ${{ github.event.inputs.force_run || 'false' }}
+          BRANCH_NAME_OVERRIDE: ${{ github.event.inputs.branch_name_override || '' }}
         run: |
           weekday="$(date +%u)"
           branch_date="$(date +%Y%m%d)"
           branch_name="tmp/${branch_date}"
+
+          if [ -n "${BRANCH_NAME_OVERRIDE}" ]; then
+            case "${BRANCH_NAME_OVERRIDE}" in
+              tmp/*)
+                branch_name="${BRANCH_NAME_OVERRIDE}"
+                ;;
+              *)
+                echo "::error::branch_name_override must start with tmp/"
+                exit 1
+                ;;
+            esac
+          fi
 
           echo "weekday=${weekday}"
           echo "branch_name=${branch_name}"
 
           echo "weekday=${weekday}" >> "$GITHUB_OUTPUT"
           echo "branch_name=${branch_name}" >> "$GITHUB_OUTPUT"
+          echo "should_create=false" >> "$GITHUB_OUTPUT"
+          echo "branch_exists=false" >> "$GITHUB_OUTPUT"
+          printf 'skip_reason=%s\n' "Today is not Friday in ${TZ}; skip creating tmp branch." >> "$GITHUB_OUTPUT"
+          echo "base_sha=" >> "$GITHUB_OUTPUT"
 
-          if [ "$weekday" != "5" ]; then
-            echo "is_friday=false" >> "$GITHUB_OUTPUT"
+          if [ "$weekday" != "5" ] && [ "${FORCE_RUN}" != "true" ]; then
             exit 0
           fi
 
-          echo "is_friday=true" >> "$GITHUB_OUTPUT"
+          echo "should_create=true" >> "$GITHUB_OUTPUT"
+
+          git fetch origin "${BASE_BRANCH}" --no-tags
+          base_sha="$(git rev-parse FETCH_HEAD)"
+          echo "base_sha=${base_sha}" >> "$GITHUB_OUTPUT"
 
           if git ls-remote --exit-code --heads origin "${branch_name}" >/dev/null 2>&1; then
             echo "branch_exists=true" >> "$GITHUB_OUTPUT"
+            echo "should_create=false" >> "$GITHUB_OUTPUT"
+            printf 'skip_reason=%s\n' "Branch ${branch_name} already exists on origin; skip creating it again." >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "branch_exists=false" >> "$GITHUB_OUTPUT"
-
       - name: Create tmp branch
-        if: steps.prepare.outputs.is_friday == 'true' && steps.prepare.outputs.branch_exists == 'false'
+        if: steps.prepare.outputs.should_create == 'true'
         env:
           BRANCH_NAME: ${{ steps.prepare.outputs.branch_name }}
+          BASE_SHA: ${{ steps.prepare.outputs.base_sha }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git fetch origin "${BASE_BRANCH}" --no-tags
-          git switch --detach "origin/${BASE_BRANCH}"
-          git switch -c "${BRANCH_NAME}"
-          git push origin "HEAD:refs/heads/${BRANCH_NAME}"
+          if [ -z "${BASE_SHA}" ]; then
+            echo "::error::Missing base SHA for ${BASE_BRANCH}"
+            exit 1
+          fi
+
+          if git push origin "${BASE_SHA}:refs/heads/${BRANCH_NAME}"; then
+            echo "Created ${BRANCH_NAME} from ${BASE_SHA}."
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" >/dev/null 2>&1; then
+            echo "Branch ${BRANCH_NAME} was created during this run; treat as success."
+            exit 0
+          fi
+
+          echo "::error::Failed to create ${BRANCH_NAME} from ${BASE_SHA}"
+          exit 1
 
       - name: Print skip reason
-        if: steps.prepare.outputs.is_friday != 'true' || steps.prepare.outputs.branch_exists == 'true'
-        env:
-          BRANCH_NAME: ${{ steps.prepare.outputs.branch_name }}
+        if: steps.prepare.outputs.should_create != 'true'
         run: |
-          if [ "${{ steps.prepare.outputs.is_friday }}" != "true" ]; then
-            echo "Today is not Friday in ${TZ}; skip creating tmp branch."
-          else
-            echo "Branch ${BRANCH_NAME} already exists on origin; skip creating it again."
-          fi
+          echo "${{ steps.prepare.outputs.skip_reason }}"

--- a/.github/workflows/create_tmp_friday_branch.yml
+++ b/.github/workflows/create_tmp_friday_branch.yml
@@ -3,13 +3,8 @@ name: Create Friday Tmp Branch
 on:
   workflow_dispatch:
     inputs:
-      force_run:
-        description: Force a manual run even when today is not Friday
-        required: false
-        type: boolean
-        default: false
       branch_name_override:
-        description: Optional branch name override for manual testing, must start with tmp/
+        description: Optional branch name override for manual testing or backfill, must start with tmp/
         required: false
         type: string
   schedule:
@@ -44,11 +39,14 @@ jobs:
       - name: Prepare branch info
         id: prepare
         env:
-          FORCE_RUN: ${{ github.event.inputs.force_run || 'false' }}
           BRANCH_NAME_OVERRIDE: ${{ github.event.inputs.branch_name_override || '' }}
         run: |
-          weekday="$(date +%u)"
-          branch_date="$(date +%Y%m%d)"
+          readarray -t friday_info < <(
+            ruby -rdate -e 'today = Date.today; days_until_friday = (5 - today.cwday) % 7; target_friday = today + days_until_friday; puts target_friday.strftime("%Y%m%d"); puts target_friday.iso8601'
+          )
+
+          branch_date="${friday_info[0]}"
+          target_friday="${friday_info[1]}"
           branch_name="tmp/${branch_date}"
 
           if [ -n "${BRANCH_NAME_OVERRIDE}" ]; then
@@ -63,21 +61,15 @@ jobs:
             esac
           fi
 
-          echo "weekday=${weekday}"
+          echo "target_friday=${target_friday}"
           echo "branch_name=${branch_name}"
 
-          echo "weekday=${weekday}" >> "$GITHUB_OUTPUT"
+          echo "target_friday=${target_friday}" >> "$GITHUB_OUTPUT"
           echo "branch_name=${branch_name}" >> "$GITHUB_OUTPUT"
           echo "should_create=false" >> "$GITHUB_OUTPUT"
           echo "branch_exists=false" >> "$GITHUB_OUTPUT"
-          printf 'skip_reason=%s\n' "Today is not Friday in ${TZ}; skip creating tmp branch." >> "$GITHUB_OUTPUT"
+          printf 'skip_reason=%s\n' "Branch ${branch_name} already exists on origin; skip creating it again." >> "$GITHUB_OUTPUT"
           echo "base_sha=" >> "$GITHUB_OUTPUT"
-
-          if [ "$weekday" != "5" ] && [ "${FORCE_RUN}" != "true" ]; then
-            exit 0
-          fi
-
-          echo "should_create=true" >> "$GITHUB_OUTPUT"
 
           git fetch origin "${BASE_BRANCH}" --no-tags
           base_sha="$(git rev-parse FETCH_HEAD)"
@@ -85,10 +77,10 @@ jobs:
 
           if git ls-remote --exit-code --heads origin "${branch_name}" >/dev/null 2>&1; then
             echo "branch_exists=true" >> "$GITHUB_OUTPUT"
-            echo "should_create=false" >> "$GITHUB_OUTPUT"
-            printf 'skip_reason=%s\n' "Branch ${branch_name} already exists on origin; skip creating it again." >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          echo "should_create=true" >> "$GITHUB_OUTPUT"
 
       - name: Create tmp branch
         if: steps.prepare.outputs.should_create == 'true'


### PR DESCRIPTION
## Summary
- harden the tmp branch creation flow by creating the remote branch from the fetched base SHA instead of relying on local branch state
- switch the workflow shell to a non-interactive bash invocation and make the prepare step emit stable outputs for every path
- add manual dispatch inputs so the workflow can be force-run with a temporary `tmp/*` branch name for verification outside Friday

## Verification
- local YAML parse passed
- local `git diff --check` passed
- local shell simulation passed for the non-Friday force-run path
- GitHub Actions manual run succeeded: https://github.com/RabbyHub/rabby-mobile/actions/runs/24069230779
