### PR TITLE
fix: allow Android debug Metro cleartext traffic

### DIFF
--- a/apps/mobile/android/app/src/debug/res/xml/network_security_config.xml
+++ b/apps/mobile/android/app/src/debug/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config>
+    <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
             <certificates src="user" />


### PR DESCRIPTION
## Summary
- allow cleartext traffic in the Android debug network security config
- unblock Metro bundle and websocket requests to localhost during device debugging

## Verification
- reproduced the failure on device with 
- verified that adding  fixes debug reload and Metro requests
