### PR TITLE
fix: restore ImportSecret scan touch behavior

### DIFF
--- a/apps/mobile/src/components2024/Form/Input.tsx
+++ b/apps/mobile/src/components2024/Form/Input.tsx
@@ -283,28 +283,23 @@ const NextInputComponent = ({
   const containerTestID = viewProps.testID ?? inputProps?.testID;
   const containerAccessibilityLabel =
     viewProps.accessibilityLabel ?? inputProps?.accessibilityLabel;
-  const shouldUseFocusableTestWrapper = !!(
+  const shouldAttachContainerA11y = !!(
     containerTestID || containerAccessibilityLabel
   );
   const normalizedInputProps = useMemo(() => {
-    if (!shouldUseFocusableTestWrapper || !inputProps) {
+    if (!shouldAttachContainerA11y || !inputProps) {
       return inputProps;
     }
 
-    const {
-      testID: _testID,
-      accessibilityLabel: _accessibilityLabel,
-      ...rest
-    } = inputProps;
+    const rest = { ...inputProps };
+    delete rest.testID;
+    delete rest.accessibilityLabel;
 
     return rest;
-  }, [inputProps, shouldUseFocusableTestWrapper]);
+  }, [inputProps, shouldAttachContainerA11y]);
 
   const needPatchTouchEvent = isAndroid && disableNestedTouchEventOnAndroid;
-  const WrapperComp =
-    needPatchTouchEvent || shouldUseFocusableTestWrapper
-      ? Pressable
-      : React.Fragment;
+  const WrapperComp = needPatchTouchEvent ? Pressable : React.Fragment;
   const shouldAttachContainerA11yToView = WrapperComp === React.Fragment;
 
   return (

--- a/apps/mobile/src/screens/Address/ImportSecret.tsx
+++ b/apps/mobile/src/screens/Address/ImportSecret.tsx
@@ -26,10 +26,7 @@ import { requestKeyring } from '@/core/apis/keyring';
 import { KEYRING_CLASS, KEYRING_TYPE } from '@rabby-wallet/keyring-utils';
 import { RcIconScannerCC } from '@/assets/icons/address';
 import { FooterButtonScreenContainer } from '@/components2024/ScreenContainer/FooterButtonScreenContainer';
-import {
-  isNewlyInputTextSameWithContentFromClipboard,
-  onPastedSensitiveData,
-} from '@/utils/clipboard';
+import { onPastedSensitiveData } from '@/utils/clipboard';
 import { Text } from '@/components/Typography';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
@@ -393,9 +390,10 @@ export const ImportSecret = ({ route }: ScreenProps) => {
                   ),
                   onChangeText: handleInputChange,
                 }}
+                // eslint-disable-next-line react/no-unstable-nested-components
                 customIcon={ctx => (
                   <TouchableOpacity
-                    style={ctx.wrapperStyle}
+                    style={[ctx.wrapperStyle, styles.scanButtonHitArea]}
                     onPress={() => {
                       navigateDeprecated(RootNames.Scanner);
                     }}>
@@ -496,6 +494,16 @@ const getStyles = createGetStyles2024(ctx => ({
   textArea: {
     marginTop: 14,
     paddingHorizontal: 20,
+  },
+  scanButtonHitArea: {
+    right: 0,
+    bottom: 0,
+    width: 32,
+    height: 32,
+    paddingRight: 14,
+    paddingBottom: 14,
+    justifyContent: 'flex-end',
+    alignItems: 'flex-end',
   },
   pasteButton: {
     marginTop: 50,


### PR DESCRIPTION
## Summary
- stop adding an extra `Pressable` wrapper in 2024 `NextInput` just because `testID` / `accessibilityLabel` is present
- keep moving those a11y props to the container so test selectors still attach without changing the touch model
- restore the ImportSecret scan button hit area so it keeps the original `right: 14 / bottom: 14` visual position while making the lower-right corner tappable

## Testing
- `yarn eslint src/components2024/Form/Input.tsx src/screens/Address/ImportSecret.tsx`
- verified the branch is based on `origin/develop`

## Context
- this fixes the regression where the private-key tab scan button stopped responding in non-production builds because `makeTestIDProps(...)` caused `NextInput` to wrap the field with an extra `Pressable`