### PR TITLE
fix: stabilize home balance change display

### DIFF
--- a/apps/mobile/src/databases/entities/balance.ts
+++ b/apps/mobile/src/databases/entities/balance.ts
@@ -71,11 +71,30 @@ export class BalanceEntity extends EntityAddressAssetBase {
     owner_addr: string,
     isCore: boolean,
   ): Promise<EvmTotalBalanceResponse> {
+    const cache = await this.queryBalanceCache(owner_addr, isCore);
+
+    return (
+      cache || {
+        total_usd_value: 0,
+        evm_usd_value: 0,
+        chain_list: [],
+      }
+    );
+  }
+
+  static async queryBalanceCache(
+    owner_addr: string,
+    isCore: boolean,
+  ): Promise<EvmTotalBalanceResponse | null> {
     await prepareAppDataSource();
     const result = await this.getRepository().findOneBy({
       owner_addr,
       isCore,
     });
+
+    if (!result) {
+      return null;
+    }
 
     return {
       total_usd_value: result?.balance || 0,

--- a/apps/mobile/src/hooks/useAccountsBalance.ts
+++ b/apps/mobile/src/hooks/useAccountsBalance.ts
@@ -217,6 +217,12 @@ async function getMatteredAccountsSnapshot() {
   };
 }
 
+async function warmupSelectedAccountsBalance(selectedAccounts: Account[]) {
+  await balanceStore
+    .getState()
+    .hydrateCachedBalancesForAccounts(selectedAccounts);
+}
+
 export function startProcessAccountBalanceEvents() {
   perfEvents.subscribe('USER_MANUALLY_UNLOCK', async () => {
     syncBalanceAccountStore();
@@ -247,6 +253,7 @@ export function startProcessAccountBalanceEvents() {
   const syncSelectionFromAccounts = async () => {
     const { selectedAccounts, selectedAddresses, matteredAccountLength } =
       await getMatteredAccountsSnapshot();
+    await warmupSelectedAccountsBalance(selectedAccounts);
     const nextBalance = buildBalanceAccountsFromList(
       selectedAccounts,
       balanceStore.getState().balanceMap,

--- a/apps/mobile/src/hooks/useScene24hBalance.ts
+++ b/apps/mobile/src/hooks/useScene24hBalance.ts
@@ -20,6 +20,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { perfEvents } from '@/core/utils/perf';
 import { getTop10MyAccounts } from '@/core/apis/account';
 import { isEqual } from 'lodash';
+import balanceStore, { IBalanceData } from '@/store/balance';
 const queues: Record<BalanceScene, PQueue> = {
   Home: new PQueue({ intervalCap: 10, concurrency: 10, interval: 1000 }),
 };
@@ -57,6 +58,7 @@ const scene24hBalanceStore = zCreate<Multi24hBalanceState>(() => ({
     Home: computeCombined24hBalanceData({
       addresses: [],
       multi24hBalance: {},
+      balanceMap: {},
       totalEvmBalance: 0,
       totalBalance: 0,
     }),
@@ -161,6 +163,7 @@ function onComputedSceneCombinedData<T extends BalanceScene>(
   const combinedData = computeCombined24hBalanceData({
     addresses,
     multi24hBalance,
+    balanceMap: balanceStore.getState().balanceMap,
     totalEvmBalance: input.totalEvmBalance,
     totalBalance: input.totalBalance,
   });
@@ -248,24 +251,22 @@ const refreshCombinedDataForScene = makeSWRKeyAsyncFunc(
         sceneLastLoadingRef[scene] = Date.now();
       }
       setSceneLoading(scene, !!force);
-      beforeReturn();
       const nextCheckAddress = new Set([...address]);
       address.forEach(_addr => {
         const addr = _addr.toLowerCase();
         setSceneAddrLoading(scene, addr, true);
         const cacheData = getBalance24hCache(addr);
         const existedData = !!getMulti24hBalanceBy(addr);
-        if (!existedData && cacheData?.data)
+        const shouldHydrateFromCache =
+          !!cacheData?.data && (!existedData || !cacheData.isExpired);
+        if (shouldHydrateFromCache) {
           setMulti24hBalance(addr, {
             ...cacheData.data,
             updateTime: cacheData.updateTime,
           });
+        }
         if (cacheData?.data && !cacheData?.isExpired) {
           nextCheckAddress.delete(addr);
-          setMulti24hBalance(addr, {
-            ...cacheData.data,
-            updateTime: cacheData.updateTime,
-          });
         }
       });
       beforeReturn();
@@ -451,21 +452,37 @@ export function useScene24hBalanceLightWeightData(scene: BalanceScene) {
 function computeCombined24hBalanceData(input: {
   addresses: string[];
   multi24hBalance: Multi24hBalance;
+  balanceMap: Record<string, IBalanceData>;
   totalEvmBalance: number;
   totalBalance: number;
 }) {
-  const { addresses, multi24hBalance, totalEvmBalance, totalBalance } = input;
+  const {
+    addresses,
+    multi24hBalance,
+    balanceMap,
+    totalEvmBalance,
+    totalBalance,
+  } = input;
 
   const list = addresses.map(address => {
     const data = multi24hBalance[address.toLowerCase()];
     return data;
   });
-  const isAllGet = list.length === addresses.length;
+  const hasAll24hBalance = addresses.every(address => {
+    return !!multi24hBalance[address.toLowerCase()];
+  });
+  const hasAllCurrentBalance = addresses.every(address => {
+    return !!balanceMap[address.toLowerCase()];
+  });
+  const canShowChange =
+    addresses.length > 0 && hasAll24hBalance && hasAllCurrentBalance;
   const total24hBalance = list.reduce((res, item) => {
     return res + (item?.total_usd_value || 0);
   }, 0);
-  const assetsChange = (totalEvmBalance || 0) - total24hBalance;
-  const rawNetWorth = isAllGet ? totalBalance || 0 : 0;
+  const assetsChange = canShowChange
+    ? (totalEvmBalance || 0) - total24hBalance
+    : 0;
+  const rawNetWorth = canShowChange ? totalBalance || 0 : 0;
 
   return {
     list,
@@ -473,11 +490,12 @@ function computeCombined24hBalanceData(input: {
     netWorth: formatSmallUsdValue(totalBalance || 0),
     rawChange: assetsChange,
     change: `${formatUsdValue(Math.abs(assetsChange))}`,
-    changePercent:
-      total24hBalance !== 0
+    changePercent: canShowChange
+      ? total24hBalance !== 0
         ? `${Math.abs((assetsChange * 100) / total24hBalance).toFixed(2)}%`
-        : `${totalEvmBalance === 0 ? '0' : '100.00'}%`,
-    isLoss: assetsChange < 0,
+        : `${totalEvmBalance === 0 ? '0' : '100.00'}%`
+      : '',
+    isLoss: canShowChange ? assetsChange < 0 : false,
     isEmptyAssets: total24hBalance === 0 && totalEvmBalance === 0,
   };
 }

--- a/apps/mobile/src/screens/Address/components/MultiAssets/AddressList.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/AddressList.tsx
@@ -52,6 +52,7 @@ const AddressList = ({
     return myTop10Accounts
       .map(item => {
         const account = balanceMap[item.address.toLowerCase()];
+        const canShowChange = !!account;
 
         const balance = account?.totalBalance || item.balance || 0;
         const evmBalance = account?.evmBalance || item.evmBalance || 0;
@@ -66,8 +67,8 @@ const AddressList = ({
           ...item,
           balance,
           evmBalance,
-          changPercent: changeData ? changePercent : undefined,
-          isLoss: changeData ? assetsChange < 0 : undefined,
+          changPercent: changeData && canShowChange ? changePercent : undefined,
+          isLoss: changeData && canShowChange ? assetsChange < 0 : undefined,
         };
       })
       .sort((a, b) => b.balance - a.balance);

--- a/apps/mobile/src/screens/Address/components/MultiAssets/RenderRow/CurveChart.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/RenderRow/CurveChart.tsx
@@ -249,6 +249,9 @@ const ChartHeader = React.memo(
       const formatLoss = isActiveIndexData
         ? data?.[currentIndex.value]?.isLoss ?? isLoss
         : isLoss;
+      if (!formatChangePercent) {
+        return '';
+      }
       return `${formatLoss ? '-' : '+'}${formatChangePercent}(${
         formatLoss ? '-' : '+'
       }${formatChangeValue})`;

--- a/apps/mobile/src/screens/Home/components/MultiAddressHomeHeader.tsx
+++ b/apps/mobile/src/screens/Home/components/MultiAddressHomeHeader.tsx
@@ -52,6 +52,7 @@ import {
 import { apiGlobalModal } from '@/components2024/GlobalBottomSheetModal/apiGlobalModal';
 import balanceStore from '@/store/balance';
 import { RNGHTouchableOpacity } from '@/components/customized/reexports';
+import { computeBalanceChange } from '@/core/apis/balance';
 
 function MultiPinnedAddressList({
   pinnedAccountList,
@@ -71,21 +72,20 @@ function MultiPinnedAddressList({
         const lcAddr = item.address.toLowerCase();
         const address24hBalanceData = multi24hBalance[lcAddr];
         const balanceAccount = balanceMap?.[lcAddr];
+        const canShowChange = !!address24hBalanceData && !!balanceAccount;
         const total_usd_value = address24hBalanceData?.total_usd_value || 0;
-        const assetsChange =
-          (balanceAccount?.evmBalance || 0) - total_usd_value;
-        let changePercent =
-          total_usd_value !== 0
-            ? `${Math.abs((assetsChange * 100) / total_usd_value).toFixed(2)}%`
-            : `${balanceAccount?.evmBalance === 0 ? '0' : '100.00'}%`;
+        const { assetsChange, changePercent } = computeBalanceChange(
+          balanceAccount?.evmBalance || 0,
+          total_usd_value,
+        );
 
         return {
           ...item,
           updateTime: address24hBalanceData?.updateTime,
           balance: balanceAccount?.totalBalance || item.balance || 0,
           evmBalance: balanceAccount?.evmBalance || item.evmBalance || 0,
-          changePercent: address24hBalanceData ? changePercent : undefined,
-          isLoss: address24hBalanceData ? assetsChange < 0 : undefined,
+          changePercent: canShowChange ? changePercent : undefined,
+          isLoss: canShowChange ? assetsChange < 0 : undefined,
         };
       }),
       item => -(item.balance || 0),

--- a/apps/mobile/src/screens/Home/components/OverviewTopHeader.tsx
+++ b/apps/mobile/src/screens/Home/components/OverviewTopHeader.tsx
@@ -147,6 +147,9 @@ export function TabsTopHeader(): JSX.Element {
     return formatSmallCurrencyValue(totalBalance, { currency });
   }, [currency, totalBalance]);
   const changePercent = useMemo(() => {
+    if (!data.changePercent) {
+      return '';
+    }
     return `${data.isLoss ? '-' : '+'}${data.changePercent}`;
   }, [data.changePercent, data.isLoss]);
 
@@ -185,17 +188,19 @@ export function TabsTopHeader(): JSX.Element {
           style={styles.leftBox}
           onPress={() => handleSwitchToTokenTab(0)}>
           <Text style={styles.balanceTextBox}>{netWorth}</Text>
-          <Text
-            style={[
-              styles.changePercentText,
-              {
-                color: data.isLoss
-                  ? colors2024['red-default']
-                  : colors2024['green-default'],
-              },
-            ]}>
-            {changePercent}
-          </Text>
+          {changePercent ? (
+            <Text
+              style={[
+                styles.changePercentText,
+                {
+                  color: data.isLoss
+                    ? colors2024['red-default']
+                    : colors2024['green-default'],
+                },
+              ]}>
+              {changePercent}
+            </Text>
+          ) : null}
           {!SHOULD_SHOW_CUSTOM_INDICATOR_WHEN_LOADING &&
           isTop10BalanceLoading ? (
             <LoadingCircle />

--- a/apps/mobile/src/store/balance.ts
+++ b/apps/mobile/src/store/balance.ts
@@ -9,6 +9,7 @@ import { CORE_KEYRING_TYPES } from '@rabby-wallet/keyring-utils';
 import { ChainWithBalance } from '@rabby-wallet/rabby-api/dist/types';
 import PQueue from 'p-queue';
 import { useAppChainStore } from './appchain';
+import type { Account } from '@/core/services/preference';
 
 export interface CURVE_STEP_ITEM {
   timestamp: number;
@@ -25,6 +26,9 @@ interface BalanceState {
   chainUSDMap: Record<string, ChainWithBalance[]>;
   isLoadingByAddress: Record<string, boolean>;
   initStore(): void;
+  hydrateCachedBalancesForAccounts(
+    accounts: Array<Pick<Account, 'address' | 'type'>>,
+  ): Promise<void>;
   batchGetTotalBalance: (
     top10Addresses: string[],
     force?: boolean,
@@ -80,6 +84,69 @@ const balanceStore = zCreate<BalanceState>(set => ({
     }
     // 写入 Store
     set(() => ({ balanceMap, chainUSDMap }));
+  },
+
+  async hydrateCachedBalancesForAccounts(accounts) {
+    if (!accounts.length) {
+      return;
+    }
+
+    const lowerAddresses = Array.from(
+      new Set(accounts.map(item => item.address.toLowerCase())),
+    );
+    const currentBalanceMap = balanceStore.getState().balanceMap;
+    const hasAnyMissingBalance = lowerAddresses.some(address => {
+      return !currentBalanceMap[address];
+    });
+
+    if (!hasAnyMissingBalance) {
+      return;
+    }
+
+    const coreAddressSet = new Set(
+      accounts
+        .filter(item => CORE_KEYRING_TYPES.includes(item.type as any))
+        .map(item => item.address.toLowerCase()),
+    );
+
+    const cacheBalanceMap: Record<string, IBalanceData> = {};
+    const cacheChainUSDMap: Record<string, ChainWithBalance[]> = {};
+
+    for (const address of lowerAddresses) {
+      const cacheBalance = await BalanceEntity.queryBalanceCache(
+        address,
+        coreAddressSet.has(address),
+      );
+
+      if (!cacheBalance) {
+        continue;
+      }
+
+      const appChainUsdValue = useAppChainStore
+        .getState()
+        .getAppChainTotalUsdValue(address);
+
+      cacheBalanceMap[address] = {
+        evmBalance: cacheBalance.evm_usd_value || 0,
+        totalBalance: (cacheBalance.evm_usd_value || 0) + appChainUsdValue,
+      };
+      cacheChainUSDMap[address] = cacheBalance.chain_list;
+    }
+
+    if (!Object.keys(cacheBalanceMap).length) {
+      return;
+    }
+
+    set(state => ({
+      balanceMap: {
+        ...state.balanceMap,
+        ...cacheBalanceMap,
+      },
+      chainUSDMap: {
+        ...state.chainUSDMap,
+        ...cacheChainUSDMap,
+      },
+    }));
   },
 
   async batchGetTotalBalance(top10Addresses: string[], force = false) {


### PR DESCRIPTION
## Summary
- hydrate cached balances for home top10 accounts before selection-driven home updates
- keep home 24h change hidden until both current balances and 24h baselines are ready
- reuse cached 24h values first and unify change-percent calculation paths on home

## Testing
- lint-staged ran during commit
- targeted eslint checks for touched files
- manual device verification by user during iteration