### PR TITLE
fix(ios): preserve metro startup in xcode debug

### DIFF
--- a/apps/mobile/ios/RabbyMobile.xcodeproj/project.pbxproj
+++ b/apps/mobile/ios/RabbyMobile.xcodeproj/project.pbxproj
@@ -587,7 +587,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > \"${SRCROOT}/../node_modules/react-native/scripts/.packager.env\"\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open \"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi\n";
+			shellScript = "export RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\nexport NO_PROXY=\"127.0.0.1,localhost,::1${NO_PROXY:+,$NO_PROXY}\"\nexport no_proxy=\"$NO_PROXY\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > \"${SRCROOT}/../node_modules/react-native/scripts/.packager.env\"\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z 127.0.0.1 ${RCT_METRO_PORT} ; then\n    if ! curl --noproxy '*' -s \"http://127.0.0.1:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open \"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/apps/mobile/ios/patches/phase-bundle-rn.sh
+++ b/apps/mobile/ios/patches/phase-bundle-rn.sh
@@ -88,8 +88,8 @@ check_env_file() {
 check_env_file;
 
 if [ "$CONFIGURATION" == "Debug" ] && [ "$IOS_SKIP_METRO_BUNDLE_ON_DEBUG" == "true" ]; then
-  echo "[RabbyMobileBuild] skip metro bundle on debug build as IOS_SKIP_METRO_BUNDLE_ON_DEBUG is true"
-  exit 0;
+  echo "[RabbyMobileBuild] skip debug bundle while preserving Metro device setup"
+  export SKIP_BUNDLING=1
 fi
 
 [ -f yarn ] && yarn install --immutable;


### PR DESCRIPTION
## Summary
- preserve React Native device Metro setup when `IOS_SKIP_METRO_BUNDLE_ON_DEBUG=true` by exporting `SKIP_BUNDLING=1` instead of exiting early
- make Xcode's packager status check bypass localhost proxy settings so an already-running Metro server on port 8081 is accepted

## Testing
- bash -n apps/mobile/ios/patches/phase-bundle-rn.sh
