### PR TITLE
build: publish 0.6.68

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -107,8 +107,8 @@ android {
         applicationId "com.debank.rabbymobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 100206
-        versionName "0.6.67"
+        versionCode 100207
+        versionName "0.6.68"
         missingDimensionStrategy "store", "play"
         externalNativeBuild {
           cmake {

--- a/apps/mobile/ios/RabbyMobile/Info.plist
+++ b/apps/mobile/ios/RabbyMobile/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.67</string>
+	<string>0.6.68</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/apps/mobile/ios/RabbyMobileTests/Info.plist
+++ b/apps/mobile/ios/RabbyMobileTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.67</string>
+	<string>0.6.68</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rabby-mobile",
-  "version": "0.6.67",
+  "version": "0.6.68",
   "private": true,
   "repository": {
     "type": "git",

--- a/apps/mobile/src/changeLogs/0.6.68.md
+++ b/apps/mobile/src/changeLogs/0.6.68.md
@@ -1,0 +1,3 @@
+### Features
+
+- Fixed some bugs and optimized user experience


### PR DESCRIPTION
## Summary
- publish Rabby Mobile 0.6.68
- sync native version metadata with yarn rnversion
- ensure a default changelog file exists for this release

## Verification
- version bump applied
- changelog present
- publish commit created