### PR TITLE
refactor(mobile): use global getter for submit form guard

### DIFF
--- a/apps/mobile/src/hooks/appSettings.ts
+++ b/apps/mobile/src/hooks/appSettings.ts
@@ -37,7 +37,7 @@ const experimentalSettingsStore = zustandByMMKV<ScreenshotSettings>(
     iosForceDisableAlertForSensitiveScene: isNonPublicProductionEnv,
 
     timeTipAboutSeedPhraseAndPrivateKey: 'copy',
-    blockSubmitIfFormChangedOnAuth: __DEV__,
+    blockSubmitIfFormChangedOnAuth: false,
     toastOpenApiHttpErrorStatus: false,
     debugSwapHistorySkipLocalLookup: false,
   },

--- a/apps/mobile/src/hooks/appSettings.ts
+++ b/apps/mobile/src/hooks/appSettings.ts
@@ -46,6 +46,7 @@ const experimentalSettingsStore = zustandByMMKV<ScreenshotSettings>(
 export const storeApiExpSettingData = {
   set: setExpSettingData,
   get: getExpSettingData,
+  getShouldBlockSubmitIfFormChangedOnAuth,
   getTimeTipAboutSeedPhraseAndPrivateKey: () => {
     if (!__DEV__) {
       return 'pasted';
@@ -68,6 +69,10 @@ function setExpSettingData(valOrFunc: UpdaterOrPartials<ScreenshotSettings>) {
 
 function getExpSettingData() {
   return experimentalSettingsStore.getState();
+}
+
+function getShouldBlockSubmitIfFormChangedOnAuth() {
+  return __DEV__ && getExpSettingData().blockSubmitIfFormChangedOnAuth;
 }
 
 const KEY = isIOS

--- a/apps/mobile/src/screens/Bridge/components/BridgeContent.tsx
+++ b/apps/mobile/src/screens/Bridge/components/BridgeContent.tsx
@@ -69,7 +69,7 @@ import {
 import { BridgeSlippage } from './BridgeSlippage';
 import { Text } from '@/components/Typography';
 import { MarketClosedTip } from '@/components/Token/MarketClosedTip';
-import { useBlockSubmitIfFormChangedOnAuth } from '@/hooks/appSettings';
+import { storeApiExpSettingData } from '@/hooks/appSettings';
 import {
   FormAmountMode,
   FormValuesOnSubmit,
@@ -657,9 +657,6 @@ export const BridgeContent = ({ isForMultipleAddress = false }) => {
 
   const directSignBtnRef = useRef<DirectSignBtnMethods>(null);
 
-  const { blockSubmitIfFormChangedOnAuth } =
-    useBlockSubmitIfFormChangedOnAuth();
-
   const buildFormSnapshot = useCallback(
     (): BridgeFormSnapshot => ({
       amount: amount || '',
@@ -703,7 +700,7 @@ export const BridgeContent = ({ isForMultipleAddress = false }) => {
   );
 
   const handleBridge = useMemoizedFn(async (p?: { ignoreGasFee?: boolean }) => {
-    if (__DEV__) {
+    if (storeApiExpSettingData.getShouldBlockSubmitIfFormChangedOnAuth()) {
       const snapshot = formValuesRef.current.getSnapshot();
 
       if (!snapshot) {

--- a/apps/mobile/src/screens/Send/hooks/useSendToken.ts
+++ b/apps/mobile/src/screens/Send/hooks/useSendToken.ts
@@ -78,6 +78,7 @@ import { GetNestedScreenRouteProp } from '@/navigation-type';
 import { useMiniSigner } from '@/hooks/useSigner';
 import { MINI_SIGN_ERROR } from '@/components2024/MiniSignV2/state/SignatureManager';
 import { useSwapBridgeSlider } from '@/screens/Swap/hooks/slider';
+import { storeApiExpSettingData } from '@/hooks/appSettings';
 import { tokenAmountBn } from '@/screens/Swap/utils';
 import { useCexSupportList } from '@/hooks/useCexSupportList';
 import { ExtractAtomValueType, IExtractFromPromise } from '@/utils/type';
@@ -585,7 +586,6 @@ export function useSendTokenForm({
   currentAccount: Account | null;
 }) {
   const { t } = useTranslation();
-
   const sendTokenEventsRef = useRef(new EventEmitter());
   const { switchAccountOnSelectedToken } =
     useSwitchSceneAccountOnSelectedTokenWithOwner('MakeTransactionAbout');
@@ -1116,7 +1116,7 @@ export function useSendTokenForm({
     }: FormSendToken & {
       isForceSignTx?: boolean;
     }) => {
-      if (__DEV__) {
+      if (storeApiExpSettingData.getShouldBlockSubmitIfFormChangedOnAuth()) {
         const snapshot = formValuesRef.current.getSnapshot();
 
         if (!snapshot) {

--- a/apps/mobile/src/screens/Swap/index.tsx
+++ b/apps/mobile/src/screens/Swap/index.tsx
@@ -110,7 +110,7 @@ import { MarketClosedTip } from '@/components/Token/MarketClosedTip';
 import { APP_VERSIONS } from '@/constant';
 import { stats } from '@/utils/stats';
 import { Text } from '@/components/Typography';
-import { useBlockSubmitIfFormChangedOnAuth } from '@/hooks/appSettings';
+import { storeApiExpSettingData } from '@/hooks/appSettings';
 import {
   FormAmountMode,
   FormValuesOnSubmit,
@@ -261,9 +261,6 @@ const Swap = ({
     () => (autoSlippage ? autoSuggestSlippage : _slippage),
     [_slippage, autoSlippage, autoSuggestSlippage],
   );
-
-  const { blockSubmitIfFormChangedOnAuth } =
-    useBlockSubmitIfFormChangedOnAuth();
 
   const {
     isSupportedChain,
@@ -615,7 +612,7 @@ const Swap = ({
   );
 
   const handleSwap = useMemoizedFn(async (p?: { ignoreGasFee?: boolean }) => {
-    if (__DEV__) {
+    if (storeApiExpSettingData.getShouldBlockSubmitIfFormChangedOnAuth()) {
       const snapshot = formValuesRef.current.getSnapshot();
 
       if (!snapshot) {

--- a/apps/mobile/src/screens/Testkits/DevSwitches.tsx
+++ b/apps/mobile/src/screens/Testkits/DevSwitches.tsx
@@ -1186,7 +1186,7 @@ function DevSwitchSubmitFormGuard() {
             styles.secondarySectionTitle,
             { fontSize: 24, marginLeft: 2 },
           ]}>
-          Swap / Bridge Submit Guard
+          Send / Swap / Bridge Submit Guard
         </Text>
       </View>
 
@@ -1204,7 +1204,7 @@ function DevSwitchSubmitFormGuard() {
           <Text style={styles.switchLabel}>
             {blockSubmitIfFormChangedOnAuth
               ? 'Block submit and alert on auth-time form change'
-              : 'Only detect auth-time form change without blocking'}
+              : 'Disable auth-time form change submit guard'}
           </Text>
         </TouchableOpacity>
       </View>


### PR DESCRIPTION
## Summary
- add a global getter in experimental app settings for the auth-time submit guard
- switch Bridge, Swap, and Send formValuesRef guard checks to use the global getter instead of a React hook
- update the Dev Switches label to reflect Send / Swap / Bridge coverage and the disabled-state wording

## Testing
- yarn eslint src/hooks/appSettings.ts src/screens/Bridge/components/BridgeContent.tsx src/screens/Swap/index.tsx src/screens/Send/hooks/useSendToken.ts src/screens/Testkits/DevSwitches.tsx --ext .ts,.tsx
- yarn typecheck