### PR TITLE
fix(mobile): avoid receive row long press swallowing taps

### DIFF
--- a/apps/mobile/src/components/AccountSelector/AccountsPanel.tsx
+++ b/apps/mobile/src/components/AccountSelector/AccountsPanel.tsx
@@ -101,6 +101,28 @@ function AddressItemInSheetModal({
     toast.success('Copied successfully');
   };
 
+  const handleRowFeedbackLongPress = useCallback(() => {
+    trigger('impactLight', {
+      enableVibrateFallback: true,
+      ignoreAndroidSystemSettings: false,
+    });
+  }, []);
+  const rowFeedbackLongPressProps = useMemo<
+    Pick<
+      React.ComponentProps<typeof TouchableOpacity>,
+      'delayLongPress' | 'onLongPress'
+    >
+  >(() => {
+    if (isReceive) {
+      return {};
+    }
+
+    return {
+      delayLongPress: 200,
+      onLongPress: handleRowFeedbackLongPress,
+    };
+  }, [handleRowFeedbackLongPress, isReceive]);
+
   return (
     <AddressItemShadowView
       style={isCurrent || isPressing ? styles.active : null}>
@@ -114,17 +136,7 @@ function AddressItemInSheetModal({
         activeOpacity={1}
         onPressIn={() => setIsPressing(true)}
         onPressOut={() => setIsPressing(false)}
-        delayLongPress={isReceive ? undefined : 200}
-        onLongPress={
-          isReceive
-            ? undefined
-            : () => {
-                trigger('impactLight', {
-                  enableVibrateFallback: true,
-                  ignoreAndroidSystemSettings: false,
-                });
-              }
-        }
+        {...rowFeedbackLongPressProps}
         onPress={() => {
           triggerLight();
           defaultPressAction === 'copy'

--- a/apps/mobile/src/components/AccountSelector/AccountsPanel.tsx
+++ b/apps/mobile/src/components/AccountSelector/AccountsPanel.tsx
@@ -114,13 +114,17 @@ function AddressItemInSheetModal({
         activeOpacity={1}
         onPressIn={() => setIsPressing(true)}
         onPressOut={() => setIsPressing(false)}
-        delayLongPress={200}
-        onLongPress={() => {
-          trigger('impactLight', {
-            enableVibrateFallback: true,
-            ignoreAndroidSystemSettings: false,
-          });
-        }}
+        delayLongPress={isReceive ? undefined : 200}
+        onLongPress={
+          isReceive
+            ? undefined
+            : () => {
+                trigger('impactLight', {
+                  enableVibrateFallback: true,
+                  ignoreAndroidSystemSettings: false,
+                });
+              }
+        }
         onPress={() => {
           triggerLight();
           defaultPressAction === 'copy'


### PR DESCRIPTION
## Summary
- disable the row-level haptic-only long press for receive account rows
- keep the outer receive address context menu intact so copy/edit long press still works
- clarify the row long-press props so non-receive rows retain the old feedback behavior

## Validation
- yarn workspace rabby-mobile eslint src/components/AccountSelector/AccountsPanel.tsx --quiet
- git diff --check origin/develop..HEAD

## Notes
This is split out from the import-cycle PRs because it is a receive-row touch handling bugfix, not import-cycle cleanup. The Friday package branch has already carried this change for device validation.