### PR TITLE
refactor(mobile): consolidate send success refresh events

### DIFF
--- a/apps/mobile/src/screens/Send/Send.tsx
+++ b/apps/mobile/src/screens/Send/Send.tsx
@@ -26,7 +26,6 @@ import {
   getSendChainToken,
   SendTokenEvents,
   SendTokenInternalContextProvider,
-  subscribeEvent,
   useSendTokenForm,
   useSendTokenInternalContext,
   useSendTokenScreenChainToken,
@@ -100,7 +99,6 @@ import Animated, {
   useSharedValue,
 } from 'react-native-reanimated';
 import { DirectSignBtnMethods } from '@/components2024/DirectSignBtn';
-import { eventBus, EventBusListeners, EVENTS } from '@/utils/events';
 
 const AnimatedKeyboardAwareScrollView = Animated.createAnimatedComponent(
   KeyboardAwareScrollView,
@@ -253,11 +251,11 @@ function SendScreen({
 
     checkCexSupport,
     loadCurrentToken,
+    refreshCurrentTokenBalance,
     handleCurrentTokenChange,
 
     directSignBtnRef,
     formValuesRef,
-    resetAfterSignedSuccess,
 
     whitelistEnabled,
     computed: {
@@ -444,37 +442,6 @@ function SendScreen({
     navParams?.toAddress,
   ]);
 
-  const refreshCurrentTokenBalance = useCallback(async () => {
-    if (!currentAccount?.address) {
-      return;
-    }
-
-    apiSendToken.putScreenState({
-      balanceError: null,
-      balanceWarn: null,
-    });
-    apiSendToken.markBalanceLoading({
-      tokenId: currentToken.id,
-      chainId: currentToken.chain,
-      currentAddress: currentAccount.address,
-    });
-
-    try {
-      await loadCurrentToken(
-        currentToken.id,
-        currentToken.chain,
-        currentAccount.address,
-      );
-    } catch (error) {
-      console.error('SendScreen refresh current token error', error);
-    }
-  }, [
-    currentAccount?.address,
-    currentToken.chain,
-    currentToken.id,
-    loadCurrentToken,
-  ]);
-
   useEffect(() => {
     (async () => {
       if (!initByCacheFinishedRef.current) return;
@@ -498,49 +465,6 @@ function SendScreen({
   }, [currentAccount, navigation]);
 
   const { fetchContactAccounts } = useContactAccounts();
-
-  useEffect(() => {
-    const disposeRets = [] as Function[];
-    subscribeEvent(
-      sendTokenEvents,
-      SendTokenEvents.ON_SIGNED_SUCCESS,
-      () => {
-        resetAfterSignedSuccess();
-        refreshCurrentTokenBalance();
-        // navigation.dispatch(
-        //   StackActions.replace(RootNames.StackRoot, {
-        //     screen: RootNames.Home,
-        //   }),
-        // );
-      },
-      { disposeRets },
-    );
-
-    return () => {
-      disposeRets.forEach(dispose => dispose());
-    };
-  }, [refreshCurrentTokenBalance, resetAfterSignedSuccess, sendTokenEvents]);
-
-  useEffect(() => {
-    const onTxCompleted: EventBusListeners[typeof EVENTS.TX_COMPLETED] =
-      txDetail => {
-        if (!currentAccount?.address) {
-          return;
-        }
-
-        if (!lowcaseSame(txDetail.address, currentAccount.address)) {
-          return;
-        }
-
-        refreshCurrentTokenBalance();
-      };
-
-    eventBus.addListener(EVENTS.TX_COMPLETED, onTxCompleted);
-
-    return () => {
-      eventBus.removeListener(EVENTS.TX_COMPLETED, onTxCompleted);
-    };
-  }, [currentAccount?.address, refreshCurrentTokenBalance]);
 
   useLayoutEffect(() => {
     return () => {

--- a/apps/mobile/src/screens/Send/Send.tsx
+++ b/apps/mobile/src/screens/Send/Send.tsx
@@ -516,7 +516,7 @@ function SendScreen({
           currentToken,
           currentTokenBalance: balanceNumText,
         },
-        events: sendTokenEvents,
+        sendTokenEvents,
         formik,
         slider,
         fns: {

--- a/apps/mobile/src/screens/Send/components/BottomArea.tsx
+++ b/apps/mobile/src/screens/Send/components/BottomArea.tsx
@@ -54,7 +54,7 @@ export default function BottomArea({ account }: { account: Account | null }) {
     },
     directSignBtnRef,
     formValuesRef,
-    events,
+    sendTokenEvents,
     callbacks: {
       handleIgnoreGasFeeChange,
       onBottomAreaLayout,
@@ -120,7 +120,7 @@ export default function BottomArea({ account }: { account: Account | null }) {
   useEffect(() => {
     const disposeRets = [] as Function[];
     subscribeEvent(
-      events,
+      sendTokenEvents,
       SendTokenEvents.ON_SIGNED_SUCCESS,
       () => {
         fetchRisks();
@@ -134,7 +134,7 @@ export default function BottomArea({ account }: { account: Account | null }) {
     return () => {
       disposeRets.forEach(dispose => dispose());
     };
-  }, [events, fetchRisks]);
+  }, [fetchRisks, sendTokenEvents]);
 
   const { mostImportantRisks, hasRiskForToAddress, hasRiskForToken } =
     React.useMemo(() => {

--- a/apps/mobile/src/screens/Send/components/BottomArea.tsx
+++ b/apps/mobile/src/screens/Send/components/BottomArea.tsx
@@ -27,7 +27,6 @@ import {
 } from '@/components2024/DirectSignBtn';
 import { Account } from '@/core/services/preference';
 import { RiskType, sortRisksDesc, useRisks } from '@/components/SendLike/risk';
-import { eventBus, EventBusListeners, EVENTS } from '@/utils/events';
 import { useSignatureStore } from '@/components2024/MiniSignV2';
 import { BottomRiskTip } from '@/components/SendLike/BottomRiskTip';
 import { resolveBgColorByType } from '@/components2024/ScreenContainer/LinearGradientContainer';
@@ -55,6 +54,7 @@ export default function BottomArea({ account }: { account: Account | null }) {
     },
     directSignBtnRef,
     formValuesRef,
+    events,
     callbacks: {
       handleIgnoreGasFeeChange,
       onBottomAreaLayout,
@@ -118,19 +118,23 @@ export default function BottomArea({ account }: { account: Account | null }) {
   });
 
   useEffect(() => {
-    const onTxCompleted: EventBusListeners[typeof EVENTS.TX_COMPLETED] =
-      txDetail => {
+    const disposeRets = [] as Function[];
+    subscribeEvent(
+      events,
+      SendTokenEvents.ON_SIGNED_SUCCESS,
+      () => {
         fetchRisks();
         setTimeout(() => {
           fetchRisks();
         }, 5000);
-      };
-    eventBus.addListener(EVENTS.TX_COMPLETED, onTxCompleted);
+      },
+      { disposeRets },
+    );
 
     return () => {
-      eventBus.removeListener(EVENTS.TX_COMPLETED, onTxCompleted);
+      disposeRets.forEach(dispose => dispose());
     };
-  }, [fetchRisks]);
+  }, [events, fetchRisks]);
 
   const { mostImportantRisks, hasRiskForToAddress, hasRiskForToken } =
     React.useMemo(() => {

--- a/apps/mobile/src/screens/Send/hooks/useSendToken.ts
+++ b/apps/mobile/src/screens/Send/hooks/useSendToken.ts
@@ -2187,7 +2187,7 @@ type InternalContext = {
   };
 
   formik: ReturnType<typeof useSendTokenFormikContext>;
-  events: EventEmitter;
+  sendTokenEvents: EventEmitter;
   slider: number;
   fns: {
     // putScreenState: (
@@ -2243,7 +2243,7 @@ const SendTokenInternalContext = React.createContext<InternalContext>({
   },
 
   formik: null as any,
-  events: null as any,
+  sendTokenEvents: null as any,
   slider: 0,
   fns: {
     // putScreenState: () => { },
@@ -2300,11 +2300,11 @@ export function subscribeEvent<T extends SendTokenEvents>(
 export function useInputBlurOnEvents(
   inputRef: React.RefObject<TextInput | null>,
 ) {
-  const { events } = useSendTokenInternalContext();
+  const { sendTokenEvents } = useSendTokenInternalContext();
   useEffect(() => {
     const disposeRets = [] as Function[];
     subscribeEvent(
-      events,
+      sendTokenEvents,
       SendTokenEvents.ON_PRESS_DISMISS,
       () => {
         inputRef.current?.blur();
@@ -2313,7 +2313,7 @@ export function useInputBlurOnEvents(
     );
 
     subscribeEvent(
-      events,
+      sendTokenEvents,
       SendTokenEvents.ON_SEND,
       () => {
         inputRef.current?.blur();
@@ -2324,5 +2324,5 @@ export function useInputBlurOnEvents(
     return () => {
       disposeRets.forEach(dispose => dispose());
     };
-  }, [events, inputRef]);
+  }, [sendTokenEvents, inputRef]);
 }

--- a/apps/mobile/src/screens/Send/hooks/useSendToken.ts
+++ b/apps/mobile/src/screens/Send/hooks/useSendToken.ts
@@ -59,11 +59,7 @@ import useAsyncFn from 'react-use/lib/useAsyncFn';
 import { useSwitchSceneAccountOnSelectedTokenWithOwner } from '@/databases/hooks/token';
 import { naviReplace } from '@/utils/navigation';
 import { RootNames } from '@/constant/layout';
-import {
-  useFocusEffect,
-  useIsFocused,
-  useRoute,
-} from '@react-navigation/native';
+import { useIsFocused, useRoute } from '@react-navigation/native';
 import { sendScreenParamsAtom } from '@/hooks/useSendRoutes';
 import { ITokenCheck } from '@/components/Token/TokenSelectorSheetModal';
 import {
@@ -71,7 +67,6 @@ import {
   makeAccountObject,
 } from '@/utils/account';
 import { usePollSendPendingCount } from './useSendPendingCount';
-import { eventBus, EventBusListeners, EVENTS } from '@/utils/events';
 import { useMemoizedFn } from 'ahooks';
 import {
   useRecentSendToHistoryFor,
@@ -1860,17 +1855,21 @@ export function useSendTokenForm({
     useRecentSendToHistoryFor(formValues.to);
 
   useEffect(() => {
-    const onTxCompleted: EventBusListeners[typeof EVENTS.TX_COMPLETED] =
-      txDetail => {
+    const disposeRets = [] as Function[];
+    subscribeEvent(
+      sendTokenEventsRef.current,
+      SendTokenEvents.ON_SIGNED_SUCCESS,
+      () => {
         reFetch();
         setTimeout(() => {
           reFetch();
         }, 5000);
-      };
-    eventBus.addListener(EVENTS.TX_COMPLETED, onTxCompleted);
+      },
+      { disposeRets },
+    );
 
     return () => {
-      eventBus.removeListener(EVENTS.TX_COMPLETED, onTxCompleted);
+      disposeRets.forEach(dispose => dispose());
     };
   }, [reFetch]);
 
@@ -1945,12 +1944,30 @@ export function useSendTokenForm({
     formik.resetForm();
   }, [setFormValues, formik]);
 
-  const refreshCurrentToken = useMemoizedFn(async () => {
-    return loadCurrentToken(
-      currentToken.id,
-      currentToken.chain,
-      currentAccount!.address,
-    );
+  const refreshCurrentTokenBalance = useMemoizedFn(async () => {
+    if (!currentAccount?.address) {
+      return;
+    }
+
+    putScreenState({
+      balanceError: null,
+      balanceWarn: null,
+    });
+    markBalanceLoading({
+      tokenId: currentToken.id,
+      chainId: currentToken.chain,
+      currentAddress: currentAccount.address,
+    });
+
+    try {
+      await loadCurrentToken(
+        currentToken.id,
+        currentToken.chain,
+        currentAccount.address,
+      );
+    } catch (error) {
+      console.error('SendScreen refresh current token error', error);
+    }
   });
 
   const prepareRef = useRef<Promise<Tx | void>>(undefined);
@@ -1999,6 +2016,23 @@ export function useSendTokenForm({
     handleFormValuesChange,
     formik.values,
   ]);
+
+  useEffect(() => {
+    const disposeRets = [] as Function[];
+    subscribeEvent(
+      sendTokenEventsRef.current,
+      SendTokenEvents.ON_SIGNED_SUCCESS,
+      () => {
+        resetAfterSignedSuccess();
+        refreshCurrentTokenBalance();
+      },
+      { disposeRets },
+    );
+
+    return () => {
+      disposeRets.forEach(dispose => dispose());
+    };
+  }, [refreshCurrentTokenBalance, resetAfterSignedSuccess]);
 
   const isFocused = useIsFocused();
 
@@ -2051,15 +2085,6 @@ export function useSendTokenForm({
     prepareDirectSubmitMiniTx,
   ]);
 
-  useFocusEffect(
-    useCallback(() => {
-      eventBus.addListener(EVENTS.RELOAD_TX, refreshCurrentToken);
-      return () => {
-        eventBus.removeListener(EVENTS.RELOAD_TX, refreshCurrentToken);
-      };
-    }, [refreshCurrentToken]),
-  );
-
   const svBottomAreaHeight = useSharedValue(220);
   useAnimatedReaction(
     () => {
@@ -2092,6 +2117,7 @@ export function useSendTokenForm({
 
     currentToken,
     loadCurrentToken,
+    refreshCurrentTokenBalance,
     checkCexSupport,
     handleCurrentTokenChange,
 
@@ -2114,7 +2140,6 @@ export function useSendTokenForm({
     formik,
     formValues,
     resetFormValues,
-    resetAfterSignedSuccess,
     handleFieldChange,
     patchFormValues,
     handleFormValuesChange,


### PR DESCRIPTION
## Summary
- consolidate Send screen post-sign refresh flows onto `SendTokenEvents.ON_SIGNED_SUCCESS`
- remove duplicated `EVENTS.TX_COMPLETED` and `EVENTS.RELOAD_TX` listeners from the Send screen stack
- keep the immediate refresh plus delayed follow-up refresh for token balance, recent send history, and risk checks

## Testing
- yarn typecheck