### PR TITLE
fix(mobile): use AnimatedText from Typography for home tab labels

### DIFF
--- a/apps/mobile/src/components/Typography.tsx
+++ b/apps/mobile/src/components/Typography.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react-native-gesture-handler';
 import AnimateableTextImpl from 'react-native-animateable-text';
 import { Text as RNEUITextImpl } from '@rneui/base';
-import { createAnimatedComponent } from 'react-native-reanimated/src/createAnimatedComponent';
+import Animated from 'react-native-reanimated';
 
 // Since createAnimatedComponent return type is ComponentClass that has the props of the argument,
 // but not things like NativeMethods, etc. we need to add them manually by extending the type.
@@ -47,7 +47,7 @@ export const AnimateableText = withDefaults(AnimateableTextImpl, {
 export const RNEUIText = withDefaults(RNEUITextImpl, {
   allowFontScaling: false,
 });
-export const AnimatedText = createAnimatedComponent(Text);
+export const AnimatedText = Animated.createAnimatedComponent(Text);
 
 export type TextInput = React.ComponentRef<typeof TextInput>;
 export type Text = React.ComponentRef<typeof Text>;

--- a/apps/mobile/src/components/Typography.tsx
+++ b/apps/mobile/src/components/Typography.tsx
@@ -7,6 +7,13 @@ import {
 } from 'react-native-gesture-handler';
 import AnimateableTextImpl from 'react-native-animateable-text';
 import { Text as RNEUITextImpl } from '@rneui/base';
+import { createAnimatedComponent } from 'react-native-reanimated/src/createAnimatedComponent';
+
+// Since createAnimatedComponent return type is ComponentClass that has the props of the argument,
+// but not things like NativeMethods, etc. we need to add them manually by extending the type.
+interface AnimatedTextComplement extends Text {
+  getNode(): Text;
+}
 
 function withDefaults<C extends React.ComponentType<any>>(
   WrappedComponent: C,
@@ -40,6 +47,7 @@ export const AnimateableText = withDefaults(AnimateableTextImpl, {
 export const RNEUIText = withDefaults(RNEUITextImpl, {
   allowFontScaling: false,
 });
+export const AnimatedText = createAnimatedComponent(Text);
 
 export type TextInput = React.ComponentRef<typeof TextInput>;
 export type Text = React.ComponentRef<typeof Text>;
@@ -47,3 +55,4 @@ export type RNGHText = RNGHTextImpl;
 export type RNGHTextInput = RNGHTextInputImpl;
 export type AnimateableText = React.ComponentRef<typeof AnimateableText>;
 export type RNEUIText = React.ComponentRef<typeof RNEUIText>;
+export type AnimatedText = typeof AnimatedText & AnimatedTextComplement;

--- a/apps/mobile/src/screens/Home/components/Tabs/CustomLabel.tsx
+++ b/apps/mobile/src/screens/Home/components/Tabs/CustomLabel.tsx
@@ -7,6 +7,7 @@ import { TextProps } from 'react-native';
 import { DefaultStyle } from 'react-native-reanimated/lib/typescript/hook/commonTypes';
 import { ThemeColors2024 } from '@rabby-wallet/base-utils';
 import { HOME_TOP_HEADER_SIZES } from '@/constant/home';
+import { AnimatedText } from '@/components/Typography';
 
 interface CustomLabelProps {
   index: number;
@@ -51,9 +52,7 @@ const CustomLabel = ({
   });
   return (
     <Animated.View style={[styles.container, wrapperStyle]}>
-      <Animated.Text style={[styles.label, stylez, style]}>
-        {text}
-      </Animated.Text>
+      <AnimatedText style={[styles.label, stylez, style]}>{text}</AnimatedText>
     </Animated.View>
   );
 };


### PR DESCRIPTION
## Summary

This PR exports an `AnimatedText` component from `Typography` using `createAnimatedComponent(Text)` from react-native-reanimated, and updates the Home screen `CustomLabel` to use it instead of `Animated.Text` directly.

This ensures the home tab labels inherit the app-wide `allowFontScaling: false` behavior enforced by the Typography wrapper, and keeps animated text consistent with other text components in the app.

## Changes
- `src/components/Typography.tsx`: add `AnimatedText` export with type complement for `getNode()`
- `src/screens/Home/components/Tabs/CustomLabel.tsx`: replace `Animated.Text` with `AnimatedText` from `@/components/Typography`