### PR TITLE
feat(mobile): extend app log archive workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,8 @@ preview-build-message.txt
 .cursor/
 .claude/*.local.*
 .claude/worktrees
-docs
+docs/*
+!docs/mobile-app-log-format.md
 CLAUDE*.local.md
 
 # codex

--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -111,9 +111,4 @@ module.exports = {
     ['@babel/plugin-transform-class-static-block'],
     ['react-native-reanimated/plugin'],
   ],
-  env: {
-    production: {
-      plugins: ['transform-remove-console'],
-    },
-  },
 };

--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -17,6 +17,7 @@ if (!__DEV__) {
   initSentry();
 }
 
+import './src/utils/logging/install';
 import './global';
 import './src/setup-app';
 if (__DEV__) {

--- a/apps/mobile/ios/RabbyMobile.xcodeproj/project.pbxproj
+++ b/apps/mobile/ios/RabbyMobile.xcodeproj/project.pbxproj
@@ -587,7 +587,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > \"${SRCROOT}/../node_modules/react-native/scripts/.packager.env\"\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open \"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi\n";
+			shellScript = "export RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\nexport NO_PROXY=\"127.0.0.1,localhost,::1${NO_PROXY:+,$NO_PROXY}\"\nexport no_proxy=\"$NO_PROXY\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > \"${SRCROOT}/../node_modules/react-native/scripts/.packager.env\"\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z 127.0.0.1 ${RCT_METRO_PORT} ; then\n    if ! curl --noproxy '*' -s \"http://127.0.0.1:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open \"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/apps/mobile/ios/patches/phase-bundle-rn.sh
+++ b/apps/mobile/ios/patches/phase-bundle-rn.sh
@@ -88,8 +88,8 @@ check_env_file() {
 check_env_file;
 
 if [ "$CONFIGURATION" == "Debug" ] && [ "$IOS_SKIP_METRO_BUNDLE_ON_DEBUG" == "true" ]; then
-  echo "[RabbyMobileBuild] skip metro bundle on debug build as IOS_SKIP_METRO_BUNDLE_ON_DEBUG is true"
-  exit 0;
+  echo "[RabbyMobileBuild] skip debug bundle while preserving Metro device setup"
+  export SKIP_BUNDLING=1
 fi
 
 [ -f yarn ] && yarn install --immutable;

--- a/apps/mobile/src/core/config/online.ts
+++ b/apps/mobile/src/core/config/online.ts
@@ -1,8 +1,8 @@
 import { isNonPublicProductionEnv } from '@/constant';
 import axios from 'axios';
-import { Platform } from 'react-native';
 import { merge } from 'lodash';
 import { stringUtils } from '@rabby-wallet/base-utils';
+import { APP_FILE_LOGGING_ONLINE_SWITCH } from '@/utils/logging/policy';
 
 function sleep(ms = 0) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -23,6 +23,7 @@ type OnlineConfig = {
     ['20260105.disable_db_prepared_upsert']?: boolean;
     ['20260116.allow_short_auto_lock_time_on_bootstrap']?: boolean;
     ['20260122.enable_db_prepared_upsert']?: boolean;
+    [APP_FILE_LOGGING_ONLINE_SWITCH]?: boolean;
   };
 };
 
@@ -35,11 +36,17 @@ function getDefaultOnlineConfig(): OnlineConfig {
       '20260105.disable_db_prepared_upsert': false,
       '20260116.allow_short_auto_lock_time_on_bootstrap': false,
       '20260122.enable_db_prepared_upsert': false,
+      [APP_FILE_LOGGING_ONLINE_SWITCH]: false,
     },
   };
 }
 
 const configRef = { current: getDefaultOnlineConfig() };
+const listeners = new Set<() => void>();
+
+function notifyOnlineConfigUpdated() {
+  listeners.forEach(listener => listener());
+}
 
 export async function fetchConfigOnBootstrap() {
   // Fetch the configuration from the appropriate URL
@@ -50,6 +57,7 @@ export async function fetchConfigOnBootstrap() {
       : response.data;
 
   configRef.current = merge(configRef.current, json);
+  notifyOnlineConfigUpdated();
 
   return json as Partial<OnlineConfig> | undefined;
 }
@@ -73,6 +81,14 @@ export function startSyncOnlineConfig() {
 
 export function getOnlineConfig() {
   return configRef.current;
+}
+
+export function subscribeOnlineConfig(listener: () => void) {
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
 }
 
 export async function getLatestOnlineConfig() {

--- a/apps/mobile/src/core/notifications/openapi.ts
+++ b/apps/mobile/src/core/notifications/openapi.ts
@@ -1,5 +1,5 @@
 import { OpenApiService } from '@rabby-wallet/rabby-api';
-import { OpenApiStore, openApiStore } from '../services/openapiStore';
+import { OpenApiStore } from '../services/openapiStore';
 import { SignApiPlugin } from '../request';
 import {
   APP_VERSIONS,
@@ -8,12 +8,10 @@ import {
   isNonPublicProductionEnv,
 } from '@/constant';
 import { APP_STORE_NAMES } from '../storage/storeConstant';
-import { ensureDeviceUUID, makeDeviceUUID } from '../apis/device';
-import {
-  TxAllHistoryResult,
-  TxHistoryResult,
-} from '@rabby-wallet/rabby-api/dist/types';
+import { makeDeviceUUID } from '../apis/device';
+import { TxHistoryResult } from '@rabby-wallet/rabby-api/dist/types';
 import { AppState } from 'react-native';
+import { instrumentOpenApiFailureLogging } from '@/utils/openapiFailureLogging';
 
 export type DeviceActiveStatusResponse = {
   success: boolean;
@@ -34,8 +32,6 @@ export type BindDeviceResponse = {
   added: number;
   removed: number;
 };
-
-type NotifiAppState = 'foreground' | 'background';
 
 class NotificationsOpenApiService extends OpenApiService {
   #getDeviceUUID() {
@@ -112,3 +108,4 @@ export const notificationOpenapi = new NotificationsOpenApiService({
 });
 
 notificationOpenapi.initSync();
+instrumentOpenApiFailureLogging(notificationOpenapi, 'notificationOpenapi');

--- a/apps/mobile/src/core/request.ts
+++ b/apps/mobile/src/core/request.ts
@@ -2,9 +2,9 @@ import { OpenApiService } from '@rabby-wallet/rabby-api';
 import { RabbyApiPlugin } from '@rabby-wallet/rabby-api/dist/plugins/intf';
 
 import { gS } from '@rabby-wallet/rabby-sign-bvm/es/sign-rabby';
-import { APP_VERSIONS, INITIAL_OPENAPI_URL } from '@/constant';
-import { isNonPublicProductionEnv } from '@/constant';
+import { APP_VERSIONS } from '@/constant';
 import { openApiStore } from './services/openapiStore';
+import { instrumentOpenApiFailureLogging } from '@/utils/openapiFailureLogging';
 
 const SIGN_HDS = [
   'x-api-ts',
@@ -34,6 +34,7 @@ export const openapi = new OpenApiService({
   clientVersion: APP_VERSIONS.fromJs,
 });
 openapi.initSync();
+instrumentOpenApiFailureLogging(openapi, 'openapi');
 
 // TODO: REMOVE ME
 export const testOpenapi = new OpenApiService({
@@ -49,6 +50,7 @@ export const testOpenapi = new OpenApiService({
   clientVersion: APP_VERSIONS.fromJs,
 });
 testOpenapi.initSync();
+instrumentOpenApiFailureLogging(testOpenapi, 'testOpenapi');
 
 export async function getOpenApiService(
   type: 'mainnet' | 'testnet' = 'mainnet',

--- a/apps/mobile/src/databases/logger.ts
+++ b/apps/mobile/src/databases/logger.ts
@@ -13,6 +13,7 @@ import {
 import { getOnlineConfig } from '@/core/config/online';
 import { type ReactotronReactNative } from 'reactotron-react-native';
 import { tryGetReadyTron } from '@/core/utils/reactotron-plugins/_utils';
+import { logger } from '@/utils/logger';
 
 // slice query string, [0...500] + [-500...end]
 function formatQueryString(query: string, len = 500): string {
@@ -285,6 +286,12 @@ export class RabbyOrmDeployedConsoleLogger
     parameters?: any[],
     queryRunner?: QueryRunner,
   ): void {
+    logger.warn('[TypeORM] slow query detected', {
+      time,
+      query: formatQueryString(query, 1000),
+      parameters: logger.mask(parameters),
+      database: queryRunner?.manager.connection.options.database,
+    });
     this.#sentryReport(time, query, parameters, queryRunner);
   }
 }

--- a/apps/mobile/src/screens/Navigators/TestkitsNavigator.tsx
+++ b/apps/mobile/src/screens/Navigators/TestkitsNavigator.tsx
@@ -196,6 +196,7 @@ export function TestkitsNavigator() {
         component={DebugLogViewer}
         options={{
           headerShown: true,
+          title: 'App Log Verification',
         }}
       />
     </Stack.Navigator>

--- a/apps/mobile/src/screens/Settings/Settings.tsx
+++ b/apps/mobile/src/screens/Settings/Settings.tsx
@@ -802,7 +802,7 @@ function DevSettingsBlocks() {
               },
             },
             {
-              label: 'Debug Logs Viewer',
+              label: 'App Log Verification',
               icon: RcCode,
               onPress: () => {
                 navigation.dispatch(

--- a/apps/mobile/src/screens/Testkits/DebugLogViewer.tsx
+++ b/apps/mobile/src/screens/Testkits/DebugLogViewer.tsx
@@ -1,252 +1,1289 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { Buffer } from '@craftzdog/react-native-buffer';
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
+  Platform,
   ScrollView,
-  View,
+  Share,
   TouchableOpacity,
-  Clipboard,
-  Alert,
-  Button,
-  Pressable,
+  View,
 } from 'react-native';
-import { useTheme2024 } from '@/hooks/theme';
-import { createGetStyles2024 } from '@/utils/styles';
-import NormalScreenContainer from '@/components/ScreenContainer/NormalScreenContainer';
-import { debugLogService } from '@/core/services';
-import type { DebugLogEntry } from '@/core/services/debugLogService';
-import { toast } from '@/components2024/Toast';
+import RNFS from 'react-native-fs';
 import dayjs from 'dayjs';
+import { strFromU8, unzipSync } from 'fflate';
+import NormalScreenContainer from '@/components/ScreenContainer/NormalScreenContainer';
+import {
+  AppBottomSheetModal,
+  AppBottomSheetModalTitle,
+} from '@/components/customized/BottomSheet';
+import { AppSwitch2024 } from '@/components/customized/Switch2024';
 import { Text } from '@/components/Typography';
+import { Button } from '@/components2024/Button';
+import { makeBottomSheetProps } from '@/components2024/GlobalBottomSheetModal/utils-help';
+import { toast } from '@/components2024/Toast';
+import { APP_RUNTIME_ENV } from '@/constant/env';
+import { getOnlineConfig, subscribeOnlineConfig } from '@/core/config/online';
+import { useTheme2024 } from '@/hooks/theme';
+import { APP_FILE_LOGGING_ONLINE_SWITCH } from '@/utils/logging/policy';
+import {
+  subscribeAppLogFileSettings,
+  useAppLogFileSwitch,
+} from '@/utils/logging/settings';
+import { APP_LOG_ROOT_PATH, logger } from '@/utils/logger';
+import { createGetStyles2024 } from '@/utils/styles';
 
-const LOG_LEVEL_COLORS = {
-  info: '#3B82F6',
-  warn: '#F59E0B',
-  error: '#EF4444',
-  debug: '#8B5CF6',
+type LoggerSnapshot = ReturnType<typeof logger.getState>;
+
+type ArchiveFileItem = {
+  name: string;
+  path: string;
+  size: number;
+  kind: 'zip' | 'partial' | 'other';
+  createdAt: string | null;
+  modifiedAt: string | null;
 };
 
-function LogEntryView({ entry }: { entry: DebugLogEntry }) {
-  const { styles, colors2024 } = useTheme2024({ getStyle: getStyles });
+type ZipValidationResult = {
+  archiveName: string;
+  archivePath: string;
+  checkedAt: string;
+  entryCount: number;
+  totalBytes: number;
+  entryNames: string[];
+  firstEntryPath: string | null;
+  firstLinePreview: string | null;
+};
 
-  const levelColor = LOG_LEVEL_COLORS[entry.level];
-  const timeStr = dayjs(entry.timestamp).format('HH:mm:ss.SSS');
+type PageSnapshot = {
+  loggerState: LoggerSnapshot;
+  rootExists: boolean;
+  files: ArchiveFileItem[];
+  prodOnlineEnabled: boolean;
+  refreshedAt: string;
+};
+
+const BURST_LINE_COUNT = 10;
+const BURST_LINE_SIZE = 120 * 1024;
+
+function noop() {}
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function formatBytes(bytes: number) {
+  if (!bytes) {
+    return '0 B';
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let value = bytes;
+  let unitIndex = 0;
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${
+    value >= 10 || unitIndex === 0 ? value.toFixed(0) : value.toFixed(1)
+  } ${units[unitIndex]}`;
+}
+
+function formatDateTime(value?: string | number | Date | null) {
+  if (!value) {
+    return 'n/a';
+  }
+
+  const nextValue = dayjs(value);
+  return nextValue.isValid() ? nextValue.format('YYYY-MM-DD HH:mm:ss') : 'n/a';
+}
+
+function formatArchiveTimeRange(
+  file: Pick<ArchiveFileItem, 'createdAt' | 'modifiedAt'>,
+) {
+  const startAt = file.createdAt || file.modifiedAt;
+  const endAt = file.modifiedAt || file.createdAt;
+
+  if (!startAt && !endAt) {
+    return 'n/a';
+  }
+
+  return `${formatDateTime(startAt)} -> ${formatDateTime(endAt)}`;
+}
+
+function getFileKind(name: string): ArchiveFileItem['kind'] {
+  if (name.endsWith('.zip.partial')) {
+    return 'partial';
+  }
+
+  if (name.endsWith('.zip')) {
+    return 'zip';
+  }
+
+  return 'other';
+}
+
+async function listArchiveFiles() {
+  const exists = await RNFS.exists(APP_LOG_ROOT_PATH);
+  if (!exists) {
+    return {
+      exists,
+      files: [] as ArchiveFileItem[],
+    };
+  }
+
+  const entries = await RNFS.readDir(APP_LOG_ROOT_PATH);
+  const files = entries
+    .filter(item => item.isFile())
+    .map(item => ({
+      name: item.name,
+      path: item.path,
+      size: item.size,
+      kind: getFileKind(item.name),
+      createdAt: item.ctime ? item.ctime.toISOString() : null,
+      modifiedAt: item.mtime ? item.mtime.toISOString() : null,
+    }))
+    .sort((left, right) => {
+      const rightTs = right.modifiedAt ? dayjs(right.modifiedAt).valueOf() : 0;
+      const leftTs = left.modifiedAt ? dayjs(left.modifiedAt).valueOf() : 0;
+
+      if (rightTs !== leftTs) {
+        return rightTs - leftTs;
+      }
+
+      return right.name.localeCompare(left.name);
+    });
+
+  return {
+    exists,
+    files,
+  };
+}
+
+async function validateArchiveFile(file: ArchiveFileItem) {
+  const base64 = await RNFS.readFile(file.path, 'base64');
+  const archive = unzipSync(Uint8Array.from(Buffer.from(base64, 'base64')));
+  const entryNames = Object.keys(archive).sort((left, right) =>
+    left.localeCompare(right),
+  );
+  const firstEntryPath = entryNames[0] || null;
+  const firstLinePreview = firstEntryPath
+    ? strFromU8(archive[firstEntryPath] || new Uint8Array())
+        .split('\n')[0]
+        ?.slice(0, 180) || null
+    : null;
+  const totalBytes = Object.values(archive).reduce(
+    (sum, chunk) => sum + chunk.byteLength,
+    0,
+  );
+
+  return {
+    archiveName: file.name,
+    archivePath: file.path,
+    checkedAt: new Date().toISOString(),
+    entryCount: entryNames.length,
+    totalBytes,
+    entryNames,
+    firstEntryPath,
+    firstLinePreview,
+  } satisfies ZipValidationResult;
+}
+
+async function writeSampleLogs() {
+  const requestId = `verify-${Date.now()}`;
+  const timerLabel = `app-log-verification:${requestId}`;
+
+  console.log('[app-log-verification] console log sample', {
+    requestId,
+    accessToken: logger.mask('sample-access-token'),
+    nested: {
+      privateKey: logger.mask('sample-private-key'),
+    },
+  });
+  console.warn('[app-log-verification] console warn sample', {
+    requestId,
+    subsystem: 'zip-writer',
+  });
+  logger.info('[app-log-verification] logger info sample', {
+    requestId,
+    endpoint: '/api/log-test',
+    responseCode: 200,
+  });
+  logger.error('[app-log-verification] logger error sample', {
+    requestId,
+    retryable: false,
+  });
+  console.time(timerLabel);
+  await sleep(32);
+  console.timeLog(timerLabel, 'sample midpoint');
+  await sleep(16);
+  console.timeEnd(timerLabel);
+
+  await logger.flush();
+}
+
+async function writeRotationBurst() {
+  logger.info('[app-log-verification] rotation burst start', {
+    lines: BURST_LINE_COUNT,
+    approxBytes: BURST_LINE_COUNT * BURST_LINE_SIZE,
+  });
+
+  for (let index = 0; index < BURST_LINE_COUNT; index += 1) {
+    const filler = `burst-${index}`.padEnd(BURST_LINE_SIZE, String(index % 10));
+
+    logger.info('[app-log-verification] rotation burst line', {
+      index,
+      filler,
+    });
+
+    if (index > 0 && index % 3 === 0) {
+      await sleep(0);
+    }
+  }
+
+  logger.info('[app-log-verification] rotation burst end');
+  await logger.flush();
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: React.PropsWithChildren<{
+  title: string;
+  description?: string;
+}>) {
+  const { styles } = useTheme2024({ getStyle: getStyles });
 
   return (
-    <View style={styles.logEntry}>
-      <View style={styles.logHeader}>
-        <Text
-          style={[
-            styles.logLevel,
-            { backgroundColor: levelColor + '20', color: levelColor },
-          ]}>
-          {entry.level.toUpperCase()}
-        </Text>
-        <Text style={styles.logTime}>{timeStr}</Text>
-      </View>
-      <Text style={styles.logMessage}>{entry.message}</Text>
-      {entry.data !== undefined && entry.data !== null ? (
-        <Text style={styles.logData}>
-          {typeof entry.data === 'string'
-            ? entry.data
-            : JSON.stringify(entry.data, null, 2)}
-        </Text>
+    <View style={styles.sectionCard}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      {description ? (
+        <Text style={styles.sectionDescription}>{description}</Text>
       ) : null}
+      {children}
+    </View>
+  );
+}
+
+function MetaRow({
+  label,
+  value,
+  tone = 'default',
+}: {
+  label: string;
+  value: string;
+  tone?: 'default' | 'success' | 'warning';
+}) {
+  const { styles, colors2024 } = useTheme2024({ getStyle: getStyles });
+  const valueColor =
+    tone === 'success'
+      ? colors2024['green-default']
+      : tone === 'warning'
+      ? colors2024['orange-default']
+      : colors2024['neutral-title-1'];
+
+  return (
+    <View style={styles.metaRow}>
+      <Text style={styles.metaLabel}>{label}</Text>
+      <Text
+        style={[styles.metaValue, { color: valueColor }]}
+        selectable
+        numberOfLines={2}
+        ellipsizeMode="middle">
+        {value}
+      </Text>
     </View>
   );
 }
 
 export default function DebugLogViewerScreen(): JSX.Element {
   const { styles, colors2024 } = useTheme2024({ getStyle: getStyles });
-  const [logs, setLogs] = useState<DebugLogEntry[]>([]);
+  const {
+    canToggle,
+    consoleCaptureEnabled,
+    effectiveEnabled,
+    isOnlineControlled,
+    localDefaultEnabled,
+    localFileLoggingEnabled,
+    onToggle,
+  } = useAppLogFileSwitch();
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [isArchiveSharePickerVisible, setIsArchiveSharePickerVisible] =
+    useState(false);
+  const [lastAction, setLastAction] = useState('Idle');
+  const [validationResult, setValidationResult] =
+    useState<ZipValidationResult | null>(null);
+  const archiveSharePickerRef = useRef<AppBottomSheetModal>(null);
+  const canShareArchive = APP_RUNTIME_ENV !== 'production';
+  const [snapshot, setSnapshot] = useState<PageSnapshot>(() => ({
+    loggerState: logger.getState(),
+    rootExists: false,
+    files: [],
+    prodOnlineEnabled:
+      !!getOnlineConfig()?.switches?.[APP_FILE_LOGGING_ONLINE_SWITCH],
+    refreshedAt: new Date().toISOString(),
+  }));
 
-  const refreshLogs = useCallback(() => {
-    setLogs(debugLogService.getLogs());
+  const latestFinalizedArchive = useMemo(
+    () => snapshot.files.find(item => item.kind === 'zip') || null,
+    [snapshot.files],
+  );
+  const finalizedArchives = useMemo(
+    () => snapshot.files.filter(item => item.kind === 'zip'),
+    [snapshot.files],
+  );
+  const archiveSharePickerSnapPoints = useMemo(() => [460], []);
+
+  const refreshSnapshot = useCallback(async () => {
+    const fileState = await listArchiveFiles();
+    const nextSnapshot = {
+      loggerState: logger.getState(),
+      rootExists: fileState.exists,
+      files: fileState.files,
+      prodOnlineEnabled:
+        !!getOnlineConfig()?.switches?.[APP_FILE_LOGGING_ONLINE_SWITCH],
+      refreshedAt: new Date().toISOString(),
+    };
+
+    setSnapshot(nextSnapshot);
+    return nextSnapshot;
   }, []);
 
   useEffect(() => {
-    refreshLogs();
-    const unsubscribe = debugLogService.subscribe(refreshLogs);
-    return unsubscribe;
-  }, [refreshLogs]);
+    refreshSnapshot().catch(noop);
 
-  const handleCopyAll = useCallback(() => {
-    const allLogs = logs
-      .map(log => {
-        const timeStr = dayjs(log.timestamp).format('YYYY-MM-DD HH:mm:ss.SSS');
-        let text = `[${log.level.toUpperCase()}] ${timeStr} - ${log.message}`;
-        if (log.data) {
-          text += `\nData: ${
-            typeof log.data === 'string'
-              ? log.data
-              : JSON.stringify(log.data, null, 2)
-          }`;
-        }
-        return text;
-      })
-      .join('\n\n');
+    const unsubscribeSettings = subscribeAppLogFileSettings(() => {
+      refreshSnapshot().catch(noop);
+    });
+    const unsubscribeOnline = subscribeOnlineConfig(() => {
+      refreshSnapshot().catch(noop);
+    });
 
-    Clipboard.setString(allLogs);
-    toast.success('Logs copied to clipboard');
-  }, [logs]);
+    return () => {
+      unsubscribeSettings();
+      unsubscribeOnline();
+    };
+  }, [refreshSnapshot]);
 
-  const handleClearLogs = useCallback(() => {
-    Alert.alert('Clear Logs', 'Are you sure you want to clear all logs?', [
-      { text: 'Cancel', style: 'cancel' },
-      {
-        text: 'Clear',
-        style: 'destructive',
-        onPress: () => {
-          debugLogService.clearLogs();
-          toast.success('Logs cleared');
-        },
-      },
-    ]);
+  useEffect(() => {
+    if (isArchiveSharePickerVisible) {
+      archiveSharePickerRef.current?.present();
+    } else {
+      archiveSharePickerRef.current?.dismiss();
+    }
+  }, [isArchiveSharePickerVisible]);
+
+  const markSuccess = useCallback((message: string) => {
+    setLastAction(`${dayjs().format('HH:mm:ss')} ${message}`);
+    toast.success(message);
   }, []);
 
+  const markInfo = useCallback((message: string) => {
+    setLastAction(`${dayjs().format('HH:mm:ss')} ${message}`);
+    toast.info(message);
+  }, []);
+
+  const markError = useCallback((label: string, error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    setLastAction(`${dayjs().format('HH:mm:ss')} ${label} failed: ${message}`);
+    toast.error(message);
+  }, []);
+
+  const handleRefresh = useCallback(async () => {
+    if (busyKey) {
+      return;
+    }
+
+    setBusyKey('refresh');
+    try {
+      await refreshSnapshot();
+      markSuccess('App log directory refreshed');
+    } catch (error) {
+      markError('Refresh', error);
+    } finally {
+      setBusyKey(null);
+    }
+  }, [busyKey, markError, markSuccess, refreshSnapshot]);
+
+  const handleWriteSampleLogs = useCallback(async () => {
+    if (busyKey) {
+      return;
+    }
+
+    setBusyKey('sample');
+    try {
+      await writeSampleLogs();
+      await refreshSnapshot();
+      markSuccess('Sample logs written and flushed');
+    } catch (error) {
+      markError('Write sample logs', error);
+    } finally {
+      setBusyKey(null);
+    }
+  }, [busyKey, markError, markSuccess, refreshSnapshot]);
+
+  const handleWriteRotationBurst = useCallback(async () => {
+    if (busyKey) {
+      return;
+    }
+
+    setBusyKey('burst');
+    try {
+      await writeRotationBurst();
+      await refreshSnapshot();
+      markSuccess('Rotation burst written and flushed');
+    } catch (error) {
+      markError('Write rotation burst', error);
+    } finally {
+      setBusyKey(null);
+    }
+  }, [busyKey, markError, markSuccess, refreshSnapshot]);
+
+  const handleFlush = useCallback(async () => {
+    if (busyKey) {
+      return;
+    }
+
+    setBusyKey('flush');
+    try {
+      await logger.flush();
+      await refreshSnapshot();
+      markSuccess('Logger queue flushed');
+    } catch (error) {
+      markError('Flush queue', error);
+    } finally {
+      setBusyKey(null);
+    }
+  }, [busyKey, markError, markSuccess, refreshSnapshot]);
+
+  const handleFinalize = useCallback(async () => {
+    if (busyKey) {
+      return;
+    }
+
+    setBusyKey('finalize');
+    try {
+      const finalPath = await logger.finalizeArchive();
+      await refreshSnapshot();
+
+      if (finalPath) {
+        markSuccess(`Log zip ready: ${finalPath.split('/').pop()}`);
+      } else {
+        markInfo('No active archive to finalize');
+      }
+    } catch (error) {
+      markError('Finalize archive', error);
+    } finally {
+      setBusyKey(null);
+    }
+  }, [busyKey, markError, markInfo, markSuccess, refreshSnapshot]);
+
+  const handleValidateLatestZip = useCallback(async () => {
+    if (busyKey) {
+      return;
+    }
+
+    setBusyKey('validate');
+    try {
+      const nextSnapshot = await refreshSnapshot();
+      const latestArchive =
+        nextSnapshot.files.find(item => item.kind === 'zip') || null;
+
+      if (!latestArchive) {
+        setValidationResult(null);
+        markInfo('No finalized zip found under applogs');
+        return;
+      }
+
+      const result = await validateArchiveFile(latestArchive);
+      setValidationResult(result);
+      await refreshSnapshot();
+      markSuccess(
+        `Zip validated: ${result.entryCount} entries / ${formatBytes(
+          result.totalBytes,
+        )}`,
+      );
+    } catch (error) {
+      markError('Validate latest zip', error);
+    } finally {
+      setBusyKey(null);
+    }
+  }, [busyKey, markError, markInfo, markSuccess, refreshSnapshot]);
+
+  const shareArchiveFile = useCallback(
+    async (archive: ArchiveFileItem) => {
+      if (!canShareArchive) {
+        markInfo('Archive sharing is disabled in production builds');
+        return;
+      }
+
+      if (!(await RNFS.exists(archive.path))) {
+        throw new Error(`Archive file missing: ${archive.path}`);
+      }
+
+      if (Platform.OS === 'ios') {
+        const result = await Share.share(
+          {
+            title: archive.name,
+            url: `file://${archive.path}`,
+            message: `Rabby app log archive: ${archive.name}`,
+          },
+          {
+            subject: archive.name,
+          },
+        );
+
+        if (result.action === Share.dismissedAction) {
+          markInfo('Share dismissed');
+        } else {
+          markSuccess(`Shared: ${archive.name}`);
+        }
+
+        return;
+      }
+
+      await Share.share(
+        {
+          title: archive.name,
+          message: archive.path,
+        },
+        {
+          dialogTitle: 'Share app log archive path',
+        },
+      );
+      markInfo(`Android core Share sent the archive path: ${archive.name}`);
+    },
+    [canShareArchive, markInfo, markSuccess],
+  );
+
+  const handleShareLatestZip = useCallback(async () => {
+    if (busyKey) {
+      return;
+    }
+
+    if (!canShareArchive) {
+      markInfo('Archive sharing is disabled in production builds');
+      return;
+    }
+
+    setBusyKey('share');
+    try {
+      const nextSnapshot = await refreshSnapshot();
+      const latestArchive =
+        nextSnapshot.files.find(item => item.kind === 'zip') || null;
+
+      if (!latestArchive) {
+        markInfo('No finalized zip found under applogs');
+        return;
+      }
+
+      await shareArchiveFile(latestArchive);
+    } catch (error) {
+      markError('Share latest zip', error);
+    } finally {
+      setBusyKey(null);
+    }
+  }, [
+    busyKey,
+    canShareArchive,
+    markError,
+    markInfo,
+    refreshSnapshot,
+    shareArchiveFile,
+  ]);
+
+  const handleOpenArchiveSharePicker = useCallback(async () => {
+    if (busyKey) {
+      return;
+    }
+
+    if (!canShareArchive) {
+      markInfo('Archive sharing is disabled in production builds');
+      return;
+    }
+
+    try {
+      const nextSnapshot = await refreshSnapshot();
+      const archives = nextSnapshot.files.filter(item => item.kind === 'zip');
+
+      if (!archives.length) {
+        markInfo('No finalized zip found under applogs');
+        return;
+      }
+
+      setIsArchiveSharePickerVisible(true);
+    } catch (error) {
+      markError('Open share picker', error);
+    }
+  }, [busyKey, canShareArchive, markError, markInfo, refreshSnapshot]);
+
+  const handleShareSelectedArchive = useCallback(
+    async (archive: ArchiveFileItem) => {
+      if (busyKey) {
+        return;
+      }
+
+      setBusyKey('share');
+      try {
+        await shareArchiveFile(archive);
+        setIsArchiveSharePickerVisible(false);
+      } catch (error) {
+        markError('Share selected zip', error);
+      } finally {
+        setBusyKey(null);
+      }
+    },
+    [busyKey, markError, shareArchiveFile],
+  );
+
+  const localPolicyHint =
+    APP_RUNTIME_ENV === 'development'
+      ? `Development local switch default is ${
+          localDefaultEnabled ? 'ON' : 'OFF'
+        }. Current local value: ${localFileLoggingEnabled ? 'true' : 'false'}.`
+      : `Regression local switch default is ${
+          localDefaultEnabled ? 'ON' : 'OFF'
+        }. Current local value: ${localFileLoggingEnabled ? 'true' : 'false'}.`;
+
   return (
-    <NormalScreenContainer style={styles.container}>
-      <View style={styles.header}>
-        <Text style={styles.title}>Debug Logs</Text>
-        <Text style={styles.count}>{logs.length} logs</Text>
-      </View>
-
-      <View style={styles.actions}>
-        <Pressable
-          style={[styles.button, { marginRight: 12 }]}
-          onPress={handleCopyAll}
-          disabled={logs.length === 0}>
-          <Text style={styles.buttonText}>Copy All</Text>
-        </Pressable>
-        <Pressable
-          style={styles.button}
-          onPress={handleClearLogs}
-          disabled={logs.length === 0}>
-          <Text
-            style={[styles.buttonText, { color: colors2024['red-default'] }]}>
-            Clear All
+    <NormalScreenContainer noHeader style={styles.container}>
+      <ScrollView
+        contentContainerStyle={styles.contentContainer}
+        showsVerticalScrollIndicator={false}>
+        <View style={styles.heroCard}>
+          <Text style={styles.heroEyebrow}>Real Device Test Lab</Text>
+          <Text style={styles.heroTitle}>App Log Verification</Text>
+          <Text style={styles.heroDescription}>
+            This page exercises the actual `react-native-fs` + zip streaming
+            path on device. Use it to write logs, force archive finalization,
+            inspect `applogs`, and validate that the latest finalized zip can be
+            parsed back.
           </Text>
-        </Pressable>
-      </View>
+        </View>
 
-      <ScrollView style={styles.scrollView}>
-        {logs.length === 0 ? (
-          <View style={styles.emptyContainer}>
-            <Text style={styles.emptyText}>No logs yet</Text>
-            <Text style={styles.emptyHint}>
-              Use debugLogService to add logs from anywhere in the app
-            </Text>
+        <Section
+          title="Archive Share"
+          description="Use sharing near the top of the page when you want to export the latest zip quickly or choose an older finalized archive by time range.">
+          <Button
+            title={busyKey === 'share' ? 'Opening...' : 'Share Latest Zip'}
+            type="ghost"
+            height={48}
+            disabled={!!busyKey || !canShareArchive}
+            onPress={handleShareLatestZip}
+            containerStyle={styles.singleActionButton}
+          />
+          <Button
+            title="Choose Zip to Share"
+            type="ghost"
+            height={48}
+            disabled={!!busyKey || !canShareArchive}
+            onPress={handleOpenArchiveSharePicker}
+            containerStyle={styles.singleActionButton}
+          />
+          <Text style={styles.sectionHint}>
+            {canShareArchive
+              ? 'Non-production builds can share the latest finalized zip directly, or open a picker to choose another finalized zip by time range. Android currently falls back to sharing the archive path.'
+              : 'Archive sharing is disabled in production builds even if this page is reachable.'}
+          </Text>
+        </Section>
+
+        <Section
+          title="Logging Policy"
+          description="Keep this enabled before running the write/flush/finalize flow. Development defaults on, regression defaults off until enabled, and production follows online config only.">
+          <View style={styles.policyRow}>
+            <View style={styles.policyTextBlock}>
+              <Text style={styles.policyLabel}>Effective file logging</Text>
+              <Text
+                style={[
+                  styles.policyValue,
+                  {
+                    color: effectiveEnabled
+                      ? colors2024['green-default']
+                      : colors2024['orange-default'],
+                  },
+                ]}>
+                {effectiveEnabled ? 'Enabled' : 'Disabled'}
+              </Text>
+              <Text style={styles.policyHint}>
+                env={APP_RUNTIME_ENV} · __DEV__={__DEV__ ? 'true' : 'false'}
+              </Text>
+            </View>
+            <AppSwitch2024
+              disabled={!canToggle}
+              value={effectiveEnabled}
+              onValueChange={nextValue => {
+                if (!canToggle) {
+                  return;
+                }
+
+                onToggle(nextValue);
+                refreshSnapshot().catch(noop);
+              }}
+            />
           </View>
-        ) : (
-          logs.map((log, index) => <LogEntryView key={index} entry={log} />)
-        )}
+
+          <Text style={styles.sectionHint}>
+            {isOnlineControlled
+              ? `Production is controlled by onlineConfig: ${APP_FILE_LOGGING_ONLINE_SWITCH}`
+              : `${localPolicyHint} Console capture follows the same policy.`}
+          </Text>
+
+          <MetaRow
+            label="Console capture"
+            value={consoleCaptureEnabled ? 'enabled' : 'disabled'}
+            tone={consoleCaptureEnabled ? 'success' : 'warning'}
+          />
+          <MetaRow
+            label="Prod online switch"
+            value={`${APP_FILE_LOGGING_ONLINE_SWITCH} = ${
+              snapshot.prodOnlineEnabled ? 'true' : 'false'
+            }`}
+            tone={snapshot.prodOnlineEnabled ? 'success' : 'warning'}
+          />
+          <MetaRow label="App log root" value={APP_LOG_ROOT_PATH} />
+        </Section>
+
+        <Section
+          title="Runtime State"
+          description="Watch these values while switching app state or forcing archive finalize.">
+          <MetaRow label="Session" value={snapshot.loggerState.sessionId} />
+          <MetaRow
+            label="Active temp archive"
+            value={snapshot.loggerState.activeArchiveTempPath || 'none'}
+          />
+          <MetaRow
+            label="Active final archive"
+            value={snapshot.loggerState.activeArchivePath || 'none'}
+          />
+          <MetaRow
+            label="Active entry"
+            value={snapshot.loggerState.activeEntryPath || 'none'}
+          />
+          <MetaRow
+            label="Current entry size"
+            value={formatBytes(snapshot.loggerState.activeEntryBytes)}
+          />
+          <MetaRow
+            label="Console capture"
+            value={
+              snapshot.loggerState.effectiveConsoleCaptureEnabled
+                ? 'enabled'
+                : 'disabled'
+            }
+            tone={
+              snapshot.loggerState.effectiveConsoleCaptureEnabled
+                ? 'success'
+                : 'warning'
+            }
+          />
+          <MetaRow
+            label="Last refresh"
+            value={formatDateTime(snapshot.refreshedAt)}
+          />
+          <MetaRow
+            label="Last action"
+            value={lastAction}
+            tone={lastAction.includes('failed') ? 'warning' : 'default'}
+          />
+        </Section>
+
+        <Section
+          title="Generate Logs"
+          description="Sample logs cover console capture, explicit logger calls, masking, and timer events. The burst action pushes roughly 1.2 MB to help verify entry rotation.">
+          <View style={styles.actionRow}>
+            <Button
+              title={busyKey === 'sample' ? 'Writing...' : 'Write Sample Set'}
+              type="ghost"
+              height={48}
+              disabled={!!busyKey}
+              onPress={handleWriteSampleLogs}
+              containerStyle={styles.actionButton}
+            />
+            <Button
+              title={
+                busyKey === 'burst' ? 'Writing...' : 'Write Rotation Burst'
+              }
+              type="ghost"
+              height={48}
+              disabled={!!busyKey}
+              onPress={handleWriteRotationBurst}
+              containerStyle={styles.actionButton}
+            />
+          </View>
+          <Text style={styles.sectionHint}>
+            Burst payload: {BURST_LINE_COUNT} lines x{' '}
+            {formatBytes(BURST_LINE_SIZE)} each.
+          </Text>
+        </Section>
+
+        <Section
+          title="Archive Controls"
+          description="Flush and finalize let you force the writer into a stable state before validating or exporting the zip.">
+          <View style={styles.actionRow}>
+            <Button
+              title={busyKey === 'flush' ? 'Flushing...' : 'Flush Queue'}
+              type="ghost"
+              height={48}
+              disabled={!!busyKey}
+              onPress={handleFlush}
+              containerStyle={styles.actionButton}
+            />
+            <Button
+              title={busyKey === 'finalize' ? 'Finalizing...' : 'Finalize Zip'}
+              type="ghost"
+              height={48}
+              disabled={!!busyKey}
+              onPress={handleFinalize}
+              containerStyle={styles.actionButton}
+            />
+          </View>
+          <View style={styles.actionRow}>
+            <Button
+              title={busyKey === 'refresh' ? 'Refreshing...' : 'Refresh Dir'}
+              type="ghost"
+              height={48}
+              disabled={!!busyKey}
+              onPress={handleRefresh}
+              containerStyle={styles.actionButton}
+            />
+            <Button
+              title={
+                busyKey === 'validate' ? 'Validating...' : 'Validate Latest Zip'
+              }
+              type="ghost"
+              height={48}
+              disabled={!!busyKey}
+              onPress={handleValidateLatestZip}
+              containerStyle={styles.actionButton}
+            />
+          </View>
+        </Section>
+
+        <Section
+          title="Archive Files"
+          description="You should see finalized `.zip` files and, while logging is active, a current `.zip.partial`.">
+          <MetaRow
+            label="Root exists"
+            value={snapshot.rootExists ? 'true' : 'false'}
+            tone={snapshot.rootExists ? 'success' : 'warning'}
+          />
+          <MetaRow
+            label="Latest finalized zip"
+            value={latestFinalizedArchive?.path || 'none'}
+          />
+
+          {snapshot.files.length === 0 ? (
+            <Text style={styles.emptyText}>No files under applogs yet.</Text>
+          ) : (
+            snapshot.files.slice(0, 8).map(file => (
+              <View key={file.path} style={styles.fileRow}>
+                <View style={styles.fileHeader}>
+                  <Text style={styles.fileName} numberOfLines={1}>
+                    {file.name}
+                  </Text>
+                  <Text
+                    style={[
+                      styles.fileBadge,
+                      file.kind === 'zip'
+                        ? styles.fileBadgeZip
+                        : file.kind === 'partial'
+                        ? styles.fileBadgePartial
+                        : styles.fileBadgeOther,
+                    ]}>
+                    {file.kind}
+                  </Text>
+                </View>
+                <Text style={styles.fileMeta}>
+                  {formatBytes(file.size)} · {formatArchiveTimeRange(file)}
+                </Text>
+                <Text
+                  style={styles.filePath}
+                  numberOfLines={2}
+                  ellipsizeMode="middle"
+                  selectable>
+                  {file.path}
+                </Text>
+              </View>
+            ))
+          )}
+        </Section>
+
+        <Section
+          title="Zip Validation"
+          description="Validation reads the latest finalized zip from device storage and parses it in-app with `fflate.unzipSync()`.">
+          {validationResult ? (
+            <>
+              <MetaRow
+                label="Archive"
+                value={`${validationResult.archiveName} · ${validationResult.entryCount} entries`}
+                tone="success"
+              />
+              <MetaRow
+                label="Archive path"
+                value={validationResult.archivePath}
+              />
+              <MetaRow
+                label="Uncompressed bytes"
+                value={formatBytes(validationResult.totalBytes)}
+              />
+              <MetaRow
+                label="First entry"
+                value={validationResult.firstEntryPath || 'none'}
+              />
+              <MetaRow
+                label="First line"
+                value={validationResult.firstLinePreview || 'none'}
+              />
+              <MetaRow
+                label="Checked at"
+                value={formatDateTime(validationResult.checkedAt)}
+              />
+              <Text style={styles.validationListLabel}>Entry preview</Text>
+              {validationResult.entryNames.slice(0, 5).map(entryName => (
+                <Text key={entryName} style={styles.validationEntry}>
+                  {entryName}
+                </Text>
+              ))}
+            </>
+          ) : (
+            <Text style={styles.emptyText}>
+              No validation result yet. Finalize a zip first, then tap `Validate
+              Latest Zip`.
+            </Text>
+          )}
+        </Section>
+
+        <Section
+          title="Suggested Flow"
+          description="This is the shortest path to verify whether device-side zip streaming is actually stable.">
+          <Text style={styles.checklistItem}>
+            1. Confirm file logging is enabled.
+          </Text>
+          <Text style={styles.checklistItem}>2. Tap `Write Sample Set`.</Text>
+          <Text style={styles.checklistItem}>3. Tap `Finalize Zip`.</Text>
+          <Text style={styles.checklistItem}>
+            4. Tap `Validate Latest Zip`.
+          </Text>
+          <Text style={styles.checklistItem}>
+            5. Export that zip off-device and unzip it again on desktop.
+          </Text>
+          <Text style={styles.checklistItem}>
+            6. Repeat once more with `Write Rotation Burst` and app
+            backgrounding.
+          </Text>
+        </Section>
       </ScrollView>
+      <AppBottomSheetModal
+        ref={archiveSharePickerRef}
+        snapPoints={archiveSharePickerSnapPoints}
+        onDismiss={() => setIsArchiveSharePickerVisible(false)}
+        enableDismissOnClose
+        {...makeBottomSheetProps({
+          colors: colors2024,
+          linearGradientType: 'bg1',
+        })}>
+        <View style={styles.shareSheetContainer}>
+          <AppBottomSheetModalTitle title="Choose Zip to Share" />
+          <Text style={styles.shareSheetDescription}>
+            Finalized zip archives only. Time range currently uses file
+            create/update timestamps.
+          </Text>
+          <BottomSheetScrollView
+            contentContainerStyle={styles.shareSheetList}
+            showsVerticalScrollIndicator={false}>
+            {finalizedArchives.length ? (
+              finalizedArchives.map(file => (
+                <TouchableOpacity
+                  key={file.path}
+                  style={styles.shareSheetItem}
+                  disabled={busyKey === 'share'}
+                  onPress={() => handleShareSelectedArchive(file)}>
+                  <View style={styles.shareSheetItemHeader}>
+                    <Text style={styles.shareSheetItemTitle} numberOfLines={1}>
+                      {file.name}
+                    </Text>
+                    <Text style={styles.shareSheetItemBadge}>zip</Text>
+                  </View>
+                  <Text style={styles.shareSheetItemMeta}>
+                    {formatBytes(file.size)} · {formatArchiveTimeRange(file)}
+                  </Text>
+                  <Text
+                    style={styles.shareSheetItemPath}
+                    numberOfLines={2}
+                    ellipsizeMode="middle">
+                    {file.path}
+                  </Text>
+                </TouchableOpacity>
+              ))
+            ) : (
+              <Text style={styles.emptyText}>
+                No finalized zip files found.
+              </Text>
+            )}
+          </BottomSheetScrollView>
+        </View>
+      </AppBottomSheetModal>
     </NormalScreenContainer>
   );
 }
 
 const getStyles = createGetStyles2024(ctx => {
+  const monoFont = Platform.select({
+    ios: 'Menlo',
+    android: 'monospace',
+    default: 'monospace',
+  });
+
   return {
     container: {
       flex: 1,
       backgroundColor: ctx.colors2024['neutral-bg-1'],
     },
-    header: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      alignItems: 'center',
+    contentContainer: {
       paddingHorizontal: 20,
-      paddingVertical: 16,
-      borderBottomWidth: 1,
-      borderBottomColor: ctx.colors2024['neutral-line'],
+      paddingTop: 20,
+      paddingBottom: 40,
+      gap: 16,
     },
-    title: {
-      fontSize: 20,
-      fontWeight: '600',
-      color: ctx.colors2024['neutral-title-1'],
-    },
-    count: {
-      fontSize: 14,
-      color: ctx.colors2024['neutral-body'],
-    },
-    actions: {
-      flexDirection: 'row',
-      paddingHorizontal: 20,
-      paddingVertical: 12,
-      borderBottomWidth: 1,
-      borderBottomColor: ctx.colors2024['neutral-line'],
-    },
-    button: {
-      flex: 1,
-      height: 40,
-      borderRadius: 8,
+    heroCard: {
+      padding: 20,
+      borderRadius: 24,
+      backgroundColor: ctx.colors2024['neutral-card-1'],
       borderWidth: 1,
       borderColor: ctx.colors2024['neutral-line'],
-      backgroundColor: ctx.colors2024['neutral-card-2'],
+      gap: 8,
     },
-    buttonText: {
-      fontSize: 14,
-      fontWeight: '500',
-      color: ctx.colors2024['blue-default'],
-    },
-    scrollView: {
-      flex: 1,
-    },
-    emptyContainer: {
-      flex: 1,
-      justifyContent: 'center',
-      alignItems: 'center',
-      paddingVertical: 60,
-      paddingHorizontal: 40,
-    },
-    emptyText: {
-      fontSize: 16,
-      fontWeight: '500',
-      color: ctx.colors2024['neutral-body'],
-      marginBottom: 8,
-    },
-    emptyHint: {
+    heroEyebrow: {
       fontSize: 13,
+      fontWeight: '700',
+      color: ctx.colors2024['brand-default'],
+      textTransform: 'uppercase',
+      letterSpacing: 0.4,
+    },
+    heroTitle: {
+      fontSize: 28,
+      fontWeight: '800',
+      color: ctx.colors2024['neutral-title-1'],
+    },
+    heroDescription: {
+      fontSize: 14,
+      lineHeight: 22,
+      color: ctx.colors2024['neutral-body'],
+    },
+    sectionCard: {
+      padding: 18,
+      borderRadius: 20,
+      backgroundColor: ctx.colors2024['neutral-card-1'],
+      borderWidth: 1,
+      borderColor: ctx.colors2024['neutral-line'],
+      gap: 12,
+    },
+    sectionTitle: {
+      fontSize: 20,
+      fontWeight: '700',
+      color: ctx.colors2024['neutral-title-1'],
+    },
+    sectionDescription: {
+      fontSize: 13,
+      lineHeight: 20,
+      color: ctx.colors2024['neutral-body'],
+    },
+    sectionHint: {
+      fontSize: 13,
+      lineHeight: 20,
       color: ctx.colors2024['neutral-foot'],
-      textAlign: 'center',
     },
-    logEntry: {
-      paddingHorizontal: 20,
-      paddingVertical: 12,
-      borderBottomWidth: 1,
-      borderBottomColor: ctx.colors2024['neutral-line'],
-    },
-    logHeader: {
+    policyRow: {
       flexDirection: 'row',
       alignItems: 'center',
-      marginBottom: 6,
+      justifyContent: 'space-between',
+      gap: 12,
+      paddingVertical: 4,
     },
-    logLevel: {
-      fontSize: 11,
+    policyTextBlock: {
+      flex: 1,
+      gap: 4,
+    },
+    policyLabel: {
+      fontSize: 14,
       fontWeight: '600',
-      paddingHorizontal: 8,
-      paddingVertical: 3,
-      borderRadius: 4,
-      marginRight: 8,
-      overflow: 'hidden',
+      color: ctx.colors2024['neutral-title-1'],
     },
-    logTime: {
+    policyValue: {
+      fontSize: 18,
+      fontWeight: '700',
+    },
+    policyHint: {
       fontSize: 12,
       color: ctx.colors2024['neutral-foot'],
-      fontFamily: 'Menlo',
     },
-    logMessage: {
-      fontSize: 14,
-      color: ctx.colors2024['neutral-title-1'],
-      lineHeight: 20,
-      marginBottom: 4,
+    metaRow: {
+      gap: 6,
+      paddingVertical: 2,
     },
-    logData: {
+    metaLabel: {
       fontSize: 12,
-      color: ctx.colors2024['neutral-body'],
-      fontFamily: 'Menlo',
+      fontWeight: '600',
+      color: ctx.colors2024['neutral-foot'],
+      textTransform: 'uppercase',
+      letterSpacing: 0.3,
+    },
+    metaValue: {
+      fontSize: 14,
+      lineHeight: 20,
+      color: ctx.colors2024['neutral-title-1'],
+      fontFamily: monoFont,
+    },
+    actionRow: {
+      flexDirection: 'row',
+      gap: 12,
+    },
+    actionButton: {
+      flex: 1,
+    },
+    singleActionButton: {
+      width: '100%',
+    },
+    shareSheetContainer: {
+      flex: 1,
+      backgroundColor: ctx.colors2024['neutral-bg-1'],
+      paddingHorizontal: 20,
+      paddingBottom: 24,
+    },
+    shareSheetDescription: {
+      fontSize: 13,
+      lineHeight: 20,
+      color: ctx.colors2024['neutral-foot'],
+      marginBottom: 16,
+    },
+    shareSheetList: {
+      gap: 12,
+      paddingBottom: 12,
+    },
+    shareSheetItem: {
+      gap: 6,
+      padding: 14,
+      borderRadius: 16,
       backgroundColor: ctx.colors2024['neutral-card-2'],
-      padding: 8,
-      borderRadius: 6,
-      marginTop: 4,
+      borderWidth: 1,
+      borderColor: ctx.colors2024['neutral-line'],
+    },
+    shareSheetItemHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 10,
+    },
+    shareSheetItemTitle: {
+      flex: 1,
+      fontSize: 14,
+      fontWeight: '700',
+      color: ctx.colors2024['neutral-title-1'],
+      fontFamily: monoFont,
+    },
+    shareSheetItemBadge: {
+      overflow: 'hidden',
+      paddingHorizontal: 8,
+      paddingVertical: 4,
+      borderRadius: 999,
+      fontSize: 11,
+      fontWeight: '700',
+      textTransform: 'uppercase',
+      color: ctx.colors2024['green-default'],
+      backgroundColor: `${ctx.colors2024['green-default']}1F`,
+    },
+    shareSheetItemMeta: {
+      fontSize: 12,
+      color: ctx.colors2024['neutral-foot'],
+      fontFamily: monoFont,
+    },
+    shareSheetItemPath: {
+      fontSize: 12,
+      lineHeight: 18,
+      color: ctx.colors2024['neutral-body'],
+      fontFamily: monoFont,
+    },
+    emptyText: {
+      fontSize: 14,
+      lineHeight: 20,
+      color: ctx.colors2024['neutral-foot'],
+    },
+    fileRow: {
+      gap: 6,
+      padding: 14,
+      borderRadius: 16,
+      backgroundColor: ctx.colors2024['neutral-card-2'],
+      borderWidth: 1,
+      borderColor: ctx.colors2024['neutral-line'],
+    },
+    fileHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 10,
+    },
+    fileName: {
+      flex: 1,
+      fontSize: 14,
+      fontWeight: '700',
+      color: ctx.colors2024['neutral-title-1'],
+      fontFamily: monoFont,
+    },
+    fileBadge: {
+      overflow: 'hidden',
+      paddingHorizontal: 8,
+      paddingVertical: 4,
+      borderRadius: 999,
+      fontSize: 11,
+      fontWeight: '700',
+      textTransform: 'uppercase',
+    },
+    fileBadgeZip: {
+      color: ctx.colors2024['green-default'],
+      backgroundColor: `${ctx.colors2024['green-default']}1F`,
+    },
+    fileBadgePartial: {
+      color: ctx.colors2024['orange-default'],
+      backgroundColor: `${ctx.colors2024['orange-default']}1F`,
+    },
+    fileBadgeOther: {
+      color: ctx.colors2024['neutral-foot'],
+      backgroundColor: ctx.colors2024['neutral-line'],
+    },
+    fileMeta: {
+      fontSize: 12,
+      color: ctx.colors2024['neutral-foot'],
+      fontFamily: monoFont,
+    },
+    filePath: {
+      fontSize: 12,
+      lineHeight: 18,
+      color: ctx.colors2024['neutral-body'],
+      fontFamily: monoFont,
+    },
+    validationListLabel: {
+      fontSize: 12,
+      fontWeight: '700',
+      color: ctx.colors2024['neutral-foot'],
+      textTransform: 'uppercase',
+      letterSpacing: 0.3,
+    },
+    validationEntry: {
+      fontSize: 13,
+      lineHeight: 18,
+      color: ctx.colors2024['neutral-title-1'],
+      fontFamily: monoFont,
+    },
+    checklistItem: {
+      fontSize: 14,
+      lineHeight: 20,
+      color: ctx.colors2024['neutral-title-1'],
     },
   };
 });

--- a/apps/mobile/src/screens/Testkits/DevSwitches.tsx
+++ b/apps/mobile/src/screens/Testkits/DevSwitches.tsx
@@ -534,8 +534,14 @@ function DevSwitchAboutExpData() {
 
 function DevSwitchAboutAppLogging() {
   const { styles } = useTheme2024({ getStyle: getStyles });
-  const { canToggle, isForcedOn, effectiveEnabled, onToggle } =
-    useAppLogFileSwitch();
+  const {
+    canToggle,
+    effectiveEnabled,
+    isOnlineControlled,
+    localDefaultEnabled,
+    runtimeEnv,
+    onToggle,
+  } = useAppLogFileSwitch();
   const [snapshot, setSnapshot] = useState(() => logger.getState());
   const [isFinalizing, setIsFinalizing] = useState(false);
 
@@ -549,11 +555,17 @@ function DevSwitchAboutAppLogging() {
 
   const statusText = canToggle
     ? effectiveEnabled
-      ? 'Regression build writes app logs into applogs zip archives'
-      : 'Regression build skips file logging'
-    : isForcedOn
-    ? 'Production always writes app logs to disk'
-    : 'Development skips file logging';
+      ? `${
+          runtimeEnv === 'development' ? 'Development' : 'Regression'
+        } build captures console and writes app logs into applogs zip archives`
+      : `${
+          runtimeEnv === 'development' ? 'Development' : 'Regression'
+        } build keeps app logs off until you enable the local switch`
+    : isOnlineControlled
+    ? effectiveEnabled
+      ? 'Production writes app logs because online config enables it'
+      : 'Production skips file logging until online config enables it'
+    : 'App file logging is unavailable';
 
   return (
     <View style={styles.showCaseRowsContainer}>
@@ -596,6 +608,12 @@ function DevSwitchAboutAppLogging() {
 
       <Text
         style={[styles.label, { marginTop: 12 }]}
+        numberOfLines={2}
+        ellipsizeMode="middle">
+        Default: {localDefaultEnabled ? 'ON' : 'OFF'}
+      </Text>
+      <Text
+        style={[styles.label, { marginTop: 4 }]}
         numberOfLines={2}
         ellipsizeMode="middle">
         Root: {APP_LOG_ROOT_PATH}

--- a/apps/mobile/src/screens/Testkits/DevSwitches.tsx
+++ b/apps/mobile/src/screens/Testkits/DevSwitches.tsx
@@ -104,6 +104,8 @@ import {
   useReport0331SnapshotTrackedState,
 } from '@/utils/analytics0331';
 import { Text, AnimateableText } from '@/components/Typography';
+import { useAppLogFileSwitch } from '@/utils/logging/settings';
+import { APP_LOG_ROOT_PATH, logger } from '@/utils/logger';
 
 export const makeNoop = () => () => {};
 
@@ -405,8 +407,8 @@ function DevSwitchAboutScreenProtection() {
           />
           <Text style={styles.switchLabel}>
             {forceAllowScreenshot
-              ? `Force Allow Capture`
-              : `Disallow Capture Sensitive Scene`}
+              ? 'Force Allow Capture'
+              : 'Disallow Capture Sensitive Scene'}
           </Text>
         </TouchableOpacity>
 
@@ -425,8 +427,8 @@ function DevSwitchAboutScreenProtection() {
             />
             <Text style={styles.switchLabel}>
               {iosForceDisableAlertForSensitiveScene
-                ? `Force Disable Alert for Sensitive Scene`
-                : `Alert for Sensitive Scene when screen recording/screenshot`}
+                ? 'Force Disable Alert for Sensitive Scene'
+                : 'Alert for Sensitive Scene when screen recording/screenshot'}
             </Text>
           </TouchableOpacity>
         )}
@@ -526,6 +528,108 @@ function DevSwitchAboutExpData() {
           </View>
         </View>
       </View>
+    </View>
+  );
+}
+
+function DevSwitchAboutAppLogging() {
+  const { styles } = useTheme2024({ getStyle: getStyles });
+  const { canToggle, isForcedOn, effectiveEnabled, onToggle } =
+    useAppLogFileSwitch();
+  const [snapshot, setSnapshot] = useState(() => logger.getState());
+  const [isFinalizing, setIsFinalizing] = useState(false);
+
+  const refreshSnapshot = useCallback(() => {
+    setSnapshot(logger.getState());
+  }, []);
+
+  useEffect(() => {
+    refreshSnapshot();
+  }, [effectiveEnabled, refreshSnapshot]);
+
+  const statusText = canToggle
+    ? effectiveEnabled
+      ? 'Regression build writes app logs into applogs zip archives'
+      : 'Regression build skips file logging'
+    : isForcedOn
+    ? 'Production always writes app logs to disk'
+    : 'Development skips file logging';
+
+  return (
+    <View style={styles.showCaseRowsContainer}>
+      <View style={styles.secondarySectionHeader}>
+        <RcCode
+          width={24}
+          height={24}
+          color={styles.secondarySectionTitle.color}
+        />
+        <Text
+          style={[
+            styles.secondarySectionTitle,
+            { fontSize: 24, marginLeft: 2 },
+          ]}>
+          App File Logs
+        </Text>
+      </View>
+
+      <TouchableOpacity
+        style={styles.switchRowWrapper}
+        disabled={!canToggle}
+        onPress={() => {
+          if (!canToggle) {
+            return;
+          }
+          onToggle();
+          refreshSnapshot();
+        }}>
+        <AppSwitch2024
+          value={effectiveEnabled}
+          disabled={!canToggle}
+          onPress={evt => evt.stopPropagation()}
+          onValueChange={nextValue => {
+            onToggle(nextValue);
+            refreshSnapshot();
+          }}
+        />
+        <Text style={styles.switchLabel}>{statusText}</Text>
+      </TouchableOpacity>
+
+      <Text
+        style={[styles.label, { marginTop: 12 }]}
+        numberOfLines={2}
+        ellipsizeMode="middle">
+        Root: {APP_LOG_ROOT_PATH}
+      </Text>
+      <Text
+        style={[styles.label, { marginTop: 4 }]}
+        numberOfLines={2}
+        ellipsizeMode="middle">
+        Active archive: {snapshot.activeArchiveTempPath || 'none'}
+      </Text>
+
+      <Button
+        title={isFinalizing ? 'Finalizing...' : 'Finalize Current Log Zip'}
+        type="ghost"
+        height={48}
+        containerStyle={{ marginTop: 12 }}
+        disabled={isFinalizing}
+        onPress={async () => {
+          setIsFinalizing(true);
+          try {
+            const finalPath = await logger.finalizeArchive();
+            refreshSnapshot();
+            toast.success(
+              finalPath
+                ? `Log zip ready: ${finalPath.split('/').pop()}`
+                : 'No active log zip',
+            );
+          } catch (error) {
+            toast.error(String(error));
+          } finally {
+            setIsFinalizing(false);
+          }
+        }}
+      />
     </View>
   );
 }
@@ -997,8 +1101,8 @@ function DevMock() {
             Alert.alert(
               'Mock done',
               [
-                `Address-indexed assets data has been mocked.`,
-                `Restart the app to trigger the migrations.`,
+                'Address-indexed assets data has been mocked.',
+                'Restart the app to trigger the migrations.',
               ].join('\n'),
               [
                 { text: 'OK', onPress: makeNoop },
@@ -1047,7 +1151,7 @@ function DevMock() {
         /> */}
 
         <Button
-          title={`Log Feedback Extra`}
+          title={'Log Feedback Extra'}
           type="ghost"
           height={48}
           containerStyle={{ marginTop: 12 }}
@@ -1085,6 +1189,7 @@ function DevSwitches(): JSX.Element {
 
         <Text style={styles.areaTitle}>Security</Text>
         <DevSwitchAboutScreenProtection />
+        <DevSwitchAboutAppLogging />
         <DevSwitchAboutExpData />
         <DevSwitchAboutAutoLock />
 

--- a/apps/mobile/src/setup-app.ts
+++ b/apps/mobile/src/setup-app.ts
@@ -1,8 +1,6 @@
 import '@exodus/patch-broken-hermes-typed-arrays';
-import {
-  setJSExceptionHandler,
-  setNativeExceptionHandler,
-} from 'react-native-exception-handler';
+import { setJSExceptionHandler } from 'react-native-exception-handler';
+import { logger } from '@/utils/logger';
 import './perfs/bundle-splitter-analysis.ts';
 import './databases/orm';
 import './core/services';
@@ -10,8 +8,10 @@ import './core/utils/devServerSettings';
 import './core/config/online';
 
 setJSExceptionHandler((error, isFatal) => {
-  console.debug('setJSExceptionHandler:: error');
-  console.log(error);
+  logger.error('setJSExceptionHandler::error', {
+    isFatal,
+    error,
+  });
 }, true);
 
 // setNativeExceptionHandler(
@@ -27,10 +27,10 @@ setJSExceptionHandler((error, isFatal) => {
 // );
 
 ErrorUtils.setGlobalHandler((error, isFatal) => {
-  // if (__DEV__) {
-  //   console.debug('setGlobalHandler:: error');
-  //   console.log(error);
-  // }
+  logger.error('setGlobalHandler::error', {
+    isFatal,
+    error,
+  });
 
   if (isFatal) {
     // WIP: alert on release mode?

--- a/apps/mobile/src/utils/logger.ts
+++ b/apps/mobile/src/utils/logger.ts
@@ -1,9 +1,40 @@
+import { Platform } from 'react-native';
+import debugLogService from '@/core/services/debugLogService';
+import { APP_DOCUMENT_LIKE_PATH } from '@/core/utils/appFS';
+import { APP_RUNTIME_ENV } from '@/constant/env';
+import { AppLogger } from './logging/core';
+import { rnfsLoggingAdapter } from './logging/rnfsAdapter';
+import { getEffectiveFileLoggingEnabled } from './logging/settings';
+import { RollingZipLogWriter } from './logging/rollingZipWriter';
+
+export const APP_LOG_ROOT_PATH = `${APP_DOCUMENT_LIKE_PATH}/applogs`;
+
+const logWriter = new RollingZipLogWriter({
+  fs: rnfsLoggingAdapter,
+  rootDir: APP_LOG_ROOT_PATH,
+  archivePrefix: 'rabby-mobile-logs',
+});
+
+export const logger = new AppLogger({
+  runtimeEnv: APP_RUNTIME_ENV,
+  platform: Platform.OS,
+  writer: logWriter,
+  shouldWriteToFile: getEffectiveFileLoggingEnabled,
+  captureInMemory: APP_RUNTIME_ENV !== 'production',
+  onInMemoryLog(entry) {
+    debugLogService.addLog(entry.message, entry.level, entry.data);
+  },
+});
+
 export const devLog = (key: string, ...info: any[]) => {
-  if (__DEV__) {
-    if (info.length === 0) {
-      console.log(key);
-    } else {
-      console.log(`[${key}]`, ...info);
-    }
+  if (!__DEV__) {
+    return;
   }
+
+  if (info.length === 0) {
+    logger.debug(key);
+    return;
+  }
+
+  logger.debug(`[${key}]`, ...info);
 };

--- a/apps/mobile/src/utils/logger.ts
+++ b/apps/mobile/src/utils/logger.ts
@@ -4,7 +4,10 @@ import { APP_DOCUMENT_LIKE_PATH } from '@/core/utils/appFS';
 import { APP_RUNTIME_ENV } from '@/constant/env';
 import { AppLogger } from './logging/core';
 import { rnfsLoggingAdapter } from './logging/rnfsAdapter';
-import { getEffectiveFileLoggingEnabled } from './logging/settings';
+import {
+  getEffectiveConsoleCaptureEnabled,
+  getEffectiveFileLoggingEnabled,
+} from './logging/settings';
 import { RollingZipLogWriter } from './logging/rollingZipWriter';
 
 export const APP_LOG_ROOT_PATH = `${APP_DOCUMENT_LIKE_PATH}/applogs`;
@@ -20,6 +23,7 @@ export const logger = new AppLogger({
   platform: Platform.OS,
   writer: logWriter,
   shouldWriteToFile: getEffectiveFileLoggingEnabled,
+  shouldCaptureConsole: getEffectiveConsoleCaptureEnabled,
   captureInMemory: APP_RUNTIME_ENV !== 'production',
   onInMemoryLog(entry) {
     debugLogService.addLog(entry.message, entry.level, entry.data);

--- a/apps/mobile/src/utils/logging/__tests__/logger.test.ts
+++ b/apps/mobile/src/utils/logging/__tests__/logger.test.ts
@@ -3,22 +3,43 @@ import { AppLogger } from '../core';
 import { MaskedLogValue, serializeLogValue } from '../format';
 import {
   LoggingFileSystemAdapter,
+  LoggingFileSystemEntry,
   RollingZipLogWriter,
 } from '../rollingZipWriter';
 
 class MemoryFS implements LoggingFileSystemAdapter {
-  private readonly files = new Map<string, Buffer>();
+  private readonly files = new Map<
+    string,
+    {
+      contents: Buffer;
+      mtimeMs: number;
+    }
+  >();
+  private clock = 1;
 
   async mkdir(_path: string) {}
 
+  async readFile(path: string, encoding: 'base64') {
+    return this.read(path).toString(encoding);
+  }
+
   async writeFile(path: string, contents: string, encoding: 'base64') {
-    this.files.set(path, Buffer.from(contents, encoding));
+    this.files.set(path, {
+      contents: Buffer.from(contents, encoding),
+      mtimeMs: this.clock++,
+    });
   }
 
   async appendFile(path: string, contents: string, encoding: 'base64') {
-    const current = this.files.get(path) || Buffer.alloc(0);
-    const next = Buffer.concat([current, Buffer.from(contents, encoding)]);
-    this.files.set(path, next);
+    const current = this.files.get(path);
+    const next = Buffer.concat([
+      current?.contents || Buffer.alloc(0),
+      Buffer.from(contents, encoding),
+    ]);
+    this.files.set(path, {
+      contents: next,
+      mtimeMs: this.clock++,
+    });
   }
 
   async moveFile(from: string, to: string) {
@@ -27,8 +48,28 @@ class MemoryFS implements LoggingFileSystemAdapter {
       throw new Error(`File not found: ${from}`);
     }
 
-    this.files.set(to, value);
+    this.files.set(to, {
+      contents: value.contents,
+      mtimeMs: this.clock++,
+    });
     this.files.delete(from);
+  }
+
+  async listFiles(path: string): Promise<LoggingFileSystemEntry[]> {
+    const prefix = `${path.replace(/\/+$/, '')}/`;
+
+    return Array.from(this.files.entries())
+      .filter(([filePath]) => filePath.startsWith(prefix))
+      .map(([filePath, file]) => ({
+        name: filePath.slice(prefix.length),
+        path: filePath,
+        size: file.contents.length,
+        mtimeMs: file.mtimeMs,
+      }));
+  }
+
+  async unlink(path: string) {
+    this.files.delete(path);
   }
 
   has(path: string) {
@@ -41,7 +82,14 @@ class MemoryFS implements LoggingFileSystemAdapter {
       throw new Error(`File not found: ${path}`);
     }
 
-    return value;
+    return value.contents;
+  }
+
+  seedFile(path: string, contents: string, mtimeMs = this.clock++) {
+    this.files.set(path, {
+      contents: Buffer.from(contents),
+      mtimeMs,
+    });
   }
 
   listPaths() {
@@ -122,6 +170,103 @@ describe('rolling zip log writer', () => {
       'line-03\n',
     ]);
   });
+
+  it('prunes the oldest archived zip files before opening a new log file', async () => {
+    const fs = new MemoryFS();
+    fs.seedFile('/applogs/test-log-older.zip', '123', 1);
+    fs.seedFile('/applogs/test-log-newer.zip', '456', 2);
+
+    const writer = new RollingZipLogWriter({
+      fs,
+      rootDir: '/applogs',
+      archivePrefix: 'test-log',
+      maxArchivedBytes: 5,
+      now: makeNowSequence('2026-04-09T13:00:00.000Z'),
+    });
+
+    await writer.writeLine('line-01\n');
+
+    expect(fs.has('/applogs/test-log-older.zip')).toBe(false);
+    expect(fs.has('/applogs/test-log-newer.zip')).toBe(true);
+    expect(fs.listPaths().some(path => path.endsWith('.zip.partial'))).toBe(
+      true,
+    );
+  });
+
+  it('reuses the latest finalized zip and keeps appending to the recent log file', async () => {
+    const fs = new MemoryFS();
+    const seedWriter = new RollingZipLogWriter({
+      fs,
+      rootDir: '/applogs',
+      archivePrefix: 'test-log',
+      maxEntryBytes: 64,
+      now: makeNowSequence(
+        '2026-04-09T14:00:00.000Z',
+        '2026-04-09T14:00:00.001Z',
+      ),
+    });
+
+    await seedWriter.writeLine('line-01\n');
+    const seedArchivePath = await seedWriter.finalizeArchive();
+
+    const writer = new RollingZipLogWriter({
+      fs,
+      rootDir: '/applogs',
+      archivePrefix: 'test-log',
+      maxEntryBytes: 64,
+      now: makeNowSequence(
+        '2026-04-09T14:05:00.000Z',
+        '2026-04-09T14:05:00.001Z',
+      ),
+    });
+
+    await writer.writeLine('line-02\n');
+    const archivePath = await writer.finalizeArchive();
+
+    expect(archivePath).toBe(seedArchivePath);
+
+    const entries = readArchiveEntries(fs, archivePath as string);
+    expect(Object.keys(entries)).toHaveLength(1);
+    expect(Object.values(entries)).toEqual(['line-01\nline-02\n']);
+  });
+
+  it('reuses the latest finalized zip and opens a new log file when the recent one is full', async () => {
+    const fs = new MemoryFS();
+    const seedWriter = new RollingZipLogWriter({
+      fs,
+      rootDir: '/applogs',
+      archivePrefix: 'test-log',
+      maxEntryBytes: 6,
+      now: makeNowSequence(
+        '2026-04-09T14:10:00.000Z',
+        '2026-04-09T14:10:00.001Z',
+      ),
+    });
+
+    await seedWriter.writeLine('12345\n');
+    const seedArchivePath = await seedWriter.finalizeArchive();
+
+    const writer = new RollingZipLogWriter({
+      fs,
+      rootDir: '/applogs',
+      archivePrefix: 'test-log',
+      maxEntryBytes: 6,
+      now: makeNowSequence(
+        '2026-04-09T14:11:00.000Z',
+        '2026-04-09T14:11:00.001Z',
+        '2026-04-09T14:11:00.002Z',
+      ),
+    });
+
+    await writer.writeLine('xx\n');
+    const archivePath = await writer.finalizeArchive();
+
+    expect(archivePath).toBe(seedArchivePath);
+
+    const entries = readArchiveEntries(fs, archivePath as string);
+    expect(Object.keys(entries)).toHaveLength(2);
+    expect(Object.values(entries)).toEqual(['12345\n', 'xx\n']);
+  });
 });
 
 describe('app logger', () => {
@@ -195,5 +340,78 @@ describe('app logger', () => {
     expect(archiveBody).toContain('"accessToken":"*******************"');
     expect(inMemoryEntries).toHaveLength(1);
     expect(inMemoryEntries[0]?.message).toContain('login payload');
+  });
+
+  it('captures console output only after console capture is enabled', async () => {
+    const fs = new MemoryFS();
+    let writeEnabled = false;
+    let consoleCaptureEnabled = false;
+    const writer = new RollingZipLogWriter({
+      fs,
+      rootDir: '/applogs',
+      archivePrefix: 'app-log',
+      now: makeNowSequence(
+        '2026-04-09T12:40:00.000Z',
+        '2026-04-09T12:40:00.100Z',
+        '2026-04-09T12:40:00.200Z',
+      ),
+    });
+    const originalConsole = {
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      log: jest.fn(),
+      debug: jest.fn(),
+      trace: jest.fn(),
+      time: jest.fn(),
+      timeLog: jest.fn(),
+      timeEnd: jest.fn(),
+      assert: jest.fn(),
+    };
+    const consoleTarget = {
+      ...originalConsole,
+    };
+    const logger = new AppLogger({
+      runtimeEnv: 'regression',
+      platform: 'ios',
+      writer,
+      shouldWriteToFile: () => writeEnabled,
+      shouldCaptureConsole: () => consoleCaptureEnabled,
+      sessionId: 'session-console-test',
+      originalConsole,
+    });
+
+    logger.installConsoleCapture(consoleTarget);
+
+    consoleTarget.log('console before enable', { visible: true });
+    await logger.flush();
+
+    expect(originalConsole.log).toHaveBeenNthCalledWith(
+      1,
+      'console before enable',
+      { visible: true },
+    );
+    expect(fs.listPaths().filter(path => path.endsWith('.zip'))).toHaveLength(
+      0,
+    );
+
+    writeEnabled = true;
+    consoleCaptureEnabled = true;
+
+    consoleTarget.log('console after enable', {
+      accessToken: logger.mask('secret-access-token'),
+    });
+
+    await logger.finalizeArchive();
+
+    const savedArchivePath = fs.listPaths().find(path => path.endsWith('.zip'));
+    expect(savedArchivePath).toBeDefined();
+
+    const entries = readArchiveEntries(fs, savedArchivePath as string);
+    const archiveBody = Object.values(entries).join('\n');
+
+    expect(archiveBody).toContain('console after enable');
+    expect(archiveBody).not.toContain('console before enable');
+    expect(archiveBody).not.toContain('secret-access-token');
   });
 });

--- a/apps/mobile/src/utils/logging/__tests__/logger.test.ts
+++ b/apps/mobile/src/utils/logging/__tests__/logger.test.ts
@@ -1,0 +1,199 @@
+import { strFromU8, unzipSync } from 'fflate';
+import { AppLogger } from '../core';
+import { MaskedLogValue, serializeLogValue } from '../format';
+import {
+  LoggingFileSystemAdapter,
+  RollingZipLogWriter,
+} from '../rollingZipWriter';
+
+class MemoryFS implements LoggingFileSystemAdapter {
+  private readonly files = new Map<string, Buffer>();
+
+  async mkdir(_path: string) {}
+
+  async writeFile(path: string, contents: string, encoding: 'base64') {
+    this.files.set(path, Buffer.from(contents, encoding));
+  }
+
+  async appendFile(path: string, contents: string, encoding: 'base64') {
+    const current = this.files.get(path) || Buffer.alloc(0);
+    const next = Buffer.concat([current, Buffer.from(contents, encoding)]);
+    this.files.set(path, next);
+  }
+
+  async moveFile(from: string, to: string) {
+    const value = this.files.get(from);
+    if (!value) {
+      throw new Error(`File not found: ${from}`);
+    }
+
+    this.files.set(to, value);
+    this.files.delete(from);
+  }
+
+  has(path: string) {
+    return this.files.has(path);
+  }
+
+  read(path: string) {
+    const value = this.files.get(path);
+    if (!value) {
+      throw new Error(`File not found: ${path}`);
+    }
+
+    return value;
+  }
+
+  listPaths() {
+    return Array.from(this.files.keys()).sort();
+  }
+}
+
+function makeNowSequence(...values: string[]) {
+  let index = 0;
+
+  return () => new Date(values[Math.min(index++, values.length - 1)]);
+}
+
+function readArchiveEntries(fs: MemoryFS, archivePath: string) {
+  const archive = unzipSync(new Uint8Array(fs.read(archivePath)));
+
+  return Object.fromEntries(
+    Object.entries(archive)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, value]) => [key, strFromU8(value)]),
+  );
+}
+
+describe('logging format', () => {
+  it('masks nested values and keeps circular references safe', () => {
+    const circular: Record<string, unknown> = { visible: 1 };
+    circular.self = circular;
+
+    expect(
+      serializeLogValue(
+        new MaskedLogValue({
+          secret: 'token-123',
+          nested: ['alpha', { beta: 'gamma' }],
+        }),
+      ),
+    ).toEqual({
+      secret: '*********',
+      nested: ['*****', { beta: '*****' }],
+    });
+
+    expect(serializeLogValue(circular)).toEqual({
+      visible: 1,
+      self: '[Circular]',
+    });
+  });
+});
+
+describe('rolling zip log writer', () => {
+  it('rotates entries at the configured max size and finalizes a zip file', async () => {
+    const fs = new MemoryFS();
+    const writer = new RollingZipLogWriter({
+      fs,
+      rootDir: '/applogs',
+      archivePrefix: 'test-log',
+      maxEntryBytes: 18,
+      now: makeNowSequence(
+        '2026-04-09T12:00:00.000Z',
+        '2026-04-09T12:00:00.001Z',
+        '2026-04-09T12:00:00.002Z',
+        '2026-04-09T12:00:00.003Z',
+      ),
+    });
+
+    await writer.writeLine('line-01\n');
+    await writer.writeLine('line-02-is-long\n');
+    await writer.writeLine('line-03\n');
+
+    const archivePath = await writer.finalizeArchive();
+
+    expect(archivePath).not.toBeNull();
+    expect(fs.has(archivePath as string)).toBe(true);
+
+    const entries = readArchiveEntries(fs, archivePath as string);
+    expect(Object.keys(entries)).toHaveLength(3);
+    expect(Object.values(entries)).toEqual([
+      'line-01\n',
+      'line-02-is-long\n',
+      'line-03\n',
+    ]);
+  });
+});
+
+describe('app logger', () => {
+  it('writes masked records and closes the archive when policy turns off', async () => {
+    const fs = new MemoryFS();
+    let enabled = true;
+    const inMemoryEntries: { message: string; data: unknown }[] = [];
+    const writer = new RollingZipLogWriter({
+      fs,
+      rootDir: '/applogs',
+      archivePrefix: 'app-log',
+      now: makeNowSequence(
+        '2026-04-09T12:30:00.000Z',
+        '2026-04-09T12:30:00.100Z',
+        '2026-04-09T12:30:00.200Z',
+      ),
+    });
+    const logger = new AppLogger({
+      runtimeEnv: 'regression',
+      platform: 'ios',
+      writer,
+      shouldWriteToFile: () => enabled,
+      sessionId: 'session-test',
+      captureInMemory: true,
+      onInMemoryLog(entry) {
+        inMemoryEntries.push({
+          message: entry.message,
+          data: entry.data,
+        });
+      },
+      originalConsole: {
+        info: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+        log: jest.fn(),
+        debug: jest.fn(),
+        trace: jest.fn(),
+        time: jest.fn(),
+        timeLog: jest.fn(),
+        timeEnd: jest.fn(),
+        assert: jest.fn(),
+      },
+    });
+
+    logger.info('login payload', {
+      accessToken: logger.mask('secret-access-token'),
+      nested: {
+        privateKey: logger.mask('very-secret-key'),
+      },
+    });
+
+    await logger.flush();
+
+    enabled = false;
+    const archivePath = await logger.handlePolicyChange();
+
+    expect(archivePath).toBeUndefined();
+
+    const finalizedPath = writer.getState().activeArchivePath;
+    expect(finalizedPath).toBeNull();
+
+    const savedArchivePath = fs.listPaths().find(path => path.endsWith('.zip'));
+    expect(savedArchivePath).toBeDefined();
+
+    const entries = readArchiveEntries(fs, savedArchivePath as string);
+    const archiveBody = Object.values(entries).join('\n');
+
+    expect(archiveBody).toContain('@rabby-log/v1');
+    expect(archiveBody).not.toContain('secret-access-token');
+    expect(archiveBody).not.toContain('very-secret-key');
+    expect(archiveBody).toContain('"accessToken":"*******************"');
+    expect(inMemoryEntries).toHaveLength(1);
+    expect(inMemoryEntries[0]?.message).toContain('login payload');
+  });
+});

--- a/apps/mobile/src/utils/logging/__tests__/policy.test.ts
+++ b/apps/mobile/src/utils/logging/__tests__/policy.test.ts
@@ -1,0 +1,92 @@
+import {
+  APP_FILE_LOGGING_ONLINE_SWITCH,
+  getDefaultLocalAppFileLoggingEnabled,
+  resolveAppFileLoggingEnabled,
+  resolveConsoleCaptureEnabled,
+} from '../policy';
+
+describe('logging policy', () => {
+  it('uses development-on and regression-off as the local defaults', () => {
+    expect(getDefaultLocalAppFileLoggingEnabled('development')).toBe(true);
+    expect(getDefaultLocalAppFileLoggingEnabled('regression')).toBe(false);
+    expect(getDefaultLocalAppFileLoggingEnabled('production')).toBe(false);
+  });
+
+  it('uses the local switch in development', () => {
+    expect(
+      resolveAppFileLoggingEnabled({
+        runtimeEnv: 'development',
+        localEnabled: true,
+        prodOnlineEnabled: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      resolveAppFileLoggingEnabled({
+        runtimeEnv: 'development',
+        localEnabled: false,
+        prodOnlineEnabled: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('uses the local switch in regression', () => {
+    expect(
+      resolveAppFileLoggingEnabled({
+        runtimeEnv: 'regression',
+        localEnabled: true,
+        prodOnlineEnabled: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      resolveAppFileLoggingEnabled({
+        runtimeEnv: 'regression',
+        localEnabled: false,
+        prodOnlineEnabled: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('uses the online config switch in production', () => {
+    expect(
+      resolveAppFileLoggingEnabled({
+        runtimeEnv: 'production',
+        localEnabled: true,
+        prodOnlineEnabled: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      resolveAppFileLoggingEnabled({
+        runtimeEnv: 'production',
+        localEnabled: false,
+        prodOnlineEnabled: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('uses the same policy to decide whether console capture is active', () => {
+    expect(
+      resolveConsoleCaptureEnabled({
+        runtimeEnv: 'development',
+        localEnabled: true,
+        prodOnlineEnabled: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      resolveConsoleCaptureEnabled({
+        runtimeEnv: 'regression',
+        localEnabled: false,
+        prodOnlineEnabled: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps the online config switch name stable', () => {
+    expect(APP_FILE_LOGGING_ONLINE_SWITCH).toBe(
+      '20260410.enable_app_file_logging',
+    );
+  });
+});

--- a/apps/mobile/src/utils/logging/core.ts
+++ b/apps/mobile/src/utils/logging/core.ts
@@ -1,0 +1,533 @@
+import {
+  AppLogLevel,
+  buildInlineMessageFromArgs,
+  createDefaultSessionId,
+  formatLogLine,
+  FormattedLogRecord,
+  MaskedLogValue,
+  SerializableLogValue,
+  serializeLogArgs,
+} from './format';
+import { RollingZipLogWriter, RollingZipWriterState } from './rollingZipWriter';
+
+type ConsoleLike = {
+  log?: (...args: unknown[]) => void;
+  info?: (...args: unknown[]) => void;
+  warn?: (...args: unknown[]) => void;
+  error?: (...args: unknown[]) => void;
+  debug?: (...args: unknown[]) => void;
+  trace?: (...args: unknown[]) => void;
+  time?: (label?: string) => void;
+  timeLog?: (label?: string, ...args: unknown[]) => void;
+  timeEnd?: (label?: string) => void;
+  assert?: (condition?: boolean, ...args: unknown[]) => void;
+};
+
+type BoundConsoleLike = {
+  log: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+  debug: (...args: unknown[]) => void;
+  trace: (...args: unknown[]) => void;
+  time: (label?: string) => void;
+  timeLog: (label?: string, ...args: unknown[]) => void;
+  timeEnd: (label?: string) => void;
+  assert: (condition?: boolean, ...args: unknown[]) => void;
+};
+
+type InMemoryLogLevel = 'info' | 'warn' | 'error' | 'debug';
+
+type AppLoggerOptions = {
+  runtimeEnv: string;
+  platform?: string;
+  writer: RollingZipLogWriter;
+  shouldWriteToFile: () => boolean;
+  originalConsole?: ConsoleLike;
+  sessionId?: string;
+  now?: () => Date;
+  captureInMemory?: boolean;
+  onInMemoryLog?: (entry: {
+    level: InMemoryLogLevel;
+    message: string;
+    data?: SerializableLogValue;
+  }) => void;
+};
+
+type LoggerState = RollingZipWriterState & {
+  runtimeEnv: string;
+  sessionId: string;
+  effectiveFileLoggingEnabled: boolean;
+};
+
+const noop = (..._args: unknown[]) => {};
+
+function bindConsoleMethod(
+  thisArg: ConsoleLike,
+  value: ConsoleLike[keyof ConsoleLike] | undefined,
+): (...args: unknown[]) => void {
+  if (typeof value !== 'function') {
+    return noop;
+  }
+
+  return value.bind(thisArg) as (...args: unknown[]) => void;
+}
+
+function hasMaskedValue(
+  input: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+  depth = 0,
+): boolean {
+  if (input instanceof MaskedLogValue) {
+    return true;
+  }
+
+  if (!input || typeof input !== 'object') {
+    return false;
+  }
+
+  if (seen.has(input)) {
+    return false;
+  }
+  seen.add(input);
+
+  if (depth >= 4) {
+    return false;
+  }
+
+  if (Array.isArray(input)) {
+    return input.some(item => hasMaskedValue(item, seen, depth + 1));
+  }
+
+  return Object.values(input as Record<string, unknown>).some(item =>
+    hasMaskedValue(item, seen, depth + 1),
+  );
+}
+
+function mapToInMemoryLevel(level: AppLogLevel): InMemoryLogLevel {
+  switch (level) {
+    case 'warn':
+      return 'warn';
+    case 'error':
+      return 'error';
+    case 'debug':
+    case 'trace':
+      return 'debug';
+    default:
+      return 'info';
+  }
+}
+
+export class AppLogger {
+  readonly mask = <T>(value: T) => new MaskedLogValue(value);
+
+  private readonly writer: RollingZipLogWriter;
+  private readonly runtimeEnv: string;
+  private readonly platform?: string;
+  private readonly shouldWriteToFile: () => boolean;
+  private readonly now: () => Date;
+  private readonly captureInMemory: boolean;
+  private readonly onInMemoryLog?: AppLoggerOptions['onInMemoryLog'];
+  private readonly originalConsole: BoundConsoleLike;
+
+  private sequence = 0;
+  private writeQueue = Promise.resolve<void>(undefined);
+  private lastWriteEnabled: boolean;
+  private readonly sessionId: string;
+  private consoleCaptureInstalled = false;
+  private readonly timers = new Map<string, number>();
+
+  constructor(options: AppLoggerOptions) {
+    this.writer = options.writer;
+    this.runtimeEnv = options.runtimeEnv;
+    this.platform = options.platform;
+    this.shouldWriteToFile = options.shouldWriteToFile;
+    this.now = options.now || (() => new Date());
+    this.captureInMemory = !!options.captureInMemory;
+    this.onInMemoryLog = options.onInMemoryLog;
+    this.lastWriteEnabled = this.shouldWriteToFile();
+    this.sessionId = options.sessionId || createDefaultSessionId(this.now());
+
+    const consoleLike = options.originalConsole || console;
+    this.originalConsole = {
+      log: bindConsoleMethod(consoleLike, consoleLike.log),
+      info: bindConsoleMethod(consoleLike, consoleLike.info),
+      warn: bindConsoleMethod(consoleLike, consoleLike.warn),
+      error: bindConsoleMethod(consoleLike, consoleLike.error),
+      debug: bindConsoleMethod(consoleLike, consoleLike.debug),
+      trace: bindConsoleMethod(consoleLike, consoleLike.trace),
+      time: bindConsoleMethod(consoleLike, consoleLike.time) as (
+        label?: string,
+      ) => void,
+      timeLog: bindConsoleMethod(consoleLike, consoleLike.timeLog) as (
+        label?: string,
+        ...args: unknown[]
+      ) => void,
+      timeEnd: bindConsoleMethod(consoleLike, consoleLike.timeEnd) as (
+        label?: string,
+      ) => void,
+      assert: bindConsoleMethod(consoleLike, consoleLike.assert) as (
+        condition?: boolean,
+        ...args: unknown[]
+      ) => void,
+    };
+  }
+
+  private enqueue<T>(task: () => Promise<T>) {
+    const run = this.writeQueue.then(task);
+
+    this.writeQueue = run
+      .then(() => undefined)
+      .catch(error => {
+        this.originalConsole.error(
+          '[AppLogger] background write failed',
+          error,
+        );
+      });
+
+    return run;
+  }
+
+  private buildRecord({
+    level,
+    source,
+    method,
+    args,
+    meta,
+  }: {
+    level: AppLogLevel;
+    source: string;
+    method: string;
+    args: unknown[];
+    meta?: Record<string, unknown>;
+  }) {
+    const serializedArgs = serializeLogArgs(args);
+    const serializedMeta =
+      meta && Object.keys(meta).length
+        ? serializeLogArgs([meta])[0]
+        : undefined;
+    const record: FormattedLogRecord = {
+      timestamp: this.now().toISOString(),
+      level,
+      source,
+      method,
+      env: this.runtimeEnv,
+      sessionId: this.sessionId,
+      sequence: ++this.sequence,
+      platform: this.platform,
+      body: {
+        message: buildInlineMessageFromArgs(serializedArgs),
+        args: serializedArgs,
+        ...(serializedMeta ? { meta: serializedMeta } : {}),
+      },
+    };
+
+    return {
+      record,
+      serializedArgs,
+    };
+  }
+
+  private captureRecord(
+    level: AppLogLevel,
+    source: string,
+    method: string,
+    args: unknown[],
+    meta?: Record<string, unknown>,
+  ) {
+    const { record, serializedArgs } = this.buildRecord({
+      level,
+      source,
+      method,
+      args,
+      meta,
+    });
+
+    if (this.captureInMemory && this.onInMemoryLog) {
+      const extraData =
+        record.body.meta ||
+        (record.body.args.length > 1 ? record.body.args : record.body.args[0]);
+      this.onInMemoryLog({
+        level: mapToInMemoryLevel(level),
+        message: record.body.message || `[${method}]`,
+        data: extraData,
+      });
+    }
+
+    const shouldWrite = this.shouldWriteToFile();
+    if (this.lastWriteEnabled && !shouldWrite) {
+      this.enqueue(async () => {
+        await this.writer.finalizeArchive();
+      }).catch(noop);
+    }
+    this.lastWriteEnabled = shouldWrite;
+
+    if (shouldWrite) {
+      const line = formatLogLine(record);
+      this.enqueue(async () => {
+        await this.writer.writeLine(line);
+      }).catch(noop);
+    }
+
+    return serializedArgs;
+  }
+
+  private getConsoleEchoArgs(
+    rawArgs: unknown[],
+    serializedArgs: SerializableLogValue[],
+    sanitizeAll: boolean,
+  ) {
+    if (sanitizeAll || rawArgs.some(item => hasMaskedValue(item))) {
+      return serializedArgs as unknown[];
+    }
+
+    return rawArgs;
+  }
+
+  log(...args: unknown[]) {
+    const serializedArgs = this.captureRecord('log', 'logger', 'log', args);
+    this.originalConsole.log(...(serializedArgs as unknown[]));
+  }
+
+  info(...args: unknown[]) {
+    const serializedArgs = this.captureRecord('info', 'logger', 'info', args);
+    this.originalConsole.info(...(serializedArgs as unknown[]));
+  }
+
+  warn(...args: unknown[]) {
+    const serializedArgs = this.captureRecord('warn', 'logger', 'warn', args);
+    this.originalConsole.warn(...(serializedArgs as unknown[]));
+  }
+
+  error(...args: unknown[]) {
+    const serializedArgs = this.captureRecord('error', 'logger', 'error', args);
+    this.originalConsole.error(...(serializedArgs as unknown[]));
+  }
+
+  debug(...args: unknown[]) {
+    const serializedArgs = this.captureRecord('debug', 'logger', 'debug', args);
+    this.originalConsole.debug(...(serializedArgs as unknown[]));
+  }
+
+  trace(...args: unknown[]) {
+    const traceStack = new Error('[logger.trace]').stack;
+    const serializedArgs = this.captureRecord(
+      'trace',
+      'logger',
+      'trace',
+      args,
+      {
+        traceStack,
+      },
+    );
+    this.originalConsole.trace(...(serializedArgs as unknown[]));
+  }
+
+  installConsoleCapture(consoleTarget: ConsoleLike = console) {
+    if (this.consoleCaptureInstalled) {
+      return;
+    }
+
+    this.consoleCaptureInstalled = true;
+
+    consoleTarget.log = (...args: unknown[]) => {
+      const serializedArgs = this.captureRecord('log', 'console', 'log', args);
+      this.originalConsole.log(
+        ...this.getConsoleEchoArgs(args, serializedArgs, false),
+      );
+    };
+
+    consoleTarget.info = (...args: unknown[]) => {
+      const serializedArgs = this.captureRecord(
+        'info',
+        'console',
+        'info',
+        args,
+      );
+      this.originalConsole.info(
+        ...this.getConsoleEchoArgs(args, serializedArgs, false),
+      );
+    };
+
+    consoleTarget.warn = (...args: unknown[]) => {
+      const serializedArgs = this.captureRecord(
+        'warn',
+        'console',
+        'warn',
+        args,
+      );
+      this.originalConsole.warn(
+        ...this.getConsoleEchoArgs(args, serializedArgs, false),
+      );
+    };
+
+    consoleTarget.error = (...args: unknown[]) => {
+      const serializedArgs = this.captureRecord(
+        'error',
+        'console',
+        'error',
+        args,
+      );
+      this.originalConsole.error(
+        ...this.getConsoleEchoArgs(args, serializedArgs, false),
+      );
+    };
+
+    consoleTarget.debug = (...args: unknown[]) => {
+      const serializedArgs = this.captureRecord(
+        'debug',
+        'console',
+        'debug',
+        args,
+      );
+      this.originalConsole.debug(
+        ...this.getConsoleEchoArgs(args, serializedArgs, false),
+      );
+    };
+
+    consoleTarget.trace = (...args: unknown[]) => {
+      const traceStack = new Error('[console.trace]').stack;
+      const serializedArgs = this.captureRecord(
+        'trace',
+        'console',
+        'trace',
+        args,
+        { traceStack },
+      );
+      this.originalConsole.trace(
+        ...this.getConsoleEchoArgs(args, serializedArgs, false),
+      );
+    };
+
+    consoleTarget.time = (label?: string) => {
+      const timerLabel = label || 'default';
+      this.timers.set(timerLabel, this.now().getTime());
+
+      this.captureRecord(
+        'debug',
+        'console',
+        'time',
+        [`[timer:start] ${timerLabel}`],
+        {
+          label: timerLabel,
+        },
+      );
+      this.originalConsole.time(timerLabel);
+    };
+
+    consoleTarget.timeLog = (label?: string, ...args: unknown[]) => {
+      const timerLabel = label || 'default';
+      const startedAt = this.timers.get(timerLabel);
+      const durationMs =
+        typeof startedAt === 'number' ? this.now().getTime() - startedAt : null;
+
+      const computedArgs = [
+        `${timerLabel}: ${durationMs ?? 'unknown'}ms`,
+        ...args,
+      ];
+      const serializedArgs = this.captureRecord(
+        'info',
+        'console',
+        'timeLog',
+        computedArgs,
+        {
+          label: timerLabel,
+          durationMs,
+        },
+      );
+
+      this.originalConsole.timeLog(
+        timerLabel,
+        ...this.getConsoleEchoArgs(computedArgs, serializedArgs, false).slice(
+          1,
+        ),
+      );
+    };
+
+    consoleTarget.timeEnd = (label?: string) => {
+      const timerLabel = label || 'default';
+      const startedAt = this.timers.get(timerLabel);
+      const durationMs =
+        typeof startedAt === 'number' ? this.now().getTime() - startedAt : null;
+
+      this.timers.delete(timerLabel);
+
+      const computedArgs = [`${timerLabel}: ${durationMs ?? 'unknown'}ms`];
+      const serializedArgs = this.captureRecord(
+        'info',
+        'console',
+        'timeEnd',
+        computedArgs,
+        {
+          label: timerLabel,
+          durationMs,
+        },
+      );
+
+      this.originalConsole.timeEnd(timerLabel);
+
+      if (!startedAt) {
+        this.originalConsole.info(...serializedArgs);
+      }
+    };
+
+    consoleTarget.assert = (condition?: boolean, ...args: unknown[]) => {
+      if (condition) {
+        this.originalConsole.assert(condition, ...args);
+        return;
+      }
+
+      const actualArgs = args.length ? args : ['Assertion failed'];
+      const serializedArgs = this.captureRecord(
+        'error',
+        'console',
+        'assert',
+        actualArgs,
+      );
+      this.originalConsole.assert(
+        false,
+        ...this.getConsoleEchoArgs(actualArgs, serializedArgs, false),
+      );
+    };
+  }
+
+  handlePolicyChange() {
+    const nextEnabled = this.shouldWriteToFile();
+    if (this.lastWriteEnabled && !nextEnabled) {
+      this.lastWriteEnabled = nextEnabled;
+      return this.enqueue(async () => {
+        await this.writer.finalizeArchive();
+      });
+    }
+
+    this.lastWriteEnabled = nextEnabled;
+    return Promise.resolve();
+  }
+
+  handleAppStateChange(nextState: string) {
+    if (nextState === 'active') {
+      return Promise.resolve(null);
+    }
+
+    return this.enqueue(async () => this.writer.finalizeArchive());
+  }
+
+  flush() {
+    return this.enqueue(async () => {
+      await this.writer.flush();
+    });
+  }
+
+  finalizeArchive() {
+    return this.enqueue(async () => this.writer.finalizeArchive());
+  }
+
+  getState(): LoggerState {
+    return {
+      ...this.writer.getState(),
+      runtimeEnv: this.runtimeEnv,
+      sessionId: this.sessionId,
+      effectiveFileLoggingEnabled: this.shouldWriteToFile(),
+    };
+  }
+}

--- a/apps/mobile/src/utils/logging/core.ts
+++ b/apps/mobile/src/utils/logging/core.ts
@@ -43,6 +43,7 @@ type AppLoggerOptions = {
   platform?: string;
   writer: RollingZipLogWriter;
   shouldWriteToFile: () => boolean;
+  shouldCaptureConsole?: () => boolean;
   originalConsole?: ConsoleLike;
   sessionId?: string;
   now?: () => Date;
@@ -58,6 +59,7 @@ type LoggerState = RollingZipWriterState & {
   runtimeEnv: string;
   sessionId: string;
   effectiveFileLoggingEnabled: boolean;
+  effectiveConsoleCaptureEnabled: boolean;
 };
 
 const noop = (..._args: unknown[]) => {};
@@ -125,6 +127,7 @@ export class AppLogger {
   private readonly runtimeEnv: string;
   private readonly platform?: string;
   private readonly shouldWriteToFile: () => boolean;
+  private readonly shouldCaptureConsole: () => boolean;
   private readonly now: () => Date;
   private readonly captureInMemory: boolean;
   private readonly onInMemoryLog?: AppLoggerOptions['onInMemoryLog'];
@@ -142,6 +145,8 @@ export class AppLogger {
     this.runtimeEnv = options.runtimeEnv;
     this.platform = options.platform;
     this.shouldWriteToFile = options.shouldWriteToFile;
+    this.shouldCaptureConsole =
+      options.shouldCaptureConsole || options.shouldWriteToFile;
     this.now = options.now || (() => new Date());
     this.captureInMemory = !!options.captureInMemory;
     this.onInMemoryLog = options.onInMemoryLog;
@@ -331,6 +336,11 @@ export class AppLogger {
     this.consoleCaptureInstalled = true;
 
     consoleTarget.log = (...args: unknown[]) => {
+      if (!this.shouldCaptureConsole()) {
+        this.originalConsole.log(...args);
+        return;
+      }
+
       const serializedArgs = this.captureRecord('log', 'console', 'log', args);
       this.originalConsole.log(
         ...this.getConsoleEchoArgs(args, serializedArgs, false),
@@ -338,6 +348,11 @@ export class AppLogger {
     };
 
     consoleTarget.info = (...args: unknown[]) => {
+      if (!this.shouldCaptureConsole()) {
+        this.originalConsole.info(...args);
+        return;
+      }
+
       const serializedArgs = this.captureRecord(
         'info',
         'console',
@@ -350,6 +365,11 @@ export class AppLogger {
     };
 
     consoleTarget.warn = (...args: unknown[]) => {
+      if (!this.shouldCaptureConsole()) {
+        this.originalConsole.warn(...args);
+        return;
+      }
+
       const serializedArgs = this.captureRecord(
         'warn',
         'console',
@@ -362,6 +382,11 @@ export class AppLogger {
     };
 
     consoleTarget.error = (...args: unknown[]) => {
+      if (!this.shouldCaptureConsole()) {
+        this.originalConsole.error(...args);
+        return;
+      }
+
       const serializedArgs = this.captureRecord(
         'error',
         'console',
@@ -374,6 +399,11 @@ export class AppLogger {
     };
 
     consoleTarget.debug = (...args: unknown[]) => {
+      if (!this.shouldCaptureConsole()) {
+        this.originalConsole.debug(...args);
+        return;
+      }
+
       const serializedArgs = this.captureRecord(
         'debug',
         'console',
@@ -386,6 +416,11 @@ export class AppLogger {
     };
 
     consoleTarget.trace = (...args: unknown[]) => {
+      if (!this.shouldCaptureConsole()) {
+        this.originalConsole.trace(...args);
+        return;
+      }
+
       const traceStack = new Error('[console.trace]').stack;
       const serializedArgs = this.captureRecord(
         'trace',
@@ -401,6 +436,12 @@ export class AppLogger {
 
     consoleTarget.time = (label?: string) => {
       const timerLabel = label || 'default';
+
+      if (!this.shouldCaptureConsole()) {
+        this.originalConsole.time(timerLabel);
+        return;
+      }
+
       this.timers.set(timerLabel, this.now().getTime());
 
       this.captureRecord(
@@ -417,6 +458,12 @@ export class AppLogger {
 
     consoleTarget.timeLog = (label?: string, ...args: unknown[]) => {
       const timerLabel = label || 'default';
+
+      if (!this.shouldCaptureConsole()) {
+        this.originalConsole.timeLog(timerLabel, ...args);
+        return;
+      }
+
       const startedAt = this.timers.get(timerLabel);
       const durationMs =
         typeof startedAt === 'number' ? this.now().getTime() - startedAt : null;
@@ -446,6 +493,13 @@ export class AppLogger {
 
     consoleTarget.timeEnd = (label?: string) => {
       const timerLabel = label || 'default';
+
+      if (!this.shouldCaptureConsole()) {
+        this.timers.delete(timerLabel);
+        this.originalConsole.timeEnd(timerLabel);
+        return;
+      }
+
       const startedAt = this.timers.get(timerLabel);
       const durationMs =
         typeof startedAt === 'number' ? this.now().getTime() - startedAt : null;
@@ -472,7 +526,7 @@ export class AppLogger {
     };
 
     consoleTarget.assert = (condition?: boolean, ...args: unknown[]) => {
-      if (condition) {
+      if (!this.shouldCaptureConsole() || condition) {
         this.originalConsole.assert(condition, ...args);
         return;
       }
@@ -528,6 +582,7 @@ export class AppLogger {
       runtimeEnv: this.runtimeEnv,
       sessionId: this.sessionId,
       effectiveFileLoggingEnabled: this.shouldWriteToFile(),
+      effectiveConsoleCaptureEnabled: this.shouldCaptureConsole(),
     };
   }
 }

--- a/apps/mobile/src/utils/logging/format.ts
+++ b/apps/mobile/src/utils/logging/format.ts
@@ -1,0 +1,407 @@
+export type AppLogLevel = 'log' | 'info' | 'warn' | 'error' | 'debug' | 'trace';
+
+export class MaskedLogValue<T = unknown> {
+  constructor(readonly value: T) {}
+}
+
+export type SerializableLogValue =
+  | null
+  | boolean
+  | number
+  | string
+  | SerializableLogValue[]
+  | { [key: string]: SerializableLogValue };
+
+export type FormattedLogRecord = {
+  timestamp: string;
+  level: AppLogLevel;
+  source: string;
+  method: string;
+  env: string;
+  sessionId: string;
+  sequence: number;
+  platform?: string;
+  body: {
+    message: string;
+    args: SerializableLogValue[];
+    meta?: SerializableLogValue;
+  };
+};
+
+const FILE_TIMESTAMP_SEPARATOR = '_';
+const HEADER_PREFIX = '@rabby-log/v1';
+
+function pad2(value: number) {
+  return String(value).padStart(2, '0');
+}
+
+function pad3(value: number) {
+  return String(value).padStart(3, '0');
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function sanitizeHeaderToken(value: string | number | boolean | undefined) {
+  return String(value ?? '').replace(/\s+/g, '_');
+}
+
+function truncateText(value: string, maxLen = 500) {
+  if (value.length <= maxLen) {
+    return value;
+  }
+
+  return `${value.slice(0, maxLen - 3)}...`;
+}
+
+function maskString(value: string) {
+  if (!value) {
+    return '***';
+  }
+
+  return '*'.repeat(Math.min(Math.max(value.length, 3), 32));
+}
+
+function maskValue(
+  value: unknown,
+  seen: WeakSet<object>,
+  depth: number,
+  maxDepth: number,
+): SerializableLogValue {
+  if (
+    value === null ||
+    value === undefined ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'bigint' ||
+    typeof value === 'symbol' ||
+    typeof value === 'function'
+  ) {
+    return '***';
+  }
+
+  if (typeof value === 'string') {
+    return maskString(value);
+  }
+
+  if (value instanceof Date) {
+    return '***';
+  }
+
+  if (value instanceof Error) {
+    const result: Record<string, SerializableLogValue> = {
+      $type: value.name || 'Error',
+      message: '***',
+    };
+
+    if (value.stack) {
+      result.stack = '***';
+    }
+
+    if ('cause' in value && value.cause !== undefined) {
+      result.cause = maskValue(value.cause, seen, depth + 1, maxDepth);
+    }
+
+    Object.keys(value).forEach(key => {
+      if (key === 'message' || key === 'stack' || key === 'cause') {
+        return;
+      }
+      result[key] = maskValue(
+        (value as unknown as Record<string, unknown>)[key],
+        seen,
+        depth + 1,
+        maxDepth,
+      );
+    });
+
+    return result;
+  }
+
+  if (Array.isArray(value)) {
+    if (depth >= maxDepth) {
+      return `***[${value.length}]`;
+    }
+
+    return value.map(item => maskValue(item, seen, depth + 1, maxDepth));
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    return `***[${value.constructor.name}]`;
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return '***[ArrayBuffer]';
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value)) {
+      return '[Circular]';
+    }
+    seen.add(value);
+
+    if (depth >= maxDepth) {
+      return `***[${value.constructor?.name || 'Object'}]`;
+    }
+
+    if (!isPlainObject(value)) {
+      return {
+        $type: value.constructor?.name || 'Object',
+      };
+    }
+
+    const output: Record<string, SerializableLogValue> = {};
+    Object.keys(value).forEach(key => {
+      output[key] = maskValue(
+        (value as Record<string, unknown>)[key],
+        seen,
+        depth + 1,
+        maxDepth,
+      );
+    });
+    return output;
+  }
+
+  return '***';
+}
+
+function serializeError(
+  error: Error,
+  seen: WeakSet<object>,
+  depth: number,
+  maxDepth: number,
+) {
+  const result: Record<string, SerializableLogValue> = {
+    $type: error.name || 'Error',
+    message: error.message,
+  };
+
+  if (error.stack) {
+    result.stack = error.stack;
+  }
+
+  if ('cause' in error && error.cause !== undefined) {
+    result.cause = serializeLogValue(error.cause, seen, depth + 1, maxDepth);
+  }
+
+  Object.keys(error).forEach(key => {
+    if (key === 'message' || key === 'stack' || key === 'cause') {
+      return;
+    }
+
+    result[key] = serializeLogValue(
+      (error as unknown as Record<string, unknown>)[key],
+      seen,
+      depth + 1,
+      maxDepth,
+    );
+  });
+
+  return result;
+}
+
+export function serializeLogValue(
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+  depth = 0,
+  maxDepth = 6,
+): SerializableLogValue {
+  if (value instanceof MaskedLogValue) {
+    return maskValue(value.value, seen, depth, maxDepth);
+  }
+
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    if (Number.isNaN(value)) {
+      return '[NaN]';
+    }
+
+    if (!Number.isFinite(value)) {
+      return String(value);
+    }
+
+    return value;
+  }
+
+  if (typeof value === 'undefined') {
+    return '[undefined]';
+  }
+
+  if (typeof value === 'bigint') {
+    return `${value.toString()}n`;
+  }
+
+  if (typeof value === 'symbol') {
+    return value.toString();
+  }
+
+  if (typeof value === 'function') {
+    return `[Function ${value.name || 'anonymous'}]`;
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime())
+      ? '[Invalid Date]'
+      : value.toISOString();
+  }
+
+  if (value instanceof Error) {
+    return serializeError(value, seen, depth, maxDepth);
+  }
+
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      return '[Circular]';
+    }
+    seen.add(value);
+
+    if (depth >= maxDepth) {
+      return `[Array(${value.length})]`;
+    }
+
+    return value.map(item =>
+      serializeLogValue(item, seen, depth + 1, maxDepth),
+    );
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    return `[${value.constructor.name}(${value.byteLength})]`;
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return `[ArrayBuffer(${value.byteLength})]`;
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value)) {
+      return '[Circular]';
+    }
+    seen.add(value);
+
+    if (depth >= maxDepth) {
+      return `[${value.constructor?.name || 'Object'}]`;
+    }
+
+    if (!isPlainObject(value)) {
+      const output: Record<string, SerializableLogValue> = {
+        $type: value.constructor?.name || 'Object',
+      };
+
+      Object.keys(value as Record<string, unknown>).forEach(key => {
+        output[key] = serializeLogValue(
+          (value as Record<string, unknown>)[key],
+          seen,
+          depth + 1,
+          maxDepth,
+        );
+      });
+
+      return output;
+    }
+
+    const output: Record<string, SerializableLogValue> = {};
+    Object.keys(value).forEach(key => {
+      output[key] = serializeLogValue(
+        (value as Record<string, unknown>)[key],
+        seen,
+        depth + 1,
+        maxDepth,
+      );
+    });
+
+    return output;
+  }
+
+  return String(value);
+}
+
+function stringifyForInlineText(value: SerializableLogValue) {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (
+    value === null ||
+    typeof value === 'boolean' ||
+    typeof value === 'number'
+  ) {
+    return String(value);
+  }
+
+  return JSON.stringify(value);
+}
+
+export function buildInlineMessageFromArgs(args: SerializableLogValue[]) {
+  if (!args.length) {
+    return '';
+  }
+
+  return truncateText(
+    args
+      .map(item => stringifyForInlineText(item))
+      .filter(Boolean)
+      .join(' '),
+  );
+}
+
+export function serializeLogArgs(args: unknown[]) {
+  return args.map(item => serializeLogValue(item));
+}
+
+export function formatLogLine(record: FormattedLogRecord) {
+  const header = [
+    HEADER_PREFIX,
+    `ts=${sanitizeHeaderToken(record.timestamp)}`,
+    `lvl=${sanitizeHeaderToken(record.level)}`,
+    `src=${sanitizeHeaderToken(record.source)}`,
+    `method=${sanitizeHeaderToken(record.method)}`,
+    `env=${sanitizeHeaderToken(record.env)}`,
+    `sid=${sanitizeHeaderToken(record.sessionId)}`,
+    `seq=${record.sequence}`,
+    'fmt=json',
+    record.platform ? `platform=${sanitizeHeaderToken(record.platform)}` : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return `${header} ${JSON.stringify(record.body)}\n`;
+}
+
+export function formatDateFolder(date: Date) {
+  return [
+    date.getFullYear(),
+    pad2(date.getMonth() + 1),
+    pad2(date.getDate()),
+  ].join('-');
+}
+
+export function formatFileTimestamp(date: Date) {
+  return [
+    formatDateFolder(date),
+    [
+      pad2(date.getHours()),
+      pad2(date.getMinutes()),
+      pad2(date.getSeconds()),
+    ].join('-'),
+    pad3(date.getMilliseconds()),
+  ].join(FILE_TIMESTAMP_SEPARATOR);
+}
+
+export function createDefaultSessionId(date: Date = new Date()) {
+  return [
+    formatFileTimestamp(date),
+    Math.random().toString(36).slice(2, 8),
+  ].join('-');
+}

--- a/apps/mobile/src/utils/logging/install.ts
+++ b/apps/mobile/src/utils/logging/install.ts
@@ -1,4 +1,5 @@
 import { AppState } from 'react-native';
+import { subscribeOnlineConfig } from '@/core/config/online';
 import { logger } from '@/utils/logger';
 import { subscribeAppLogFileSettings } from './settings';
 
@@ -17,6 +18,10 @@ if (
   logger.installConsoleCapture();
 
   subscribeAppLogFileSettings(() => {
+    logger.handlePolicyChange().catch(noop);
+  });
+
+  subscribeOnlineConfig(() => {
     logger.handlePolicyChange().catch(noop);
   });
 

--- a/apps/mobile/src/utils/logging/install.ts
+++ b/apps/mobile/src/utils/logging/install.ts
@@ -1,0 +1,28 @@
+import { AppState } from 'react-native';
+import { logger } from '@/utils/logger';
+import { subscribeAppLogFileSettings } from './settings';
+
+declare global {
+  var __RABBY_APP_LOGGER_INSTALLED__: boolean | undefined;
+}
+
+if (
+  !(global as typeof global & { __RABBY_APP_LOGGER_INSTALLED__?: boolean })
+    .__RABBY_APP_LOGGER_INSTALLED__
+) {
+  (
+    global as typeof global & { __RABBY_APP_LOGGER_INSTALLED__?: boolean }
+  ).__RABBY_APP_LOGGER_INSTALLED__ = true;
+
+  logger.installConsoleCapture();
+
+  subscribeAppLogFileSettings(() => {
+    logger.handlePolicyChange().catch(noop);
+  });
+
+  AppState.addEventListener('change', nextState => {
+    logger.handleAppStateChange(nextState).catch(noop);
+  });
+}
+
+function noop() {}

--- a/apps/mobile/src/utils/logging/policy.ts
+++ b/apps/mobile/src/utils/logging/policy.ts
@@ -1,0 +1,31 @@
+export const APP_FILE_LOGGING_ONLINE_SWITCH =
+  '20260410.enable_app_file_logging' as const;
+
+export function getDefaultLocalAppFileLoggingEnabled(runtimeEnv: string) {
+  switch (runtimeEnv) {
+    case 'development':
+      return true;
+    case 'regression':
+      return false;
+    default:
+      return false;
+  }
+}
+
+export function resolveAppFileLoggingEnabled(options: {
+  runtimeEnv: string;
+  localEnabled: boolean;
+  prodOnlineEnabled: boolean;
+}) {
+  const { runtimeEnv, localEnabled, prodOnlineEnabled } = options;
+
+  return runtimeEnv === 'production' ? prodOnlineEnabled : localEnabled;
+}
+
+export function resolveConsoleCaptureEnabled(options: {
+  runtimeEnv: string;
+  localEnabled: boolean;
+  prodOnlineEnabled: boolean;
+}) {
+  return resolveAppFileLoggingEnabled(options);
+}

--- a/apps/mobile/src/utils/logging/rnfsAdapter.ts
+++ b/apps/mobile/src/utils/logging/rnfsAdapter.ts
@@ -1,0 +1,19 @@
+import RNFS from 'react-native-fs';
+import { LoggingFileSystemAdapter } from './rollingZipWriter';
+
+export const rnfsLoggingAdapter: LoggingFileSystemAdapter = {
+  mkdir(path) {
+    return RNFS.mkdir(path, {
+      NSURLIsExcludedFromBackupKey: true,
+    });
+  },
+  writeFile(path, contents, encoding) {
+    return RNFS.writeFile(path, contents, encoding);
+  },
+  appendFile(path, contents, encoding) {
+    return RNFS.appendFile(path, contents, encoding);
+  },
+  moveFile(from, to) {
+    return RNFS.moveFile(from, to);
+  },
+};

--- a/apps/mobile/src/utils/logging/rnfsAdapter.ts
+++ b/apps/mobile/src/utils/logging/rnfsAdapter.ts
@@ -7,6 +7,9 @@ export const rnfsLoggingAdapter: LoggingFileSystemAdapter = {
       NSURLIsExcludedFromBackupKey: true,
     });
   },
+  readFile(path, encoding) {
+    return RNFS.readFile(path, encoding);
+  },
   writeFile(path, contents, encoding) {
     return RNFS.writeFile(path, contents, encoding);
   },
@@ -15,5 +18,20 @@ export const rnfsLoggingAdapter: LoggingFileSystemAdapter = {
   },
   moveFile(from, to) {
     return RNFS.moveFile(from, to);
+  },
+  async listFiles(path) {
+    const entries = await RNFS.readDir(path);
+
+    return entries
+      .filter(item => item.isFile())
+      .map(item => ({
+        name: item.name,
+        path: item.path,
+        size: item.size,
+        mtimeMs: item.mtime ? item.mtime.getTime() : undefined,
+      }));
+  },
+  unlink(path) {
+    return RNFS.unlink(path);
   },
 };

--- a/apps/mobile/src/utils/logging/rollingZipWriter.ts
+++ b/apps/mobile/src/utils/logging/rollingZipWriter.ts
@@ -1,11 +1,21 @@
-import { strToU8, Zip, ZipDeflate } from 'fflate';
+import { strToU8, unzipSync, Zip, ZipDeflate } from 'fflate';
 import { formatDateFolder, formatFileTimestamp } from './format';
+
+export type LoggingFileSystemEntry = {
+  name: string;
+  path: string;
+  size: number;
+  mtimeMs?: number;
+};
 
 export interface LoggingFileSystemAdapter {
   mkdir(path: string): Promise<void>;
+  readFile(path: string, encoding: 'base64'): Promise<string>;
   writeFile(path: string, contents: string, encoding: 'base64'): Promise<void>;
   appendFile(path: string, contents: string, encoding: 'base64'): Promise<void>;
   moveFile(from: string, to: string): Promise<void>;
+  listFiles(path: string): Promise<LoggingFileSystemEntry[]>;
+  unlink(path: string): Promise<void>;
 }
 
 export type RollingZipWriterState = {
@@ -21,6 +31,7 @@ type RollingZipWriterOptions = {
   rootDir: string;
   archivePrefix?: string;
   maxEntryBytes?: number;
+  maxArchivedBytes?: number;
   now?: () => Date;
   onError?: (error: unknown) => void;
 };
@@ -28,6 +39,7 @@ type RollingZipWriterOptions = {
 type ArchiveState = {
   tempPath: string;
   finalPath: string;
+  replaceFinalOnFinalize: boolean;
   zip: Zip;
   fileWriteQueue: Promise<void>;
   currentEntry: ZipDeflate | null;
@@ -36,9 +48,15 @@ type ArchiveState = {
 };
 
 const DEFAULT_MAX_ENTRY_BYTES = 1024 * 1024;
+const DEFAULT_MAX_ARCHIVED_BYTES = 500 * 1024 * 1024;
 const BASE64_TABLE =
   'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+const BASE64_LOOKUP = new Uint8Array(256).fill(255);
 const EMPTY_CHUNK = new Uint8Array(0);
+
+for (let index = 0; index < BASE64_TABLE.length; index += 1) {
+  BASE64_LOOKUP[BASE64_TABLE.charCodeAt(index)] = index;
+}
 
 function u8ToBase64(input: Uint8Array) {
   let output = '';
@@ -61,12 +79,53 @@ function u8ToBase64(input: Uint8Array) {
   return output;
 }
 
+function base64ToU8(input: string) {
+  const sanitized = input.replace(/\s+/g, '');
+  if (!sanitized) {
+    return EMPTY_CHUNK;
+  }
+
+  const padding =
+    (sanitized.endsWith('==') ? 2 : 0) || (sanitized.endsWith('=') ? 1 : 0);
+  const output = new Uint8Array(
+    Math.floor((sanitized.length * 3) / 4) - padding,
+  );
+  let outIndex = 0;
+
+  for (let index = 0; index < sanitized.length; index += 4) {
+    const code0 = BASE64_LOOKUP[sanitized.charCodeAt(index)] || 0;
+    const code1 = BASE64_LOOKUP[sanitized.charCodeAt(index + 1)] || 0;
+    const code2 =
+      sanitized[index + 2] === '='
+        ? 0
+        : BASE64_LOOKUP[sanitized.charCodeAt(index + 2)] || 0;
+    const code3 =
+      sanitized[index + 3] === '='
+        ? 0
+        : BASE64_LOOKUP[sanitized.charCodeAt(index + 3)] || 0;
+    const combined = code0 * 262144 + code1 * 4096 + code2 * 64 + code3;
+
+    output[outIndex++] = Math.floor(combined / 65536) % 256;
+
+    if (sanitized[index + 2] !== '=' && outIndex < output.length) {
+      output[outIndex++] = Math.floor(combined / 256) % 256;
+    }
+
+    if (sanitized[index + 3] !== '=' && outIndex < output.length) {
+      output[outIndex++] = combined % 256;
+    }
+  }
+
+  return output;
+}
+
 export class RollingZipLogWriter {
   readonly rootDir: string;
 
   private readonly fs: LoggingFileSystemAdapter;
   private readonly archivePrefix: string;
   private readonly maxEntryBytes: number;
+  private readonly maxArchivedBytes: number;
   private readonly now: () => Date;
   private readonly onError?: (error: unknown) => void;
 
@@ -80,6 +139,8 @@ export class RollingZipLogWriter {
     this.rootDir = options.rootDir;
     this.archivePrefix = options.archivePrefix || 'rabby-mobile-logs';
     this.maxEntryBytes = options.maxEntryBytes || DEFAULT_MAX_ENTRY_BYTES;
+    this.maxArchivedBytes =
+      options.maxArchivedBytes || DEFAULT_MAX_ARCHIVED_BYTES;
     this.now = options.now || (() => new Date());
     this.onError = options.onError;
   }
@@ -111,14 +172,67 @@ export class RollingZipLogWriter {
     ].join('/');
   }
 
-  private async createArchive() {
+  private isManagedArchiveFile(file: LoggingFileSystemEntry) {
+    return (
+      file.name.startsWith(this.archivePrefix) &&
+      (file.name.endsWith('.zip') || file.name.endsWith('.zip.partial'))
+    );
+  }
+
+  private isFinalizedManagedArchiveFile(file: LoggingFileSystemEntry) {
+    return (
+      file.name.startsWith(this.archivePrefix) && file.name.endsWith('.zip')
+    );
+  }
+
+  private async listManagedArchiveFiles() {
     await this.ensureRootDir();
+    return (await this.fs.listFiles(this.rootDir)).filter(file =>
+      this.isManagedArchiveFile(file),
+    );
+  }
 
-    const now = this.now();
-    const baseName = this.makeArchiveBaseName(now);
-    const finalPath = `${this.rootDir}/${baseName}.zip`;
-    const tempPath = `${finalPath}.partial`;
+  private async pruneOldArchivesIfNeeded(excludePaths: string[] = []) {
+    if (this.maxArchivedBytes <= 0) {
+      return;
+    }
 
+    const excluded = new Set(excludePaths);
+    const archivedFiles = (await this.listManagedArchiveFiles())
+      .filter(file => this.isFinalizedManagedArchiveFile(file))
+      .sort((left, right) => {
+        const leftMtime = left.mtimeMs || 0;
+        const rightMtime = right.mtimeMs || 0;
+
+        if (leftMtime !== rightMtime) {
+          return leftMtime - rightMtime;
+        }
+
+        return left.name.localeCompare(right.name);
+      });
+
+    let totalBytes = archivedFiles.reduce((sum, file) => sum + file.size, 0);
+    let index = 0;
+
+    while (
+      totalBytes >= this.maxArchivedBytes &&
+      index < archivedFiles.length
+    ) {
+      const target = archivedFiles[index++];
+      if (excluded.has(target.path)) {
+        continue;
+      }
+
+      await this.fs.unlink(target.path);
+      totalBytes -= target.size;
+    }
+  }
+
+  private async createArchiveState(options: {
+    finalPath: string;
+    tempPath: string;
+    replaceFinalOnFinalize: boolean;
+  }) {
     let archiveState: ArchiveState;
     const zip = new Zip((error, chunk) => {
       if (error) {
@@ -131,13 +245,14 @@ export class RollingZipLogWriter {
       }
 
       archiveState.fileWriteQueue = archiveState.fileWriteQueue.then(() =>
-        this.fs.appendFile(tempPath, u8ToBase64(chunk), 'base64'),
+        this.fs.appendFile(options.tempPath, u8ToBase64(chunk), 'base64'),
       );
     });
 
     archiveState = {
-      tempPath,
-      finalPath,
+      tempPath: options.tempPath,
+      finalPath: options.finalPath,
+      replaceFinalOnFinalize: options.replaceFinalOnFinalize,
       zip,
       fileWriteQueue: Promise.resolve(),
       currentEntry: null,
@@ -145,15 +260,108 @@ export class RollingZipLogWriter {
       currentEntryBytes: 0,
     };
 
-    await this.fs.writeFile(tempPath, '', 'base64');
-
+    await this.fs.writeFile(options.tempPath, '', 'base64');
     this.currentArchive = archiveState;
     return archiveState;
+  }
+
+  private async restoreLatestArchiveIfPossible() {
+    const latestArchive = (await this.listManagedArchiveFiles())
+      .filter(file => this.isFinalizedManagedArchiveFile(file))
+      .sort((left, right) => {
+        const rightMtime = right.mtimeMs || 0;
+        const leftMtime = left.mtimeMs || 0;
+
+        if (rightMtime !== leftMtime) {
+          return rightMtime - leftMtime;
+        }
+
+        return right.name.localeCompare(left.name);
+      })[0];
+
+    if (!latestArchive) {
+      return null;
+    }
+
+    try {
+      await this.pruneOldArchivesIfNeeded([latestArchive.path]);
+
+      const archivedBase64 = await this.fs.readFile(
+        latestArchive.path,
+        'base64',
+      );
+      const archivedEntries = unzipSync(base64ToU8(archivedBase64));
+      const entryNames = Object.keys(archivedEntries).sort((left, right) =>
+        left.localeCompare(right),
+      );
+      const logEntryNames = entryNames.filter(name => name.endsWith('.log'));
+      const latestEntryPath = logEntryNames[logEntryNames.length - 1] || null;
+      const latestEntryBytes = latestEntryPath
+        ? (archivedEntries[latestEntryPath] || EMPTY_CHUNK).byteLength
+        : 0;
+      const continueLatestEntry =
+        !!latestEntryPath && latestEntryBytes < this.maxEntryBytes;
+
+      this.entryCounter = Math.max(this.entryCounter, logEntryNames.length);
+
+      const archive = await this.createArchiveState({
+        finalPath: latestArchive.path,
+        tempPath: `${latestArchive.path}.partial`,
+        replaceFinalOnFinalize: true,
+      });
+
+      for (const entryName of entryNames) {
+        const entryBytes = archivedEntries[entryName] || EMPTY_CHUNK;
+        const entry = new ZipDeflate(entryName, {
+          level: 6,
+        });
+
+        archive.zip.add(entry);
+
+        if (continueLatestEntry && entryName === latestEntryPath) {
+          entry.push(entryBytes, false);
+          archive.currentEntry = entry;
+          archive.currentEntryPath = entryName;
+          archive.currentEntryBytes = entryBytes.byteLength;
+        } else {
+          entry.push(entryBytes, true);
+        }
+
+        await archive.fileWriteQueue;
+      }
+
+      return archive;
+    } catch (error) {
+      this.currentArchive = null;
+      this.onError?.(error);
+      return null;
+    }
+  }
+
+  private async createArchive() {
+    await this.ensureRootDir();
+    await this.pruneOldArchivesIfNeeded();
+
+    const now = this.now();
+    const baseName = this.makeArchiveBaseName(now);
+    const finalPath = `${this.rootDir}/${baseName}.zip`;
+    const tempPath = `${finalPath}.partial`;
+
+    return this.createArchiveState({
+      finalPath,
+      tempPath,
+      replaceFinalOnFinalize: false,
+    });
   }
 
   private async ensureArchive() {
     if (this.currentArchive) {
       return this.currentArchive;
+    }
+
+    const restoredArchive = await this.restoreLatestArchiveIfPossible();
+    if (restoredArchive) {
+      return restoredArchive;
     }
 
     return this.createArchive();
@@ -184,6 +392,8 @@ export class RollingZipLogWriter {
     }
 
     if (!archive.currentEntry) {
+      await this.pruneOldArchivesIfNeeded([archive.finalPath]);
+
       const entry = new ZipDeflate(this.makeEntryName(this.now()), {
         level: 6,
       });
@@ -220,6 +430,9 @@ export class RollingZipLogWriter {
       await this.closeCurrentEntry();
       archive.zip.end();
       await archive.fileWriteQueue;
+      if (archive.replaceFinalOnFinalize) {
+        await this.fs.unlink(archive.finalPath).catch(() => undefined);
+      }
       await this.fs.moveFile(archive.tempPath, archive.finalPath);
       return archive.finalPath;
     } finally {

--- a/apps/mobile/src/utils/logging/rollingZipWriter.ts
+++ b/apps/mobile/src/utils/logging/rollingZipWriter.ts
@@ -1,0 +1,239 @@
+import { strToU8, Zip, ZipDeflate } from 'fflate';
+import { formatDateFolder, formatFileTimestamp } from './format';
+
+export interface LoggingFileSystemAdapter {
+  mkdir(path: string): Promise<void>;
+  writeFile(path: string, contents: string, encoding: 'base64'): Promise<void>;
+  appendFile(path: string, contents: string, encoding: 'base64'): Promise<void>;
+  moveFile(from: string, to: string): Promise<void>;
+}
+
+export type RollingZipWriterState = {
+  rootDir: string;
+  activeArchiveTempPath: string | null;
+  activeArchivePath: string | null;
+  activeEntryPath: string | null;
+  activeEntryBytes: number;
+};
+
+type RollingZipWriterOptions = {
+  fs: LoggingFileSystemAdapter;
+  rootDir: string;
+  archivePrefix?: string;
+  maxEntryBytes?: number;
+  now?: () => Date;
+  onError?: (error: unknown) => void;
+};
+
+type ArchiveState = {
+  tempPath: string;
+  finalPath: string;
+  zip: Zip;
+  fileWriteQueue: Promise<void>;
+  currentEntry: ZipDeflate | null;
+  currentEntryPath: string | null;
+  currentEntryBytes: number;
+};
+
+const DEFAULT_MAX_ENTRY_BYTES = 1024 * 1024;
+const BASE64_TABLE =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+const EMPTY_CHUNK = new Uint8Array(0);
+
+function u8ToBase64(input: Uint8Array) {
+  let output = '';
+
+  for (let index = 0; index < input.length; index += 3) {
+    const byte1 = input[index] ?? 0;
+    const byte2 = input[index + 1] ?? 0;
+    const byte3 = input[index + 2] ?? 0;
+    const combined = byte1 * 65536 + byte2 * 256 + byte3;
+
+    output += BASE64_TABLE[Math.floor(combined / 262144) % 64];
+    output += BASE64_TABLE[Math.floor(combined / 4096) % 64];
+    output +=
+      index + 1 < input.length
+        ? BASE64_TABLE[Math.floor(combined / 64) % 64]
+        : '=';
+    output += index + 2 < input.length ? BASE64_TABLE[combined % 64] : '=';
+  }
+
+  return output;
+}
+
+export class RollingZipLogWriter {
+  readonly rootDir: string;
+
+  private readonly fs: LoggingFileSystemAdapter;
+  private readonly archivePrefix: string;
+  private readonly maxEntryBytes: number;
+  private readonly now: () => Date;
+  private readonly onError?: (error: unknown) => void;
+
+  private rootDirReady: Promise<void> | null = null;
+  private archiveCounter = 0;
+  private entryCounter = 0;
+  private currentArchive: ArchiveState | null = null;
+
+  constructor(options: RollingZipWriterOptions) {
+    this.fs = options.fs;
+    this.rootDir = options.rootDir;
+    this.archivePrefix = options.archivePrefix || 'rabby-mobile-logs';
+    this.maxEntryBytes = options.maxEntryBytes || DEFAULT_MAX_ENTRY_BYTES;
+    this.now = options.now || (() => new Date());
+    this.onError = options.onError;
+  }
+
+  private ensureRootDir() {
+    if (!this.rootDirReady) {
+      this.rootDirReady = this.fs.mkdir(this.rootDir);
+    }
+
+    return this.rootDirReady;
+  }
+
+  private makeArchiveBaseName(date: Date) {
+    return [
+      this.archivePrefix,
+      formatFileTimestamp(date),
+      String(this.archiveCounter++).padStart(3, '0'),
+    ].join('-');
+  }
+
+  private makeEntryName(date: Date) {
+    return [
+      'logs',
+      formatDateFolder(date),
+      `${formatFileTimestamp(date)}-${String(this.entryCounter++).padStart(
+        3,
+        '0',
+      )}.log`,
+    ].join('/');
+  }
+
+  private async createArchive() {
+    await this.ensureRootDir();
+
+    const now = this.now();
+    const baseName = this.makeArchiveBaseName(now);
+    const finalPath = `${this.rootDir}/${baseName}.zip`;
+    const tempPath = `${finalPath}.partial`;
+
+    let archiveState: ArchiveState;
+    const zip = new Zip((error, chunk) => {
+      if (error) {
+        this.onError?.(error);
+        return;
+      }
+
+      if (!chunk || !chunk.length) {
+        return;
+      }
+
+      archiveState.fileWriteQueue = archiveState.fileWriteQueue.then(() =>
+        this.fs.appendFile(tempPath, u8ToBase64(chunk), 'base64'),
+      );
+    });
+
+    archiveState = {
+      tempPath,
+      finalPath,
+      zip,
+      fileWriteQueue: Promise.resolve(),
+      currentEntry: null,
+      currentEntryPath: null,
+      currentEntryBytes: 0,
+    };
+
+    await this.fs.writeFile(tempPath, '', 'base64');
+
+    this.currentArchive = archiveState;
+    return archiveState;
+  }
+
+  private async ensureArchive() {
+    if (this.currentArchive) {
+      return this.currentArchive;
+    }
+
+    return this.createArchive();
+  }
+
+  private async closeCurrentEntry() {
+    if (!this.currentArchive?.currentEntry) {
+      return;
+    }
+
+    this.currentArchive.currentEntry.push(EMPTY_CHUNK, true);
+    await this.currentArchive.fileWriteQueue;
+
+    this.currentArchive.currentEntry = null;
+    this.currentArchive.currentEntryPath = null;
+    this.currentArchive.currentEntryBytes = 0;
+  }
+
+  private async ensureEntry(nextLineBytes: number) {
+    const archive = await this.ensureArchive();
+
+    if (
+      archive.currentEntry &&
+      archive.currentEntryBytes > 0 &&
+      archive.currentEntryBytes + nextLineBytes > this.maxEntryBytes
+    ) {
+      await this.closeCurrentEntry();
+    }
+
+    if (!archive.currentEntry) {
+      const entry = new ZipDeflate(this.makeEntryName(this.now()), {
+        level: 6,
+      });
+      archive.zip.add(entry);
+      archive.currentEntry = entry;
+      archive.currentEntryPath = entry.filename;
+      archive.currentEntryBytes = 0;
+    }
+
+    return archive;
+  }
+
+  async writeLine(line: string) {
+    const lineBytes = strToU8(line);
+    const archive = await this.ensureEntry(lineBytes.length);
+
+    archive.currentEntryBytes += lineBytes.length;
+    archive.currentEntry?.push(lineBytes, false);
+
+    await archive.fileWriteQueue;
+  }
+
+  async flush() {
+    await this.currentArchive?.fileWriteQueue;
+  }
+
+  async finalizeArchive() {
+    const archive = this.currentArchive;
+    if (!archive) {
+      return null;
+    }
+
+    try {
+      await this.closeCurrentEntry();
+      archive.zip.end();
+      await archive.fileWriteQueue;
+      await this.fs.moveFile(archive.tempPath, archive.finalPath);
+      return archive.finalPath;
+    } finally {
+      this.currentArchive = null;
+    }
+  }
+
+  getState(): RollingZipWriterState {
+    return {
+      rootDir: this.rootDir,
+      activeArchiveTempPath: this.currentArchive?.tempPath || null,
+      activeArchivePath: this.currentArchive?.finalPath || null,
+      activeEntryPath: this.currentArchive?.currentEntryPath || null,
+      activeEntryBytes: this.currentArchive?.currentEntryBytes || 0,
+    };
+  }
+}

--- a/apps/mobile/src/utils/logging/settings.ts
+++ b/apps/mobile/src/utils/logging/settings.ts
@@ -1,37 +1,93 @@
 import { useCallback } from 'react';
 import { zustandByMMKV } from '@/core/storage/mmkv';
 import { APP_RUNTIME_ENV } from '@/constant/env';
+import { getOnlineConfig } from '@/core/config/online';
+import {
+  APP_FILE_LOGGING_ONLINE_SWITCH,
+  getDefaultLocalAppFileLoggingEnabled,
+  resolveAppFileLoggingEnabled,
+  resolveConsoleCaptureEnabled,
+} from './policy';
 
 type AppLogFileSettings = {
-  regressionFileLoggingEnabled: boolean;
+  developmentFileLoggingEnabled?: boolean;
+  regressionFileLoggingEnabled?: boolean;
+  nonProdFileLoggingEnabled?: boolean;
 };
 
 const appLogFileSettingsStore = zustandByMMKV<AppLogFileSettings>(
   '@AppLogFileSettings',
   {
-    regressionFileLoggingEnabled: true,
+    developmentFileLoggingEnabled:
+      getDefaultLocalAppFileLoggingEnabled('development'),
+    regressionFileLoggingEnabled:
+      getDefaultLocalAppFileLoggingEnabled('regression'),
   },
 );
 
-export function getEffectiveFileLoggingEnabled() {
-  switch (APP_RUNTIME_ENV) {
-    case 'production':
-      return true;
+function getProdOnlineLoggingEnabled() {
+  return !!getOnlineConfig()?.switches?.[APP_FILE_LOGGING_ONLINE_SWITCH];
+}
+
+function resolveLocalFileLoggingEnabled(
+  state: AppLogFileSettings,
+  runtimeEnv = APP_RUNTIME_ENV,
+) {
+  switch (runtimeEnv) {
+    case 'development':
+      if (typeof state.developmentFileLoggingEnabled === 'boolean') {
+        return state.developmentFileLoggingEnabled;
+      }
+
+      if (typeof state.nonProdFileLoggingEnabled === 'boolean') {
+        return state.nonProdFileLoggingEnabled;
+      }
+
+      return getDefaultLocalAppFileLoggingEnabled(runtimeEnv);
     case 'regression':
-      return appLogFileSettingsStore.getState().regressionFileLoggingEnabled;
+      if (typeof state.regressionFileLoggingEnabled === 'boolean') {
+        return state.regressionFileLoggingEnabled;
+      }
+
+      return getDefaultLocalAppFileLoggingEnabled(runtimeEnv);
     default:
-      return false;
+      return getDefaultLocalAppFileLoggingEnabled(runtimeEnv);
   }
 }
 
-export function setRegressionFileLoggingEnabled(nextValue: boolean) {
-  if (APP_RUNTIME_ENV !== 'regression') {
+function getLocalFileLoggingEnabled(runtimeEnv = APP_RUNTIME_ENV) {
+  return resolveLocalFileLoggingEnabled(
+    appLogFileSettingsStore.getState(),
+    runtimeEnv,
+  );
+}
+
+export function getEffectiveFileLoggingEnabled() {
+  return resolveAppFileLoggingEnabled({
+    runtimeEnv: APP_RUNTIME_ENV,
+    localEnabled: getLocalFileLoggingEnabled(),
+    prodOnlineEnabled: getProdOnlineLoggingEnabled(),
+  });
+}
+
+export function getEffectiveConsoleCaptureEnabled() {
+  return resolveConsoleCaptureEnabled({
+    runtimeEnv: APP_RUNTIME_ENV,
+    localEnabled: getLocalFileLoggingEnabled(),
+    prodOnlineEnabled: getProdOnlineLoggingEnabled(),
+  });
+}
+
+export function setLocalFileLoggingEnabled(nextValue: boolean) {
+  if (APP_RUNTIME_ENV === 'production') {
     return getEffectiveFileLoggingEnabled();
   }
 
-  appLogFileSettingsStore.setState({
-    regressionFileLoggingEnabled: nextValue,
-  });
+  appLogFileSettingsStore.setState(
+    APP_RUNTIME_ENV === 'development'
+      ? { developmentFileLoggingEnabled: nextValue }
+      : { regressionFileLoggingEnabled: nextValue },
+  );
 
   return nextValue;
 }
@@ -41,31 +97,35 @@ export function subscribeAppLogFileSettings(listener: () => void) {
 }
 
 export function useAppLogFileSwitch() {
-  const regressionFileLoggingEnabled = appLogFileSettingsStore(
-    state => state.regressionFileLoggingEnabled,
+  const localFileLoggingEnabled = appLogFileSettingsStore(state =>
+    resolveLocalFileLoggingEnabled(state),
   );
 
   const effectiveEnabled = getEffectiveFileLoggingEnabled();
-  const canToggle = APP_RUNTIME_ENV === 'regression';
-  const isForcedOn = APP_RUNTIME_ENV === 'production';
+  const consoleCaptureEnabled = getEffectiveConsoleCaptureEnabled();
+  const localDefaultEnabled =
+    getDefaultLocalAppFileLoggingEnabled(APP_RUNTIME_ENV);
+  const canToggle = APP_RUNTIME_ENV !== 'production';
+  const isOnlineControlled = APP_RUNTIME_ENV === 'production';
 
   const onToggle = useCallback(
     (nextValue?: boolean) => {
       const targetValue =
-        typeof nextValue === 'boolean'
-          ? nextValue
-          : !regressionFileLoggingEnabled;
+        typeof nextValue === 'boolean' ? nextValue : !localFileLoggingEnabled;
 
-      return setRegressionFileLoggingEnabled(targetValue);
+      return setLocalFileLoggingEnabled(targetValue);
     },
-    [regressionFileLoggingEnabled],
+    [localFileLoggingEnabled],
   );
 
   return {
+    runtimeEnv: APP_RUNTIME_ENV,
     canToggle,
-    isForcedOn,
+    isOnlineControlled,
     effectiveEnabled,
-    regressionFileLoggingEnabled,
+    consoleCaptureEnabled,
+    localDefaultEnabled,
+    localFileLoggingEnabled,
     onToggle,
   };
 }

--- a/apps/mobile/src/utils/logging/settings.ts
+++ b/apps/mobile/src/utils/logging/settings.ts
@@ -1,0 +1,71 @@
+import { useCallback } from 'react';
+import { zustandByMMKV } from '@/core/storage/mmkv';
+import { APP_RUNTIME_ENV } from '@/constant/env';
+
+type AppLogFileSettings = {
+  regressionFileLoggingEnabled: boolean;
+};
+
+const appLogFileSettingsStore = zustandByMMKV<AppLogFileSettings>(
+  '@AppLogFileSettings',
+  {
+    regressionFileLoggingEnabled: true,
+  },
+);
+
+export function getEffectiveFileLoggingEnabled() {
+  switch (APP_RUNTIME_ENV) {
+    case 'production':
+      return true;
+    case 'regression':
+      return appLogFileSettingsStore.getState().regressionFileLoggingEnabled;
+    default:
+      return false;
+  }
+}
+
+export function setRegressionFileLoggingEnabled(nextValue: boolean) {
+  if (APP_RUNTIME_ENV !== 'regression') {
+    return getEffectiveFileLoggingEnabled();
+  }
+
+  appLogFileSettingsStore.setState({
+    regressionFileLoggingEnabled: nextValue,
+  });
+
+  return nextValue;
+}
+
+export function subscribeAppLogFileSettings(listener: () => void) {
+  return appLogFileSettingsStore.subscribe(listener);
+}
+
+export function useAppLogFileSwitch() {
+  const regressionFileLoggingEnabled = appLogFileSettingsStore(
+    state => state.regressionFileLoggingEnabled,
+  );
+
+  const effectiveEnabled = getEffectiveFileLoggingEnabled();
+  const canToggle = APP_RUNTIME_ENV === 'regression';
+  const isForcedOn = APP_RUNTIME_ENV === 'production';
+
+  const onToggle = useCallback(
+    (nextValue?: boolean) => {
+      const targetValue =
+        typeof nextValue === 'boolean'
+          ? nextValue
+          : !regressionFileLoggingEnabled;
+
+      return setRegressionFileLoggingEnabled(targetValue);
+    },
+    [regressionFileLoggingEnabled],
+  );
+
+  return {
+    canToggle,
+    isForcedOn,
+    effectiveEnabled,
+    regressionFileLoggingEnabled,
+    onToggle,
+  };
+}

--- a/apps/mobile/src/utils/openapiFailureLogging.test.ts
+++ b/apps/mobile/src/utils/openapiFailureLogging.test.ts
@@ -1,0 +1,98 @@
+import { MaskedLogValue } from './logging/format';
+
+jest.mock('./logger', () => {
+  const { MaskedLogValue: NextMaskedLogValue } = require('./logging/format');
+
+  return {
+    logger: {
+      mask: jest.fn((value: unknown) => new NextMaskedLogValue(value)),
+      warn: jest.fn(),
+    },
+  };
+});
+
+import {
+  buildOpenApiFailurePayload,
+  extractOpenApiResponseCode,
+  shouldLogOpenApiFailureResponse,
+} from './openapiFailureLogging';
+
+describe('openapi failure logging', () => {
+  it('detects http and api-level non-200 responses', () => {
+    expect(
+      shouldLogOpenApiFailureResponse({
+        status: 500,
+        data: { err_code: 200 },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldLogOpenApiFailureResponse({
+        status: 200,
+        data: { err_code: 401 },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldLogOpenApiFailureResponse({
+        status: 200,
+        data: { err_code: 200 },
+      }),
+    ).toBe(false);
+  });
+
+  it('extracts normalized api codes from different response shapes', () => {
+    expect(extractOpenApiResponseCode({ err_code: 403 })).toBe(403);
+    expect(extractOpenApiResponseCode({ error_code: '429' })).toBe(429);
+    expect(extractOpenApiResponseCode({})).toBeNull();
+  });
+
+  it('masks sensitive headers when building the failure payload', () => {
+    const payload = buildOpenApiFailurePayload({
+      source: 'openapi',
+      config: {
+        method: 'post',
+        baseURL: 'https://app-api.rabby.io',
+        url: '/v1/demo',
+        headers: {
+          Authorization: 'Bearer secret',
+          'X-API-Key': 'api-key-value',
+          'X-Trace-Id': 'trace-123',
+        },
+        data: {
+          token: 'should-mask',
+          visible: 'hello',
+        },
+      },
+      response: {
+        status: 503,
+        statusText: 'Service Unavailable',
+        headers: {
+          'set-cookie': 'token=secret',
+        },
+        data: {
+          err_code: 503,
+          err_msg: 'upstream failed',
+        },
+        config: {} as never,
+      } as never,
+    });
+
+    expect(payload.request?.url).toBe('https://app-api.rabby.io/v1/demo');
+    expect(payload.request?.headers.Authorization).toBeInstanceOf(
+      MaskedLogValue,
+    );
+    expect(payload.request?.headers['X-API-Key']).toBeInstanceOf(
+      MaskedLogValue,
+    );
+    expect(payload.request?.headers['X-Trace-Id']).toBe('trace-123');
+    expect(payload.request?.data).toEqual({
+      token: expect.any(MaskedLogValue),
+      visible: 'hello',
+    });
+    expect(payload.response?.headers['set-cookie']).toBeInstanceOf(
+      MaskedLogValue,
+    );
+    expect(payload.response?.apiCode).toBe(503);
+  });
+});

--- a/apps/mobile/src/utils/openapiFailureLogging.ts
+++ b/apps/mobile/src/utils/openapiFailureLogging.ts
@@ -1,0 +1,427 @@
+import type { OpenApiService } from '@rabby-wallet/rabby-api';
+import type { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { logger } from './logger';
+
+const REQUEST_LOG_META_KEY = '__rabbyOpenApiFailureMeta';
+const REQUEST_INSTRUMENTED_KEY = Symbol('rabbyOpenApiFailureLogging/request');
+const SERVICE_INSTRUMENTED_KEY = Symbol('rabbyOpenApiFailureLogging/service');
+const RESPONSE_WRAPPED_KEY = Symbol('rabbyOpenApiFailureLogging/response');
+
+const SENSITIVE_KEYWORDS = [
+  'api-key',
+  'api-sign',
+  'authorization',
+  'cookie',
+  'mnemonic',
+  'nonce',
+  'password',
+  'private',
+  'secret',
+  'seed',
+  'session',
+  'signature',
+  'token',
+] as const;
+
+type OpenApiFailureSource = 'openapi' | 'testOpenapi' | 'notificationOpenapi';
+
+type InstrumentedRequestConfig = AxiosRequestConfig & {
+  [REQUEST_LOG_META_KEY]?: {
+    source: OpenApiFailureSource;
+    requestId: string;
+  };
+};
+
+type AxiosRequestLike = OpenApiService['request'] & {
+  [REQUEST_INSTRUMENTED_KEY]?: boolean;
+  interceptors: OpenApiService['request']['interceptors'] & {
+    response: OpenApiService['request']['interceptors']['response'] & {
+      handlers?: Array<{
+        fulfilled?: (
+          value: AxiosResponse,
+        ) => AxiosResponse | Promise<AxiosResponse>;
+        rejected?: (error: unknown) => unknown;
+      } | null>;
+    };
+  };
+};
+
+function toHeaderObject(
+  headers: AxiosRequestConfig['headers'] | AxiosResponse['headers'],
+) {
+  if (!headers) {
+    return {};
+  }
+
+  const maybeHeaders = headers as {
+    toJSON?: () => Record<string, unknown>;
+  };
+
+  if (typeof maybeHeaders.toJSON === 'function') {
+    return maybeHeaders.toJSON();
+  }
+
+  if (typeof headers === 'object') {
+    return { ...(headers as Record<string, unknown>) };
+  }
+
+  return {};
+}
+
+function makeRequestId(source: OpenApiFailureSource) {
+  return `${source}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function truncateString(value: string, max = 1200) {
+  if (value.length <= max) {
+    return value;
+  }
+
+  return `${value.slice(0, max - 3)}...`;
+}
+
+function isSensitiveKey(key: string) {
+  const normalized = key.toLowerCase();
+  return SENSITIVE_KEYWORDS.some(keyword => normalized.includes(keyword));
+}
+
+function normalizeErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+function sanitizeValue(
+  value: unknown,
+  depth = 0,
+  seen: WeakSet<object> = new WeakSet(),
+): unknown {
+  if (
+    value === null ||
+    typeof value === 'boolean' ||
+    typeof value === 'number'
+  ) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return truncateString(value);
+  }
+
+  if (typeof value === 'undefined') {
+    return '[undefined]';
+  }
+
+  if (typeof value === 'bigint') {
+    return `${value.toString()}n`;
+  }
+
+  if (typeof value === 'function') {
+    return `[Function ${value.name || 'anonymous'}]`;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: truncateString(value.message),
+      ...(value.stack ? { stack: truncateString(value.stack, 2400) } : {}),
+    };
+  }
+
+  if (Array.isArray(value)) {
+    if (depth >= 4) {
+      return `[Array(${value.length})]`;
+    }
+
+    const nextValues = value
+      .slice(0, 20)
+      .map(item => sanitizeValue(item, depth + 1, seen));
+
+    if (value.length > 20) {
+      nextValues.push(`[Truncated ${value.length - 20} items]`);
+    }
+
+    return nextValues;
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value)) {
+      return '[Circular]';
+    }
+    seen.add(value);
+
+    if (depth >= 4) {
+      return `[${value.constructor?.name || 'Object'}]`;
+    }
+
+    const output: Record<string, unknown> = {};
+    const entries = Object.entries(value as Record<string, unknown>);
+
+    entries.slice(0, 40).forEach(([key, item]) => {
+      output[key] = isSensitiveKey(key)
+        ? logger.mask(String(item ?? ''))
+        : sanitizeValue(item, depth + 1, seen);
+    });
+
+    if (entries.length > 40) {
+      output.__truncated_keys__ = entries.length - 40;
+    }
+
+    return output;
+  }
+
+  return String(value);
+}
+
+function sanitizeHeaders(
+  headers: AxiosRequestConfig['headers'] | AxiosResponse['headers'],
+) {
+  const headerObject = toHeaderObject(headers);
+
+  return Object.fromEntries(
+    Object.entries(headerObject).map(([key, value]) => [
+      key,
+      isSensitiveKey(key)
+        ? logger.mask(String(value ?? ''))
+        : sanitizeValue(value),
+    ]),
+  );
+}
+
+function buildRequestUrl(config: AxiosRequestConfig) {
+  if (!config.url) {
+    return config.baseURL || '[missing-url]';
+  }
+
+  if (/^https?:\/\//i.test(config.url)) {
+    return config.url;
+  }
+
+  if (!config.baseURL) {
+    return config.url;
+  }
+
+  try {
+    return new URL(config.url, config.baseURL).toString();
+  } catch (_error) {
+    const left = config.baseURL.replace(/\/+$/, '');
+    const right = config.url.replace(/^\/+/, '');
+    return `${left}/${right}`;
+  }
+}
+
+export function extractOpenApiResponseCode(data: unknown) {
+  if (!data || typeof data !== 'object') {
+    return null;
+  }
+
+  const rawCode =
+    (data as { err_code?: unknown }).err_code ??
+    (data as { error_code?: unknown }).error_code;
+
+  if (rawCode === null || typeof rawCode === 'undefined') {
+    return null;
+  }
+
+  if (typeof rawCode === 'number') {
+    return rawCode;
+  }
+
+  if (typeof rawCode === 'string' && rawCode.trim()) {
+    const numericCode = Number(rawCode);
+    return Number.isNaN(numericCode) ? rawCode : numericCode;
+  }
+
+  return String(rawCode);
+}
+
+export function shouldLogOpenApiFailureResponse(response: {
+  status?: number;
+  data?: unknown;
+}) {
+  const apiCode = extractOpenApiResponseCode(response.data);
+
+  if (typeof response.status === 'number' && response.status !== 200) {
+    return true;
+  }
+
+  if (typeof apiCode === 'number') {
+    return apiCode !== 200;
+  }
+
+  if (typeof apiCode === 'string') {
+    return apiCode !== '200';
+  }
+
+  return false;
+}
+
+export function buildOpenApiFailurePayload(args: {
+  source: OpenApiFailureSource;
+  config?: AxiosRequestConfig;
+  response?: AxiosResponse;
+  error?: unknown;
+}) {
+  const { source, config, response, error } = args;
+  const meta = (config as InstrumentedRequestConfig | undefined)?.[
+    REQUEST_LOG_META_KEY
+  ];
+
+  return {
+    source,
+    requestId: meta?.requestId || 'unknown',
+    request: config
+      ? {
+          method: String(config.method || 'GET').toUpperCase(),
+          url: buildRequestUrl(config),
+          baseURL: config.baseURL || '',
+          timeout: config.timeout || 0,
+          headers: sanitizeHeaders(config.headers),
+          params: sanitizeValue(config.params),
+          data: sanitizeValue(config.data),
+        }
+      : null,
+    response: response
+      ? {
+          status: response.status,
+          statusText: response.statusText || '',
+          headers: sanitizeHeaders(response.headers),
+          data: sanitizeValue(response.data),
+          apiCode: extractOpenApiResponseCode(response.data),
+        }
+      : null,
+    error: error
+      ? {
+          name: error instanceof Error ? error.name : 'Error',
+          message: truncateString(normalizeErrorMessage(error)),
+          ...(error instanceof Error && error.stack
+            ? { stack: truncateString(error.stack, 2400) }
+            : {}),
+          ...(typeof (error as AxiosError).code === 'string'
+            ? { code: (error as AxiosError).code }
+            : {}),
+        }
+      : null,
+  };
+}
+
+function logOpenApiFailure(args: {
+  source: OpenApiFailureSource;
+  config?: AxiosRequestConfig;
+  response?: AxiosResponse;
+  error?: unknown;
+}) {
+  logger.warn(
+    '[openapi] non-200 request detected',
+    buildOpenApiFailurePayload(args),
+  );
+}
+
+function wrapExistingResponseHandlers(
+  request: AxiosRequestLike,
+  source: OpenApiFailureSource,
+) {
+  request.interceptors.response.handlers?.forEach(handler => {
+    if (!handler?.fulfilled) {
+      return;
+    }
+
+    if (
+      (handler.fulfilled as unknown as Record<symbol, unknown>)[
+        RESPONSE_WRAPPED_KEY
+      ]
+    ) {
+      return;
+    }
+
+    const originalFulfilled = handler.fulfilled;
+    const wrappedFulfilled = (response: AxiosResponse) => {
+      if (shouldLogOpenApiFailureResponse(response)) {
+        logOpenApiFailure({
+          source,
+          config: response.config,
+          response,
+        });
+      }
+
+      return originalFulfilled(response);
+    };
+
+    (wrappedFulfilled as unknown as Record<symbol, unknown>)[
+      RESPONSE_WRAPPED_KEY
+    ] = true;
+
+    handler.fulfilled = wrappedFulfilled;
+  });
+}
+
+function attachFailureLoggingToRequest(
+  request: AxiosRequestLike,
+  source: OpenApiFailureSource,
+) {
+  if (request[REQUEST_INSTRUMENTED_KEY]) {
+    return;
+  }
+
+  request[REQUEST_INSTRUMENTED_KEY] = true;
+
+  wrapExistingResponseHandlers(request, source);
+
+  request.interceptors.request.use(config => {
+    const nextConfig = config as InstrumentedRequestConfig;
+    nextConfig[REQUEST_LOG_META_KEY] = {
+      source,
+      requestId: makeRequestId(source),
+    };
+    return nextConfig;
+  });
+
+  request.interceptors.response.use(undefined, error => {
+    const axiosError = error as AxiosError;
+    const config = axiosError.config;
+    const response = axiosError.response;
+
+    if (config && (!response || shouldLogOpenApiFailureResponse(response))) {
+      logOpenApiFailure({
+        source,
+        config,
+        response,
+        error,
+      });
+    }
+
+    return Promise.reject(error);
+  });
+}
+
+export function instrumentOpenApiFailureLogging(
+  service: OpenApiService,
+  source: OpenApiFailureSource,
+) {
+  const instrumentedService = service as OpenApiService & {
+    [SERVICE_INSTRUMENTED_KEY]?: boolean;
+    initSync(options?: unknown): void;
+  };
+
+  if (!instrumentedService[SERVICE_INSTRUMENTED_KEY]) {
+    const originalInitSync = service.initSync.bind(service);
+
+    instrumentedService.initSync = (options?: unknown) => {
+      originalInitSync(options as never);
+      attachFailureLoggingToRequest(
+        instrumentedService.request as AxiosRequestLike,
+        source,
+      );
+    };
+
+    instrumentedService[SERVICE_INSTRUMENTED_KEY] = true;
+  }
+
+  attachFailureLoggingToRequest(service.request as AxiosRequestLike, source);
+}

--- a/docs/mobile-app-log-format.md
+++ b/docs/mobile-app-log-format.md
@@ -1,0 +1,378 @@
+# Mobile App Log Format
+
+## Purpose
+
+This document defines the on-device log archive format produced by the mobile app.
+It is intended for downstream tooling that needs to parse Rabby mobile logs outside
+the app itself, for example:
+
+- VS Code extensions
+- Desktop log viewers
+- Automated support triage tools
+- Internal debugging pipelines
+
+The current line protocol version is `@rabby-log/v1`.
+
+## Scope
+
+This document covers:
+
+- archive and file naming
+- archive rotation and reuse rules
+- per-line log record format
+- JSON body schema
+- masking behavior
+- compatibility expectations for third-party parsers
+
+It does not define:
+
+- UI behavior in the app
+- transport / upload APIs
+- retention policy knobs beyond the current defaults
+
+## Storage Layout
+
+The app writes logs under an app-private writable root:
+
+```text
+<app-document-like-path>/applogs/
+```
+
+Each archive is a zip file:
+
+```text
+rabby-mobile-logs-YYYY-MM-DD_HH-mm-ss_SSS-NNN.zip
+```
+
+Examples:
+
+```text
+rabby-mobile-logs-2026-04-10_18-21-06_693-035.zip
+rabby-mobile-logs-2026-04-10_18-24-19_104-036.zip
+```
+
+Inside each zip, logical log files are stored under a date folder:
+
+```text
+logs/YYYY-MM-DD/YYYY-MM-DD_HH-mm-ss_SSS-NNN.log
+```
+
+Example:
+
+```text
+logs/2026-04-10/2026-04-10_18-21-06_693-035.log
+```
+
+## Archive Reuse and Rotation
+
+### Archive-level behavior
+
+The logger prefers to keep writing into a single zip archive:
+
+1. If the current process already has an active archive in memory, continue using it.
+2. Otherwise, try to reuse the latest finalized zip archive under `applogs/`.
+3. If no finalized zip archive exists, create a new one.
+
+When reusing a finalized archive, the logger reconstructs a new `.zip.partial`
+working file from the latest finalized `.zip`, appends new records, and replaces
+the old finalized zip on the next finalize.
+
+### Entry-level behavior
+
+Within the selected zip archive, the logger prefers to continue writing into the
+latest `.log` entry file.
+
+Rules:
+
+1. If the latest `.log` entry is smaller than the configured threshold, append to it.
+2. If the latest `.log` entry would exceed the threshold after the next line, close it.
+3. Create a new `.log` entry in the same zip archive.
+
+Current default entry size threshold:
+
+```text
+1 MiB
+```
+
+### Finalization behavior
+
+The current working archive is finalized when one of these happens:
+
+- the app moves away from `active` app state
+- file logging is turned off by policy
+- the app explicitly triggers archive finalization from the debug page
+
+### Retention behavior
+
+Before opening a new logical `.log` entry, the logger checks total size of finalized
+managed zip archives under `applogs/`.
+
+Current default retention limit:
+
+```text
+500 MiB
+```
+
+If the total finalized archive size is at or above the limit, the oldest finalized
+managed zip archives are deleted first.
+
+Only managed archives matching the current archive prefix are considered.
+
+## Line Protocol
+
+Every log line is a single line of UTF-8 text with this shape:
+
+```text
+@rabby-log/v1 ts=<timestamp> lvl=<level> src=<source> method=<method> env=<env> sid=<session-id> seq=<sequence> fmt=json [platform=<platform>] <json-body>\n
+```
+
+Example:
+
+```text
+@rabby-log/v1 ts=2026-04-10T10:21:06.693Z lvl=warn src=console method=warn env=development sid=2026-04-10_18-20-41_102-abc123 seq=184 fmt=json platform=ios {"message":"[openapi] non-200 request detected","args":["[openapi] non-200 request detected",{"source":"openapi","request":{"method":"get","url":"https://api.example.com/foo"}}]}
+```
+
+### Parsing boundary
+
+The header is space-delimited and the JSON body is always appended after a single
+space. The version marker is always the first token.
+
+Recommended parser behavior:
+
+1. Check that the line starts with `@rabby-log/`.
+2. Read the first token as the protocol version.
+3. Parse subsequent `key=value` tokens until the first token that starts with `{`.
+4. Treat the remaining substring from `{` to end-of-line as the JSON body.
+
+Parsers should not assume a fixed token count. New header tokens may be added in the
+future.
+
+## Header Fields
+
+Current v1 fields:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `ts` | yes | ISO timestamp from `Date#toISOString()` |
+| `lvl` | yes | log level |
+| `src` | yes | log source, for example `console` or `logger` |
+| `method` | yes | original logging method, for example `log`, `warn`, `error`, `timeEnd` |
+| `env` | yes | runtime environment, currently `development`, `regression`, or `production` |
+| `sid` | yes | session identifier for the current app runtime |
+| `seq` | yes | monotonically increasing per-session sequence number |
+| `fmt` | yes | body encoding format, currently always `json` |
+| `platform` | no | platform token, currently `ios` or `android` when available |
+
+### Header value normalization
+
+Header values are normalized for safe token parsing:
+
+- whitespace is replaced with `_`
+- values are emitted as plain tokens
+
+The JSON body retains the richer original structure.
+
+## JSON Body Schema
+
+The line body is always a JSON object in v1:
+
+```json
+{
+  "message": "inline human-readable message",
+  "args": ["serialized", "arguments"],
+  "meta": {
+    "optional": "serialized metadata"
+  }
+}
+```
+
+### Body fields
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `message` | yes | truncated human-readable inline message derived from `args` |
+| `args` | yes | serialized original log arguments |
+| `meta` | no | serialized metadata added by the logger implementation |
+
+## Serializable Value Rules
+
+`args` and `meta` are serialized into JSON-compatible values.
+
+Supported output types:
+
+- `null`
+- `boolean`
+- `number`
+- `string`
+- arrays of serializable values
+- plain JSON objects whose values are serializable values
+
+### Special conversions
+
+| Input value | Serialized output |
+| --- | --- |
+| `undefined` | `"[undefined]"` |
+| `NaN` | `"[NaN]"` |
+| `Infinity`, `-Infinity` | string form, for example `"Infinity"` |
+| `bigint` | string with `n` suffix, for example `"123n"` |
+| `symbol` | string form from `Symbol#toString()` |
+| function | `"[Function <name>]"` |
+| `Date` | ISO string |
+| `Error` | object with `$type`, `message`, optional `stack`, optional serialized custom fields |
+| typed arrays | string like `"[Uint8Array(32)]"` |
+| `ArrayBuffer` | string like `"[ArrayBuffer(32)]"` |
+| circular reference | `"[Circular]"` |
+| deep array/object beyond max depth | compact placeholder string |
+| non-plain object | object containing `$type` plus enumerable serialized fields |
+
+### Depth rules
+
+Current serialization depth cap for ordinary values is 6 levels.
+
+Parsers should treat placeholder strings such as these as terminal values:
+
+- `"[Circular]"`
+- `"[Array(12)]"`
+- `"[Object]"`
+- `"[Uint8Array(32)]"`
+
+Exact placeholder wording is part of current behavior but should not be treated as
+stable schema for business logic.
+
+## Masking
+
+Sensitive values may be intentionally masked before serialization by wrapping them
+through `logger.mask(...)`.
+
+Masked output is intentionally lossy.
+
+Examples of possible masked output:
+
+- `"***"`
+- `"*********"`
+- `"***[ArrayBuffer]"`
+- object fields whose nested leaf values are replaced with `*`
+
+Tooling must not attempt to recover masked values.
+
+## Sources and Methods
+
+Common `src` values:
+
+- `console`
+- `logger`
+
+Common `method` values:
+
+- `log`
+- `info`
+- `warn`
+- `error`
+- `debug`
+- `trace`
+- `time`
+- `timeLog`
+- `timeEnd`
+- `assert`
+
+Additional record-specific metadata may appear in the JSON body `meta` field. For
+example:
+
+- stack traces for `trace`
+- timer labels and durations
+- OpenAPI request / response snapshots for instrumented failures
+
+## Session Identifier
+
+`sid` identifies one app runtime session.
+
+Current format:
+
+```text
+YYYY-MM-DD_HH-mm-ss_SSS-<random-base36-suffix>
+```
+
+Example:
+
+```text
+2026-04-10_18-20-41_102-k3v9qd
+```
+
+Parsers should treat `sid` as an opaque identifier.
+
+## Ordering Guarantees
+
+Within a single session:
+
+- `seq` is strictly increasing
+- records are written in enqueue order
+
+For cross-session analysis:
+
+- use `ts` first
+- use `sid` + `seq` for stable ordering inside the same session
+
+## Forward Compatibility
+
+Downstream parsers should follow these rules:
+
+1. Gate behavior by version marker, for example `@rabby-log/v1`.
+2. Ignore unknown header tokens.
+3. Ignore unknown JSON fields.
+4. Do not require a fixed header field order beyond the version token being first.
+5. Do not assume only one `.log` file exists inside a zip.
+6. Do not assume only one zip exists in `applogs/`.
+
+If a future version is introduced, it should use a new marker, for example:
+
+```text
+@rabby-log/v2
+```
+
+Version-specific parsers can then branch cleanly.
+
+## Recommended Parser Output Model
+
+External tools should normalize each line into a structure close to:
+
+```json
+{
+  "version": "v1",
+  "header": {
+    "ts": "2026-04-10T10:21:06.693Z",
+    "lvl": "warn",
+    "src": "console",
+    "method": "warn",
+    "env": "development",
+    "sid": "2026-04-10_18-20-41_102-k3v9qd",
+    "seq": 184,
+    "fmt": "json",
+    "platform": "ios"
+  },
+  "body": {
+    "message": "...",
+    "args": [],
+    "meta": {}
+  },
+  "rawLine": "@rabby-log/v1 ..."
+}
+```
+
+## Current Limitations
+
+- Unfinalized `.zip.partial` files are implementation details and should not be
+  treated as stable inputs for external tools.
+- Time range shown in the in-app archive picker currently uses file
+  create/update timestamps rather than log-content-derived start/end timestamps.
+- Finalized zip reuse is an implementation detail; tools should rely on file and
+  line formats, not on exact archive lifecycle behavior.
+
+## Source of Truth
+
+The implementation source of truth currently lives in:
+
+- `apps/mobile/src/utils/logging/format.ts`
+- `apps/mobile/src/utils/logging/rollingZipWriter.ts`
+- `apps/mobile/src/utils/logging/core.ts`
+
+If implementation and this document diverge, update both together in the same change.


### PR DESCRIPTION
## Summary
- extend the mobile app log archive system with environment-aware console capture and file logging policy
- add OpenAPI non-200 request/response logging, archive reuse/retention, and an on-device verification/share flow
- document the `@rabby-log/v1` archive and line format for downstream tooling under `docs/`

## Testing
- yarn workspace rabby-mobile test --runTestsByPath src/utils/logging/__tests__/logger.test.ts src/utils/logging/__tests__/policy.test.ts src/utils/openapiFailureLogging.test.ts --runInBand
- yarn workspace rabby-mobile typecheck
- yarn workspace rabby-mobile eslint src/utils/logging/rollingZipWriter.ts src/utils/logging/rnfsAdapter.ts src/utils/logging/__tests__/logger.test.ts src/utils/logging/policy.ts src/utils/logging/settings.ts src/utils/logging/core.ts src/utils/logger.ts src/utils/logging/__tests__/policy.test.ts src/utils/openapiFailureLogging.ts src/utils/openapiFailureLogging.test.ts src/core/request.ts src/core/notifications/openapi.ts --ext .ts --quiet
- yarn workspace rabby-mobile eslint src/screens/Testkits/DebugLogViewer.tsx --ext .tsx --quiet
