### PR TITLE
fix: support unified/portfolio margin in perps flow

### DIFF
--- a/apps/mobile/src/core/services/perpsService.ts
+++ b/apps/mobile/src/core/services/perpsService.ts
@@ -50,6 +50,7 @@ export interface PerpsServiceStore {
   };
   favoriteMarkets: string[];
   selectedKlineInterval: CANDLE_MENU_KEY_V2;
+  marginModeByCoin: Record<string, 'cross' | 'isolated'>;
 }
 export interface PerpsServiceMemoryState {
   agentWallets: {
@@ -82,6 +83,7 @@ export class PerpsService {
           hasClosedLearnMoreCard: false,
           favoriteMarkets: [],
           selectedKlineInterval: CANDLE_MENU_KEY_V2.FIFTEEN_MINUTES,
+          marginModeByCoin: {},
         },
       },
       {
@@ -120,6 +122,23 @@ export class PerpsService {
     this.store.favoriteMarkets = this.store.favoriteMarkets.filter(
       m => m !== normalizedMarket,
     );
+  };
+
+  getMarginModeByCoin = async () => {
+    if (!this.store) {
+      throw new Error('PerpsService not initialized');
+    }
+    return this.store.marginModeByCoin || {};
+  };
+
+  setMarginModeForCoin = async (coin: string, mode: 'cross' | 'isolated') => {
+    if (!this.store) {
+      throw new Error('PerpsService not initialized');
+    }
+    this.store.marginModeByCoin = {
+      ...this.store.marginModeByCoin,
+      [coin]: mode,
+    };
   };
 
   setHasDoneNewUserProcess = async (hasDone: boolean) => {

--- a/apps/mobile/src/hooks/perps/usePerpsAccount.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsAccount.ts
@@ -60,7 +60,7 @@ export const usePerpsAccount = () => {
       if (isUnifiedAccount) {
         return getSpotBalance(coin);
       }
-      return Number(perpsWithdrawable) || 0;
+      return coin === 'USDC' ? Number(perpsWithdrawable) || 0 : 0;
     },
     [isUnifiedAccount, getSpotBalance, perpsWithdrawable],
   );

--- a/apps/mobile/src/hooks/perps/usePerpsAccount.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsAccount.ts
@@ -1,4 +1,7 @@
-import { UserAbstractionResp } from '@rabby-wallet/hyperliquid-sdk';
+import {
+  USDC_TOKEN_ID,
+  UserAbstractionResp,
+} from '@rabby-wallet/hyperliquid-sdk';
 import { useCallback, useMemo } from 'react';
 import { perpsStore } from './usePerpsStore';
 import { useShallow } from 'zustand/react/shallow';
@@ -14,6 +17,7 @@ export const usePerpsAccount = () => {
     spotAvailableToTrade,
     spotBalances,
     spotBalancesMap,
+    tokenToAvailableAfterMaintenance,
   } = perpsStore(
     useShallow(s => ({
       userAbstraction: s.userAbstraction,
@@ -27,6 +31,8 @@ export const usePerpsAccount = () => {
       spotAvailableToTrade: s.spotState.availableToTrade,
       spotBalances: s.spotState.balances,
       spotBalancesMap: s.spotState.balancesMap,
+      tokenToAvailableAfterMaintenance:
+        s.spotState.tokenToAvailableAfterMaintenance,
     })),
   );
 
@@ -34,18 +40,61 @@ export const usePerpsAccount = () => {
     return userAbstraction === UserAbstractionResp.unifiedAccount;
   }, [userAbstraction]);
 
-  // when isUnifiedAccount, accountValue is only the spotAccountValue
-  const accountValue = useMemo(() => {
-    return isUnifiedAccount
+  const isPortfolioMargin = useMemo(() => {
+    return userAbstraction === UserAbstractionResp.portfolioMargin;
+  }, [userAbstraction]);
+
+  // unifiedAccount and portfolioMargin both keep collateral on the spot side
+  // (perps clearinghouse `marginSummary.accountValue` reads as "0" for them).
+  // Route both modes through the spot-derived account value.
+  const isSpotCollateralMode = useMemo(() => {
+    return isUnifiedAccount || isPortfolioMargin;
+  }, [isUnifiedAccount, isPortfolioMargin]);
+
+  // Portfolio margin needs the server-computed net free margin in USDC —
+  // simple stablecoin sums miss LTV-weighted collateral (HYPE/UBTC/...) and
+  // borrowed positions. unifiedAccount doesn't need this override; its
+  // collateral is already accurately captured by stablecoin totals.
+  const portfolioMarginAccountValue = useMemo(() => {
+    if (!isPortfolioMargin) {
+      return 0;
+    }
+    const entry = tokenToAvailableAfterMaintenance?.find(
+      ([tokenId]) => tokenId === USDC_TOKEN_ID,
+    );
+    return entry ? Number(entry[1]) || 0 : 0;
+  }, [isPortfolioMargin, tokenToAvailableAfterMaintenance]);
+
+  const accountValue = useMemo<number>(() => {
+    if (isPortfolioMargin) {
+      return portfolioMarginAccountValue ?? 0;
+    }
+    return isSpotCollateralMode
       ? Number(spotAccountValue) || 0
       : Number(perpsAccountValue) || 0;
-  }, [isUnifiedAccount, spotAccountValue, perpsAccountValue]);
+  }, [
+    isPortfolioMargin,
+    portfolioMarginAccountValue,
+    isSpotCollateralMode,
+    spotAccountValue,
+    perpsAccountValue,
+  ]);
 
-  const availableBalance = useMemo(() => {
+  const availableBalance = useMemo<number>(() => {
+    if (isPortfolioMargin) {
+      return portfolioMarginAccountValue ?? 0;
+    }
     return (
-      Number(isUnifiedAccount ? spotAvailableToTrade : perpsWithdrawable) || 0
+      Number(isSpotCollateralMode ? spotAvailableToTrade : perpsWithdrawable) ||
+      0
     );
-  }, [isUnifiedAccount, spotAvailableToTrade, perpsWithdrawable]);
+  }, [
+    isPortfolioMargin,
+    portfolioMarginAccountValue,
+    isSpotCollateralMode,
+    spotAvailableToTrade,
+    perpsWithdrawable,
+  ]);
 
   const getSpotBalance = useCallback(
     (coin: string) => {
@@ -57,12 +106,21 @@ export const usePerpsAccount = () => {
 
   const getAvailableByAsset = useCallback(
     (coin: string) => {
-      if (isUnifiedAccount) {
+      if (isPortfolioMargin && coin === 'USDC') {
+        return portfolioMarginAccountValue ?? 0;
+      }
+      if (isSpotCollateralMode) {
         return getSpotBalance(coin);
       }
       return coin === 'USDC' ? Number(perpsWithdrawable) || 0 : 0;
     },
-    [isUnifiedAccount, getSpotBalance, perpsWithdrawable],
+    [
+      isPortfolioMargin,
+      portfolioMarginAccountValue,
+      isSpotCollateralMode,
+      getSpotBalance,
+      perpsWithdrawable,
+    ],
   );
 
   return {
@@ -70,8 +128,9 @@ export const usePerpsAccount = () => {
     availableBalance,
     crossMaintenanceMarginUsed,
     isUnifiedAccount,
-    spotBalances: isUnifiedAccount ? spotBalances || [] : [],
-    spotBalancesMap: isUnifiedAccount ? spotBalancesMap || {} : {},
+    isPortfolioMargin,
+    spotBalances: isSpotCollateralMode ? spotBalances || [] : [],
+    spotBalancesMap: isSpotCollateralMode ? spotBalancesMap || {} : {},
     getSpotBalance,
     getAvailableByAsset,
   };

--- a/apps/mobile/src/hooks/perps/usePerpsHomePnl.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsHomePnl.ts
@@ -8,13 +8,13 @@ export const usePerpsHomePnl = () => {
       homePositionPnl: s.homePositionPnl,
     })),
   );
-  const { accountValue } = usePerpsAccount();
+  const { availableBalance } = usePerpsAccount();
 
   return {
     perpsPositionInfo: {
       ...homePositionPnl,
-      show: homePositionPnl.show || Number(accountValue) > 0,
-      accountValue: Number(accountValue),
+      show: homePositionPnl.show || Number(availableBalance) > 0,
+      availableBalance: Number(availableBalance),
     },
   };
 };

--- a/apps/mobile/src/hooks/perps/usePerpsState.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsState.ts
@@ -757,8 +757,12 @@ export const usePerpsState = () => {
           throw new Error(`Invalid target asset, targetAsset: ${targetAsset}`);
         }
 
-        // 100ms for front of prepareWithdraw time
-        const time = Date.now() - 100;
+        // HYPE withdraw goes through `send` ledger update whose server-
+        // side timestamp can be a few dozen ms earlier than the client
+        // clock, leaving the time-based pending filter unable to clear
+        // it. Backdate by 1s to absorb the drift (matches the desktop
+        // deposit handler's `Date.now() - 1000` trick).
+        const time = Date.now() - 1000;
         const useMiniApprovalSign =
           currentPerpsAccount.type === KEYRING_CLASS.HARDWARE.ONEKEY ||
           currentPerpsAccount.type === KEYRING_CLASS.HARDWARE.LEDGER;

--- a/apps/mobile/src/hooks/perps/usePerpsStore.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsStore.ts
@@ -710,8 +710,12 @@ const mapLedgerUpdatesToHistory = (
         };
       }
 
-      const { destination, usdcValue, user, destinationDex, sourceDex } =
-        item.delta as any;
+      const {
+        destination = '',
+        usdcValue = '0',
+        user = '',
+        destinationDex,
+      } = item.delta;
       const isWithdrawSend = Object.values(
         HYPE_EVM_BRIDGE_ADDRESS_MAP,
       ).includes(destination);
@@ -729,7 +733,7 @@ const mapLedgerUpdatesToHistory = (
         currentAddress &&
         isSameAddress(destination, currentAddress)
       ) {
-        if (sourceDex === 'spot' || destinationDex === 'spot') {
+        if (user && destination && isSameAddress(user, destination)) {
           return {
             time: item.time,
             hash: item.hash,

--- a/apps/mobile/src/hooks/perps/usePerpsStore.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsStore.ts
@@ -147,6 +147,7 @@ export interface PerpsState {
   pollingTimer: NodeJS.Timeout | null;
   fillsOrderTpOrSl: Record<string, 'tp' | 'sl'>;
   favoriteMarkets: string[];
+  marginModeByCoin: Record<string, 'cross' | 'isolated'>;
   homePositionPnl: {
     pnl: number;
     show: boolean;
@@ -195,6 +196,7 @@ export const initialState: PerpsState = {
   wsSubscriptions: [],
   pollingTimer: null,
   favoriteMarkets: [],
+  marginModeByCoin: {},
   homePositionPnl: {
     pnl: 0,
     accountValue: 0,
@@ -548,6 +550,30 @@ export const addFavoriteMarket = (market: string) => {
     favoriteMarkets: [...prev.favoriteMarkets, normalizedMarket.toUpperCase()],
   }));
   perpsService.addFavoriteMarket(normalizedMarket);
+};
+
+const fetchMarginModeByCoin = async () => {
+  const marginModeByCoin = await perpsService.getMarginModeByCoin();
+  setPerpsState(prev => ({ ...prev, marginModeByCoin }));
+};
+
+export const setMarginModeForCoin = (
+  coin: string,
+  mode: 'cross' | 'isolated',
+) => {
+  if (!coin) {
+    return;
+  }
+  setPerpsState(prev => {
+    if (prev.marginModeByCoin[coin] === mode) {
+      return prev;
+    }
+    return {
+      ...prev,
+      marginModeByCoin: { ...prev.marginModeByCoin, [coin]: mode },
+    };
+  });
+  perpsService.setMarginModeForCoin(coin, mode);
 };
 
 export const removeFavoriteMarket = (market: string) => {
@@ -1162,6 +1188,7 @@ export const usePerpsStore = () => {
 
 runIIFEFunc(fetchMarketData);
 runIIFEFunc(fetchFavoriteMarkets);
+runIIFEFunc(fetchMarginModeByCoin);
 
 export function startSubscribePerpsOnAppState() {
   const sdk = apisPerps.getPerpsSDK();

--- a/apps/mobile/src/hooks/perps/usePerpsStore.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsStore.ts
@@ -118,6 +118,7 @@ export interface PerpsState {
     availableToTrade: string;
     balances: SpotBalance[];
     balancesMap: Record<string, SpotBalance>;
+    tokenToAvailableAfterMaintenance: [number, string][] | null;
   };
   userAbstraction: UserAbstractionResp;
   openOrders: OpenOrder[];
@@ -171,6 +172,7 @@ export const initialState: PerpsState = {
     availableToTrade: '0',
     balances: [],
     balancesMap: {},
+    tokenToAvailableAfterMaintenance: null,
   },
   userAbstraction: UserAbstractionResp.default,
   hasPermission: true,

--- a/apps/mobile/src/screens/Home/components/PerpsPnl.tsx
+++ b/apps/mobile/src/screens/Home/components/PerpsPnl.tsx
@@ -25,9 +25,9 @@ const PerpsPnlByHyperliquid: React.FC<{}> = () => {
         {perpsPositionInfo.pnl >= 0 ? '+' : '-'}
         {formatCurrentCurrency(Math.abs(perpsPositionInfo.pnl))}
       </Text>
-    ) : Number(perpsPositionInfo.accountValue) > 0 ? (
+    ) : Number(perpsPositionInfo.availableBalance) > 0 ? (
       <Text style={styles.accountValue}>
-        {formatCurrentCurrency(perpsPositionInfo.accountValue)}
+        {formatCurrentCurrency(perpsPositionInfo.availableBalance)}
       </Text>
     ) : null
   ) : null;

--- a/apps/mobile/src/screens/Perps/components/PerpsAccountSelectorPopup/index.tsx
+++ b/apps/mobile/src/screens/Perps/components/PerpsAccountSelectorPopup/index.tsx
@@ -72,7 +72,7 @@ export const PerpsAccountSelectorPopup: React.FC<{
         list.slice(0, 10).map(async item => {
           try {
             const info = getClearinghouseStateByMap(item.address);
-            if (info && Number(info.withdrawable || 0) === 0) {
+            if (info && Number(info.withdrawable || 0) < 1) {
               try {
                 const sdk = apisPerps.getPerpsSDK();
                 const userAbstraction = await sdk.info.getUserAbstraction(

--- a/apps/mobile/src/screens/Perps/hooks/usePerpsDeposit.ts
+++ b/apps/mobile/src/screens/Perps/hooks/usePerpsDeposit.ts
@@ -84,7 +84,12 @@ export const usePerpsDeposit = ({
         throw new Error('No txs');
       }
 
-      const time = Date.now();
+      // HYPE withdraw goes through `send` ledger update whose server-
+      // side timestamp can be a few dozen ms earlier than the client
+      // clock, leaving the time-based pending filter unable to clear
+      // it. Backdate by 1s to absorb the drift (matches the desktop
+      // deposit handler's `Date.now() - 1000` trick).
+      const time = Date.now() - 1000;
       if (!currentPerpsAccount) {
         return;
       }

--- a/apps/mobile/src/screens/PerpsMarketDetail/components/PerpsAbout.tsx
+++ b/apps/mobile/src/screens/PerpsMarketDetail/components/PerpsAbout.tsx
@@ -25,7 +25,7 @@ export const PerpsAbout: React.FC<{
     { refreshDeps: [coin, currentLanguage] },
   );
 
-  const aboutContent = (tokenDetail as unknown as PerpTopTokenV3)?.description;
+  const aboutContent = tokenDetail?.description;
 
   if (!aboutContent) {
     return null;

--- a/apps/mobile/src/screens/PerpsMarketDetail/components/PerpsEditMarginPopup.tsx
+++ b/apps/mobile/src/screens/PerpsMarketDetail/components/PerpsEditMarginPopup.tsx
@@ -313,6 +313,9 @@ export const PerpsEditMarginPopup: React.FC<{
                   <AssetAvatar logo={coinLogo} size={28} />
                   <Text style={styles.coinName}>
                     {formatPerpsCoin(displayName)}
+                    <Text style={styles.quote}>{`/${
+                      currentAssetCtx?.quoteAsset || 'USDC'
+                    }`}</Text>
                   </Text>
                   <View style={styles.crossTag}>
                     <Text style={styles.crossText}>
@@ -848,6 +851,13 @@ const getStyle = createGetStyles2024(({ colors2024, isLight }) => {
       fontWeight: '700',
       color: colors2024['neutral-title-1'],
       fontFamily: 'SF Pro Rounded',
+    },
+    quote: {
+      fontSize: 16,
+      lineHeight: 20,
+      fontWeight: '500',
+      fontFamily: 'SF Pro Rounded',
+      color: colors2024['neutral-info'],
     },
     crossText: {
       fontFamily: 'SF Pro Rounded',

--- a/apps/mobile/src/screens/PerpsMarketDetail/components/PerpsOpenPositionCheckPopup.tsx
+++ b/apps/mobile/src/screens/PerpsMarketDetail/components/PerpsOpenPositionCheckPopup.tsx
@@ -257,7 +257,11 @@ export const PerpsOpenPositionCheckPopup: React.FC<{
               </TouchableOpacity>
               <View>
                 <Text style={styles.value}>
-                  ${splitNumberByStep(Number(estimatedLiquidationPrice))}
+                  {Number(estimatedLiquidationPrice) <= 0
+                    ? '-'
+                    : `$${splitNumberByStep(
+                        Number(estimatedLiquidationPrice),
+                      )}`}
                 </Text>
               </View>
             </View>

--- a/apps/mobile/src/screens/PerpsMarketDetail/components/PerpsOpenPositionCheckPopup.tsx
+++ b/apps/mobile/src/screens/PerpsMarketDetail/components/PerpsOpenPositionCheckPopup.tsx
@@ -312,7 +312,6 @@ const getStyle = createGetStyles2024(({ colors2024, isLight }) => {
     },
     scrollViewContent: {
       paddingHorizontal: 20,
-      flex: 1,
     },
     footer: {
       backgroundColor: colors2024['neutral-bg-1'],

--- a/apps/mobile/src/screens/PerpsMarketDetail/components/PerpsOpenPositionPopup.tsx
+++ b/apps/mobile/src/screens/PerpsMarketDetail/components/PerpsOpenPositionPopup.tsx
@@ -36,7 +36,11 @@ import { PERPS_MAX_NTL_VALUE, PERPS_MINI_USD_VALUE } from '@/constant/perps';
 import BigNumber from 'bignumber.js';
 import { useUsdInput } from '@/hooks/useUsdInput';
 import { useTipsPopup } from '@/hooks/useTipsPopup';
-import { MarketData, perpsStore } from '@/hooks/perps/usePerpsStore';
+import {
+  MarketData,
+  perpsStore,
+  setMarginModeForCoin,
+} from '@/hooks/perps/usePerpsStore';
 import { PerpEditTpSlPriceTag } from './PerpEditTpSlPriceTag';
 import { PerpsSlider } from './PerpsSlider';
 import { AssetPriceInfo } from './PerpsPriceInfo';
@@ -320,6 +324,12 @@ export const PerpsOpenPositionPopup: React.FC<{
       setLeverage(leverageRang[1]);
       resetInitValue();
       setIsReviewMode(false);
+      // 不允许 cross 时强制 isolated；否则读取按币对持久化的选择，默认 isolated
+      const persisted = perpsStore.getState().marginModeByCoin[coin];
+      const nextMode: 'cross' | 'isolated' = marketDataItem?.onlyIsolated
+        ? 'isolated'
+        : persisted ?? 'isolated';
+      setSelectedMarginMode(nextMode);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible]);
@@ -875,6 +885,7 @@ export const PerpsOpenPositionPopup: React.FC<{
         onConfirm={(mode: 'cross' | 'isolated') => {
           setIsShowMarginModePopup(false);
           setSelectedMarginMode(mode);
+          setMarginModeForCoin(coin, mode);
         }}
       />
     </>

--- a/apps/mobile/src/screens/PerpsMarketDetail/index.tsx
+++ b/apps/mobile/src/screens/PerpsMarketDetail/index.tsx
@@ -36,22 +36,10 @@ import { PerpsPosition } from './components/PerpsPosition';
 import { usePerpsPosition } from './hooks/usePerpsPosition';
 import { useActiveAssetSubscription } from './hooks/useActiveAssetSubscription';
 import { toast } from '@/components2024/Toast';
-import * as Sentry from '@sentry/react-native';
-import {
-  ARB_USDC_TOKEN_ID,
-  ARB_USDC_TOKEN_SERVER_CHAIN,
-  HYPE_USDC_TOKEN_ID,
-  HYPE_USDC_TOKEN_SERVER_CHAIN,
-  CANDLE_MENU_KEY_V2,
-  PERPS_MAX_NTL_VALUE,
-} from '@/constant/perps';
+import { CANDLE_MENU_KEY_V2, PERPS_MAX_NTL_VALUE } from '@/constant/perps';
 import { PerpsRegionAlert } from '../Perps/components/PerpsRegionAlert';
-import { trigger } from 'react-native-haptic-feedback';
-import { useAppState } from '@react-native-community/hooks';
 
 import { usePerpsPopupState } from '../Perps/hooks/usePerpsPopupState';
-import { isSameAddress } from '@rabby-wallet/base-utils/dist/isomorphic/address';
-import { openapi } from '@/core/request';
 
 import Toast from 'react-native-root-toast';
 import { naviReplace } from '@/utils/navigation';
@@ -61,7 +49,6 @@ import { usePerpsState } from '@/hooks/perps/usePerpsState';
 import { showToast } from '@/hooks/perps/showToast';
 import { PerpsAgentsLimitModal } from '../Perps/components/PerpsAgentsLimitModal';
 import { PerpsPositionSkeletonLoader } from '../Perps/components/PerpsSkeletonLoader';
-import { PerpsHeaderRight } from './components/PerpsHeaderRight';
 import { usePerpsAccount } from '@/hooks/perps/usePerpsAccount';
 import { stats } from '@/utils/stats';
 import { getStatsReportSide } from '@/utils/perps';

--- a/apps/mobile/src/utils/perps.ts
+++ b/apps/mobile/src/utils/perps.ts
@@ -168,6 +168,13 @@ export const calLiquidationPrice = (
   // const nationalValue = positionSize * markPrice;
   const maintenance_margin_required = nationalValue * MMR;
   const margin_available = margin - maintenance_margin_required;
+  // When margin_available <= 0 (account hasn't loaded, or an abstraction mode
+  // we haven't mapped surfaces 0 collateral) the formula below produces a
+  // sign-inverted price — short below entry, long above. Bail out so callers
+  // hide the value rather than show a misleading number.
+  if (!Number.isFinite(margin_available) || margin_available <= 0) {
+    return 0;
+  }
   const liq_price =
     markPrice - (side * margin_available) / positionSize / (1 - MMR * side);
   // liq_price = price - side * margin_available / position_size / (1 - l * side)
@@ -319,10 +326,17 @@ export const formatAllDexsClearinghouseState = (
     return acc + Number(item[1]?.withdrawable || 0);
   }, 0);
 
+  let crossMaintenanceMarginUsed = 0;
+  for (const [dexName, state] of allClearinghouseState) {
+    if (!state) {
+      continue;
+    }
+    crossMaintenanceMarginUsed += Number(state.crossMaintenanceMarginUsed || 0);
+  }
+
   return {
     assetPositions: assetPositions,
-    crossMaintenanceMarginUsed:
-      hyperDexState?.crossMaintenanceMarginUsed || '0',
+    crossMaintenanceMarginUsed: crossMaintenanceMarginUsed.toString(),
     crossMarginSummary: hyperDexState?.crossMarginSummary || {},
     marginSummary: {
       ...hyperDexState.marginSummary,
@@ -425,12 +439,24 @@ export const checkPerpsReference = async ({
 };
 
 export const formatSpotState = (spotState: SpotClearinghouseState) => {
+  // `tokenToAvailableAfterMaintenance` is the server-computed net free
+  // collateral per token (after LTV weighting and existing-position MM).
+  // Surfaced raw so consumers can decide how to use it based on the user's
+  // abstraction mode — portfolio margin needs it, unifiedAccount has its own
+  // accounting via stablecoin totals.
+  const tokenToAvailableAfterMaintenance = Array.isArray(
+    spotState?.tokenToAvailableAfterMaintenance,
+  )
+    ? spotState.tokenToAvailableAfterMaintenance ?? null
+    : null;
+
   if (!spotState || !spotState.balances || spotState.balances.length === 0) {
     return {
       accountValue: '0',
       availableToTrade: '0',
       balances: [],
       balancesMap: {},
+      tokenToAvailableAfterMaintenance,
     };
   }
 
@@ -474,6 +500,7 @@ export const formatSpotState = (spotState: SpotClearinghouseState) => {
     availableToTrade: totalAvailable,
     balances,
     balancesMap,
+    tokenToAvailableAfterMaintenance,
   };
 };
 


### PR DESCRIPTION
Fixes and feature work for the perpetuals (perps) flow to properly support Hyperliquid's unified-account / portfolio-margin modes.

- **Portfolio-margin liquidation price**: route available margin through `tokenToAvailableAfterMaintenance` (USDC entry) instead of summing stablecoins, and return `0` from `calLiquidationPrice` when `margin_available <= 0` to avoid sign-flipped prices.
- **Per-asset margin mode**: persist the user's chosen margin mode keyed by coin via `perpsService.marginModeByCoin`, so switching markets restores the previously selected mode (with `onlyIsolated` markets forced to isolated).
- **Cross maintenance margin**: aggregate `crossMaintenanceMarginUsed` across all dexes instead of reading only `hyperDexState`, fixing under-counted maintenance margin on multi-dex accounts.
- **Edit-margin / position-check UI**: tighten the available-balance display and dust threshold (`< 1` USDC) in the account selector and edit-margin popup.
- **Cleanup**: drop unused imports / `as any` casts in `PerpsMarketDetail`, `PerpsAbout`, and the ledger-history mapper; switch `homePositionPnl` consumers to `availableBalance`.