### PR TITLE
fix: prevent CrossToken approval crash from orphan JSX whitespace

### DIFF
--- a/apps/mobile/src/components/Approval/components/Actions/CrossToken.tsx
+++ b/apps/mobile/src/components/Approval/components/Actions/CrossToken.tsx
@@ -65,7 +65,9 @@ const Swap = ({
 
   const handleClickRule = (id: string) => {
     const rule = rules.find(item => item.id === id);
-    if (!rule) return;
+    if (!rule) {
+      return;
+    }
     const result = engineResultMap[id];
     openRuleDrawer({
       ruleConfig: rule,
@@ -206,7 +208,7 @@ const Swap = ({
                 <Values.Percentage
                   style={commonStyle.subRowText}
                   value={usdValuePercentage!}
-                />{' '}
+                />
                 <Text style={commonStyle.subRowText}>
                   ({formatUsdValue(usdValueDiff || '')})
                 </Text>


### PR DESCRIPTION
## Summary
- `apps/mobile/src/components/Approval/components/Actions/CrossToken.tsx`: remove stray `{' '}` between `Values.Percentage` and the diff `<Text>`. In React Native that whitespace renders as an orphan text node outside a `<Text>` parent, triggering "Text strings must be rendered within a <Text> component" and crashing the cross-token approval screen.
- Drive-by: wrap the early-return `if` in `handleClickRule` in braces for brace-style consistency.

## Test plan
- [ ] Reproduce the original crash on `develop` by opening a cross-token approval that exercises the `Swap` action row (requires a tx with `usdValuePercentage` + `usdValueDiff`).
- [ ] With this patch, open the same approval and confirm no RN red-box, and the sub-row still renders `<percentage> (<usd diff>)` with readable spacing.
- [ ] `yarn typecheck` in `apps/mobile`.