### PR TITLE
build: keep node_modules between CI runs

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -44,8 +44,30 @@ jobs:
       - self-hosted
       - mobile
       - Linux
+    env:
+      RABBY_MOBILE_NM_USE_CACHE: 'true'
     steps:
       - uses: actions/checkout@v3
+        with:
+          clean: false
+
+      - name: Clean git Manually
+        run: |
+          yarn_exclude_args=()
+          if [ "$RABBY_MOBILE_NM_USE_CACHE" = "true" ]; then
+            echo "Keep yarn install outputs";
+            yarn_exclude_args+=(
+              -e node_modules
+              -e 'apps/*/node_modules'
+              -e 'packages/*/node_modules'
+              -e .yarn/install-state.gz
+              -e .yarn/unplugged
+            )
+          fi
+
+          git clean -ffdx "${yarn_exclude_args[@]}";
+          git reset --hard HEAD;
+
       - name: Get Actions Variables
         id: actionvars
         run: |

--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -86,29 +86,34 @@ jobs:
         run: |
           OS_TYPE=$(uname -s);
           echo "OS_TYPE is $OS_TYPE";
+          yarn_exclude_args=()
           if [ "$RABBY_MOBILE_NM_USE_CACHE" = "true" ]; then
-            echo "Use yarn installed node_modules";
-            yarn_exclude_files="-e node_modules -e apps/mobile/node_modules -e apps/mobile/packages/*/node_modules"
-          else
-            yarn_exclude_files="";
+            echo "Keep yarn install outputs";
+            yarn_exclude_args+=(
+              -e node_modules
+              -e 'apps/*/node_modules'
+              -e 'packages/*/node_modules'
+              -e .yarn/install-state.gz
+              -e .yarn/unplugged
+            )
           fi
 
           if [ "$OS_TYPE" == "Linux" ]; then
             if [ "$RABBY_MOBILE_GRADLE_USE_CACHE" = "true" ]; then
               echo "Keep gradle cache";
-              git clean -ffdx $yarn_exclude_files -e apps/mobile/android/.gradle -e apps/mobile/android/app/build;
+              git clean -ffdx "${yarn_exclude_args[@]}" -e apps/mobile/android/.gradle -e apps/mobile/android/app/build;
               rm -rf apps/mobile/android/app/build/outputs;
             else
               echo "Clean gradle cache";
-              git clean -ffdx $yarn_exclude_files;
+              git clean -ffdx "${yarn_exclude_args[@]}";
             fi
           elif [ "$OS_TYPE" == "Darwin" ]; then
             if [ "$RABBY_MOBILE_POD_USE_CACHE" = "true" ]; then
               echo "Keep cocoapods cache";
-              git clean -ffdx $yarn_exclude_files -e apps/mobile/ios/Pods -e apps/mobile/ios/build;
+              git clean -ffdx "${yarn_exclude_args[@]}" -e apps/mobile/ios/Pods -e apps/mobile/ios/build;
             else
               echo "Clean cocoapods cache";
-              git clean -ffdx $yarn_exclude_files;
+              git clean -ffdx "${yarn_exclude_args[@]}";
             fi
           fi
           git reset --hard HEAD;
@@ -176,7 +181,6 @@ jobs:
           echo "REALLY_UPLOAD value: $REALLY_UPLOAD";
           cd apps/mobile;
           nvm use;
-          rm -rf node_modules;
           yarn install --immutable;
           bundle install;
 

--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -48,10 +48,30 @@ jobs:
       - ${{ matrix.host }}
       - ${{ matrix.machine_loc }}
     env:
+      RABBY_MOBILE_NM_USE_CACHE: 'true'
       XCODE_VER: '26.3'
     steps:
       - name: Checkout git repo
         uses: actions/checkout@v4
+        with:
+          clean: false
+
+      - name: Clean git Manually
+        run: |
+          yarn_exclude_args=()
+          if [ "$RABBY_MOBILE_NM_USE_CACHE" = "true" ]; then
+            echo "Keep yarn install outputs";
+            yarn_exclude_args+=(
+              -e node_modules
+              -e 'apps/*/node_modules'
+              -e 'packages/*/node_modules'
+              -e .yarn/install-state.gz
+              -e .yarn/unplugged
+            )
+          fi
+
+          git clean -ffdx "${yarn_exclude_args[@]}";
+          git reset --hard HEAD;
 
       - name: Env Test
         id: env-test
@@ -95,7 +115,6 @@ jobs:
       - name: Install dependencies && Build app
         run: |
           cd apps/mobile;
-          rm -rf node_modules;
           yarn install --immutable;
           yarn postinstall;
 


### PR DESCRIPTION
## Summary
- keep installed node_modules between CI runs instead of deleting them before every build
- preserve Yarn install outputs during manual git clean in feature test and release workflows
- continue to run `yarn install --immutable` so the existing install is validated before build

## Testing
- not run (workflow-only change)