### PR TITLE
build: reduce duplicate mobile postinstall work in CI

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -19,7 +19,7 @@
     "vbundle:android": "react-native-bundle-visualizer --platform=android --entry-file=./index.js",
     "vbundle:ios": "react-native-bundle-visualizer --platform=ios --entry-file=./index.js",
     "ensure-git-hooks": "yarn ../../ install-husky",
-    "postinstall": "yarn build:deps && yarn build-inpage",
+    "postinstall": "sh ./scripts/run-postinstall.sh",
     "ios": "react-native run-ios",
     "link-assets": "react-native-asset && sh ./scripts/fns.sh reset_builtin_assets && sh ./scripts/fns.sh build_worker_if_not_exist",
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",

--- a/apps/mobile/scripts/run-postinstall.sh
+++ b/apps/mobile/scripts/run-postinstall.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+if [ "$(uname -s)" != "Linux" ]; then
+  set -euo pipefail
+fi
+
+script_dir="$( cd "$( dirname "$0"  )" && pwd  )"
+project_dir=$(dirname "$script_dir")
+
+echo "Mobile postinstall:"
+
+if [ "${RABBY_MOBILE_SKIP_BUILD_DEPS:-0}" != "1" ]; then
+  echo "0. Build workspace deps..."
+  cd "$project_dir"
+  yarn build:deps
+else
+  echo "0. Skip workspace deps build (already built by caller)"
+fi
+
+echo "1. Build inpage bridge and bundle built-in pages..."
+cd "$project_dir"
+yarn build-inpage

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:watch": "yarn run build --watch",
     "changelog:validate": "yarn workspaces foreach --parallel --interlaced --verbose run changelog:validate",
     "child-workspace-package-names-as-json": "ts-node scripts/child-workspace-package-names-as-json.ts",
-    "postinstall": "yarn build && yarn apps/mobile postinstall",
+    "postinstall": "yarn build && RABBY_MOBILE_SKIP_BUILD_DEPS=1 yarn apps/mobile postinstall",
     "install-husky": "husky install",
     "typecheck": "yarn workspace rabby-mobile typecheck",
     "lint": "yarn lint:eslint && yarn lint:misc --check && yarn constraints",


### PR DESCRIPTION
## Summary
- avoid rebuilding workspace deps twice during the root install -> mobile postinstall chain
- route mobile postinstall through a dedicated script that preserves standalone behavior
- keep current inpage and built-in page generation behavior intact while removing duplicate work
