### PR TITLE
fix(mobile): make global bottom sheets singleton

### DIFF
--- a/apps/mobile/src/components/GlobalBottomSheetModal/types.ts
+++ b/apps/mobile/src/components/GlobalBottomSheetModal/types.ts
@@ -91,6 +91,17 @@ export type CreateParams<T extends MODAL_NAMES = MODAL_NAMES> = {
    * @default false
    */
   allowAndroidHarewareBack?: boolean;
+  /**
+   * @description global sheets are singleton by modal name by default. Set this
+   * only when the same modal name intentionally needs multiple active instances.
+   * @default false
+   */
+  allowMultipleInstances?: boolean;
+  /**
+   * @description optional discriminator for singleton reuse when one modal name
+   * needs separate singleton buckets.
+   */
+  singletonKey?: string;
   [key: string]: any;
 } & (T extends keyof MODAL_CREATE_PARAMS ? MODAL_CREATE_PARAMS[T] : {});
 

--- a/apps/mobile/src/components2024/GlobalBottomSheetModal/index.ts
+++ b/apps/mobile/src/components2024/GlobalBottomSheetModal/index.ts
@@ -3,7 +3,6 @@ import { globalSheetModalEvents } from './event';
 import { apisAppWin2024 } from '@/core/services2024/appWin';
 import { keyringService } from '@/core/services/shared';
 import { uiRefreshTimeout } from '@/core/apis/autoLock';
-import { debounce } from 'lodash';
 
 class IdSet<T = any> extends Set<T> {
   add(id: T) {
@@ -28,14 +27,8 @@ keyringService.on('lock', () => {
   });
 });
 
-export const createGlobalBottomSheetModal2024 = debounce(
-  apisAppWin2024.createGlobalBottomSheetModal,
-  200,
-  {
-    leading: true,
-    trailing: false,
-  },
-) as typeof apisAppWin2024.createGlobalBottomSheetModal;
+export const createGlobalBottomSheetModal2024 =
+  apisAppWin2024.createGlobalBottomSheetModal;
 export const removeGlobalBottomSheetModal2024 =
   apisAppWin2024.removeGlobalBottomSheetModal;
 export const globalBottomSheetModalAddListener2024 =

--- a/apps/mobile/src/components2024/GlobalBottomSheetModal/types.ts
+++ b/apps/mobile/src/components2024/GlobalBottomSheetModal/types.ts
@@ -126,6 +126,17 @@ type CreateParamsBase<T extends MODAL_NAMES = MODAL_NAMES> = {
    * @description specify whether to disable screenshot report before modal close
    */
   screenshotReportFreeBeforeModalClose?: boolean;
+  /**
+   * @description global sheets are singleton by modal name by default. Set this
+   * only when the same modal name intentionally needs multiple active instances.
+   * @default false
+   */
+  allowMultipleInstances?: boolean;
+  /**
+   * @description optional discriminator for singleton reuse when one modal name
+   * needs separate singleton buckets.
+   */
+  singletonKey?: string;
 };
 
 export type CreateParams<T extends MODAL_NAMES = MODAL_NAMES> =

--- a/apps/mobile/src/core/services/appWin.test.ts
+++ b/apps/mobile/src/core/services/appWin.test.ts
@@ -80,4 +80,41 @@ describe('legacy apisAppWin global bottom sheet singleton', () => {
     expect(secondId).not.toBe(firstId);
     expect(createdIds).toEqual([firstId, secondId]);
   });
+
+  it('separates approval modals by approvalComponent', () => {
+    const {
+      apisAppWin,
+      APPROVAL_MODAL_NAMES,
+      EVENT_NAMES,
+      MODAL_NAMES,
+      globalSheetModalEvents,
+    } = loadLegacyAppWinModule();
+    const createdIds: string[] = [];
+    const presentedIds: string[] = [];
+
+    globalSheetModalEvents.on(EVENT_NAMES.CREATE, id => {
+      createdIds.push(id);
+    });
+    globalSheetModalEvents.on(EVENT_NAMES.PRESENT, id => {
+      presentedIds.push(id);
+    });
+
+    const signTxId = apisAppWin.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.APPROVAL,
+      approvalComponent: APPROVAL_MODAL_NAMES.SignTx,
+    });
+    const sameSignTxId = apisAppWin.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.APPROVAL,
+      approvalComponent: APPROVAL_MODAL_NAMES.SignTx,
+    });
+    const waitingId = apisAppWin.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.APPROVAL,
+      approvalComponent: APPROVAL_MODAL_NAMES.PrivatekeyWaiting,
+    });
+
+    expect(sameSignTxId).toBe(signTxId);
+    expect(waitingId).not.toBe(signTxId);
+    expect(createdIds).toEqual([signTxId, waitingId]);
+    expect(presentedIds).toEqual([signTxId]);
+  });
 });

--- a/apps/mobile/src/core/services/appWin.test.ts
+++ b/apps/mobile/src/core/services/appWin.test.ts
@@ -1,0 +1,83 @@
+function loadLegacyAppWinModule() {
+  jest.resetModules();
+
+  const appWinModule = require('./appWin') as typeof import('./appWin');
+  const eventModule =
+    require('@/components/GlobalBottomSheetModal/event') as typeof import('@/components/GlobalBottomSheetModal/event');
+  const typesModule =
+    require('@/components/GlobalBottomSheetModal/types') as typeof import('@/components/GlobalBottomSheetModal/types');
+
+  return {
+    ...appWinModule,
+    ...eventModule,
+    ...typesModule,
+  };
+}
+
+describe('legacy apisAppWin global bottom sheet singleton', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('reuses the active modal id by modal name by default', () => {
+    const { apisAppWin, EVENT_NAMES, MODAL_NAMES, globalSheetModalEvents } =
+      loadLegacyAppWinModule();
+    const createdIds: string[] = [];
+    const presentedIds: string[] = [];
+
+    globalSheetModalEvents.on(EVENT_NAMES.CREATE, id => {
+      createdIds.push(id);
+    });
+    globalSheetModalEvents.on(EVENT_NAMES.PRESENT, id => {
+      presentedIds.push(id);
+    });
+
+    const firstId = apisAppWin.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.TIP_PRIVACY_POLICY,
+    });
+    const secondId = apisAppWin.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.TIP_PRIVACY_POLICY,
+    });
+
+    expect(secondId).toBe(firstId);
+    expect(createdIds).toEqual([firstId]);
+    expect(presentedIds).toEqual([firstId]);
+  });
+
+  it('creates a new singleton instance after the previous one is dismissed', () => {
+    const { apisAppWin, EVENT_NAMES, MODAL_NAMES, globalSheetModalEvents } =
+      loadLegacyAppWinModule();
+
+    const firstId = apisAppWin.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.TIP_TERM_OF_USE,
+    });
+    globalSheetModalEvents.emit(EVENT_NAMES.DISMISS, firstId);
+    const secondId = apisAppWin.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.TIP_TERM_OF_USE,
+    });
+
+    expect(secondId).not.toBe(firstId);
+  });
+
+  it('allows explicit multiple instances for the same modal name', () => {
+    const { apisAppWin, EVENT_NAMES, MODAL_NAMES, globalSheetModalEvents } =
+      loadLegacyAppWinModule();
+    const createdIds: string[] = [];
+
+    globalSheetModalEvents.on(EVENT_NAMES.CREATE, id => {
+      createdIds.push(id);
+    });
+
+    const firstId = apisAppWin.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.TIP_PRIVACY_POLICY,
+      allowMultipleInstances: true,
+    });
+    const secondId = apisAppWin.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.TIP_PRIVACY_POLICY,
+      allowMultipleInstances: true,
+    });
+
+    expect(secondId).not.toBe(firstId);
+    expect(createdIds).toEqual([firstId, secondId]);
+  });
+});

--- a/apps/mobile/src/core/services/appWin.ts
+++ b/apps/mobile/src/core/services/appWin.ts
@@ -8,6 +8,18 @@ import { uniqueId } from 'lodash';
 
 import { sleep } from '@/utils/async';
 import { globalSheetModalEvents } from '@/components/GlobalBottomSheetModal/event';
+import { makeGlobalBottomSheetSingletonRegistry } from './globalBottomSheetSingleton';
+
+const globalBottomSheetSingletonRegistry =
+  makeGlobalBottomSheetSingletonRegistry<string>();
+
+globalSheetModalEvents.on(EVENT_NAMES.REMOVE, id => {
+  globalBottomSheetSingletonRegistry.releaseId(id);
+});
+
+globalSheetModalEvents.on(EVENT_NAMES.DISMISS, id => {
+  globalBottomSheetSingletonRegistry.releaseId(id);
+});
 
 /**
  * @deprecated
@@ -16,9 +28,19 @@ import { globalSheetModalEvents } from '@/components/GlobalBottomSheetModal/even
 const createGlobalBottomSheetModal = <T extends MODAL_NAMES = MODAL_NAMES>(
   params: CreateParams<T>,
 ) => {
-  params.name = params.name ?? MODAL_NAMES.APPROVAL;
-  const id = `${params.name}_${uniqueId(`gBm_`)}`;
-  globalSheetModalEvents.emit(EVENT_NAMES.CREATE, id, params);
+  const nextParams = {
+    ...params,
+    name: params.name ?? MODAL_NAMES.APPROVAL,
+  };
+  const activeId = globalBottomSheetSingletonRegistry.getActiveId(nextParams);
+  if (activeId) {
+    globalSheetModalEvents.emit(EVENT_NAMES.PRESENT, activeId);
+    return activeId;
+  }
+
+  const id = `${nextParams.name}_${uniqueId(`gBm_`)}`;
+  globalBottomSheetSingletonRegistry.bindActiveId(id, nextParams);
+  globalSheetModalEvents.emit(EVENT_NAMES.CREATE, id, nextParams);
 
   return id;
 };

--- a/apps/mobile/src/core/services/globalBottomSheetSingleton.ts
+++ b/apps/mobile/src/core/services/globalBottomSheetSingleton.ts
@@ -1,0 +1,46 @@
+type SingletonCreateOptions = {
+  name: string;
+  allowMultipleInstances?: boolean;
+  singletonKey?: string;
+};
+
+export function makeGlobalBottomSheetSingletonRegistry<
+  ModalId extends string,
+>() {
+  const activeIdsBySingletonKey = new Map<string, ModalId>();
+
+  const getSingletonKey = (options: SingletonCreateOptions) => {
+    if (options.allowMultipleInstances) {
+      return null;
+    }
+
+    return `${options.name}:${options.singletonKey || 'default'}`;
+  };
+
+  const getActiveId = (options: SingletonCreateOptions) => {
+    const singletonKey = getSingletonKey(options);
+    return singletonKey ? activeIdsBySingletonKey.get(singletonKey) : undefined;
+  };
+
+  const bindActiveId = (id: ModalId, options: SingletonCreateOptions) => {
+    const singletonKey = getSingletonKey(options);
+    if (singletonKey) {
+      activeIdsBySingletonKey.set(singletonKey, id);
+    }
+  };
+
+  const releaseId = (id: ModalId) => {
+    activeIdsBySingletonKey.forEach((activeId, singletonKey) => {
+      if (activeId === id) {
+        activeIdsBySingletonKey.delete(singletonKey);
+      }
+    });
+  };
+
+  return {
+    getActiveId,
+    bindActiveId,
+    releaseId,
+    clear: () => activeIdsBySingletonKey.clear(),
+  };
+}

--- a/apps/mobile/src/core/services/globalBottomSheetSingleton.ts
+++ b/apps/mobile/src/core/services/globalBottomSheetSingleton.ts
@@ -1,5 +1,6 @@
 type SingletonCreateOptions = {
   name: string;
+  approvalComponent?: string;
   allowMultipleInstances?: boolean;
   singletonKey?: string;
 };
@@ -14,7 +15,12 @@ export function makeGlobalBottomSheetSingletonRegistry<
       return null;
     }
 
-    return `${options.name}:${options.singletonKey || 'default'}`;
+    const discriminator =
+      options.name === 'APPROVAL'
+        ? options.approvalComponent || options.singletonKey || 'default'
+        : options.singletonKey || 'default';
+
+    return `${options.name}:${discriminator}`;
   };
 
   const getActiveId = (options: SingletonCreateOptions) => {

--- a/apps/mobile/src/core/services/notification.ts
+++ b/apps/mobile/src/core/services/notification.ts
@@ -396,7 +396,12 @@ export class NotificationService extends Events {
       this.notifyWindowId = null;
     }
     this.notifyWindowId =
-      apisAppWin.createGlobalBottomSheetModal(winProps) ?? null;
+      apisAppWin.createGlobalBottomSheetModal({
+        ...winProps,
+        approvalComponent:
+          winProps?.approvalComponent ??
+          this.currentApproval?.data.approvalComponent,
+      }) ?? null;
   };
 
   setCurrentRequestDeferFn = (fn: (isRetry?: boolean) => void) => {

--- a/apps/mobile/src/core/services2024/appWin.test.ts
+++ b/apps/mobile/src/core/services2024/appWin.test.ts
@@ -1,0 +1,121 @@
+function loadAppWin2024Module() {
+  jest.resetModules();
+
+  const appWinModule = require('./appWin') as typeof import('./appWin');
+  const eventModule =
+    require('@/components2024/GlobalBottomSheetModal/event') as typeof import('@/components2024/GlobalBottomSheetModal/event');
+  const typesModule =
+    require('@/components2024/GlobalBottomSheetModal/types') as typeof import('@/components2024/GlobalBottomSheetModal/types');
+
+  return {
+    ...appWinModule,
+    ...eventModule,
+    ...typesModule,
+  };
+}
+
+describe('apisAppWin2024 global bottom sheet singleton', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('reuses the active modal id by modal name by default', () => {
+    const { apisAppWin2024, EVENT_NAMES, MODAL_NAMES, globalSheetModalEvents } =
+      loadAppWin2024Module();
+    const createdIds: string[] = [];
+    const presentedIds: string[] = [];
+
+    globalSheetModalEvents.on(EVENT_NAMES.CREATE, id => {
+      createdIds.push(id);
+    });
+    globalSheetModalEvents.on(EVENT_NAMES.PRESENT, id => {
+      presentedIds.push(id);
+    });
+
+    const firstId = apisAppWin2024.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.DESCRIPTION,
+      title: 'Risk',
+      sections: [{ description: 'Risk details' }],
+    });
+    const secondId = apisAppWin2024.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.DESCRIPTION,
+      title: 'Risk',
+      sections: [{ description: 'Risk details' }],
+    });
+
+    expect(secondId).toBe(firstId);
+    expect(createdIds).toEqual([firstId]);
+    expect(presentedIds).toEqual([firstId]);
+  });
+
+  it('creates a new singleton instance after the previous one is dismissed', () => {
+    const { apisAppWin2024, EVENT_NAMES, MODAL_NAMES, globalSheetModalEvents } =
+      loadAppWin2024Module();
+
+    const firstId = apisAppWin2024.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.DESCRIPTION,
+      title: 'Risk',
+      sections: [{ description: 'Risk details' }],
+    });
+    globalSheetModalEvents.emit(EVENT_NAMES.DISMISS, firstId);
+    const secondId = apisAppWin2024.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.DESCRIPTION,
+      title: 'Risk',
+      sections: [{ description: 'Risk details' }],
+    });
+
+    expect(secondId).not.toBe(firstId);
+  });
+
+  it('allows explicit multiple instances for the same modal name', () => {
+    const { apisAppWin2024, EVENT_NAMES, MODAL_NAMES, globalSheetModalEvents } =
+      loadAppWin2024Module();
+    const createdIds: string[] = [];
+
+    globalSheetModalEvents.on(EVENT_NAMES.CREATE, id => {
+      createdIds.push(id);
+    });
+
+    const firstId = apisAppWin2024.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.DESCRIPTION,
+      title: 'Risk',
+      sections: [{ description: 'Risk details' }],
+      allowMultipleInstances: true,
+    });
+    const secondId = apisAppWin2024.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.DESCRIPTION,
+      title: 'Risk',
+      sections: [{ description: 'Risk details' }],
+      allowMultipleInstances: true,
+    });
+
+    expect(secondId).not.toBe(firstId);
+    expect(createdIds).toEqual([firstId, secondId]);
+  });
+
+  it('uses singletonKey as an optional discriminator', () => {
+    const { apisAppWin2024, MODAL_NAMES } = loadAppWin2024Module();
+
+    const firstAId = apisAppWin2024.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.DESCRIPTION,
+      title: 'Risk A',
+      sections: [{ description: 'Risk details' }],
+      singletonKey: 'a',
+    });
+    const secondAId = apisAppWin2024.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.DESCRIPTION,
+      title: 'Risk A',
+      sections: [{ description: 'Risk details' }],
+      singletonKey: 'a',
+    });
+    const bId = apisAppWin2024.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.DESCRIPTION,
+      title: 'Risk B',
+      sections: [{ description: 'Risk details' }],
+      singletonKey: 'b',
+    });
+
+    expect(secondAId).toBe(firstAId);
+    expect(bId).not.toBe(firstAId);
+  });
+});

--- a/apps/mobile/src/core/services2024/appWin.test.ts
+++ b/apps/mobile/src/core/services2024/appWin.test.ts
@@ -118,4 +118,41 @@ describe('apisAppWin2024 global bottom sheet singleton', () => {
     expect(secondAId).toBe(firstAId);
     expect(bId).not.toBe(firstAId);
   });
+
+  it('separates approval modals by approvalComponent', () => {
+    const {
+      apisAppWin2024,
+      APPROVAL_MODAL_NAMES,
+      EVENT_NAMES,
+      MODAL_NAMES,
+      globalSheetModalEvents,
+    } = loadAppWin2024Module();
+    const createdIds: string[] = [];
+    const presentedIds: string[] = [];
+
+    globalSheetModalEvents.on(EVENT_NAMES.CREATE, id => {
+      createdIds.push(id);
+    });
+    globalSheetModalEvents.on(EVENT_NAMES.PRESENT, id => {
+      presentedIds.push(id);
+    });
+
+    const signTxId = apisAppWin2024.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.APPROVAL,
+      approvalComponent: APPROVAL_MODAL_NAMES.SignTx,
+    });
+    const sameSignTxId = apisAppWin2024.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.APPROVAL,
+      approvalComponent: APPROVAL_MODAL_NAMES.SignTx,
+    });
+    const waitingId = apisAppWin2024.createGlobalBottomSheetModal({
+      name: MODAL_NAMES.APPROVAL,
+      approvalComponent: APPROVAL_MODAL_NAMES.PrivatekeyWaiting,
+    });
+
+    expect(sameSignTxId).toBe(signTxId);
+    expect(waitingId).not.toBe(signTxId);
+    expect(createdIds).toEqual([signTxId, waitingId]);
+    expect(presentedIds).toEqual([signTxId]);
+  });
 });

--- a/apps/mobile/src/core/services2024/appWin.ts
+++ b/apps/mobile/src/core/services2024/appWin.ts
@@ -9,13 +9,35 @@ import { uniqueId } from 'lodash';
 
 import { sleep } from '@/utils/async';
 import { globalSheetModalEvents } from '@/components2024/GlobalBottomSheetModal/event';
+import { makeGlobalBottomSheetSingletonRegistry } from '@/core/services/globalBottomSheetSingleton';
+
+const globalBottomSheetSingletonRegistry =
+  makeGlobalBottomSheetSingletonRegistry<MODAL_ID>();
+
+globalSheetModalEvents.on(EVENT_NAMES.REMOVE, id => {
+  globalBottomSheetSingletonRegistry.releaseId(id);
+});
+
+globalSheetModalEvents.on(EVENT_NAMES.DISMISS, id => {
+  globalBottomSheetSingletonRegistry.releaseId(id);
+});
 
 const createGlobalBottomSheetModal = <T extends MODAL_NAMES = MODAL_NAMES>(
   params: CreateParams<T>,
 ) => {
-  params.name = params.name ?? MODAL_NAMES.APPROVAL;
-  const id = `${params.name}_${uniqueId(`gBm_`)}` as MODAL_ID;
-  globalSheetModalEvents.emit(EVENT_NAMES.CREATE, id, params);
+  const nextParams = {
+    ...params,
+    name: params.name ?? MODAL_NAMES.APPROVAL,
+  };
+  const activeId = globalBottomSheetSingletonRegistry.getActiveId(nextParams);
+  if (activeId) {
+    globalSheetModalEvents.emit(EVENT_NAMES.PRESENT, activeId);
+    return activeId;
+  }
+
+  const id = `${nextParams.name}_${uniqueId(`gBm_`)}` as MODAL_ID;
+  globalBottomSheetSingletonRegistry.bindActiveId(id, nextParams);
+  globalSheetModalEvents.emit(EVENT_NAMES.CREATE, id, nextParams);
 
   return id as MODAL_ID;
 };
@@ -74,6 +96,7 @@ const removeAllGlobalBottomSheetModals = (
   if (removeAllFn) {
     const { waitMaxtime, ...removeParams } = params || {};
     removeAllFn(removeParams);
+    globalBottomSheetSingletonRegistry.clear();
   }
 };
 

--- a/apps/mobile/src/hooks/useApproval.ts
+++ b/apps/mobile/src/hooks/useApproval.ts
@@ -37,7 +37,7 @@ export const useApproval = () => {
 
     setTimeout(() => {
       if (data && enablePopup(data.type)) {
-        return showPopup();
+        return showPopup(data.uiRequestComponent);
       }
 
       closePopup();

--- a/apps/mobile/src/hooks/useApprovalPopup.ts
+++ b/apps/mobile/src/hooks/useApprovalPopup.ts
@@ -1,4 +1,7 @@
-import { MODAL_NAMES } from '@/components/GlobalBottomSheetModal/types';
+import {
+  MODAL_NAMES,
+  type APPROVAL_MODAL_NAMES,
+} from '@/components/GlobalBottomSheetModal/types';
 import {
   createGlobalBottomSheetModal,
   removeGlobalBottomSheetModal,
@@ -6,7 +9,6 @@ import {
 } from '@/components/GlobalBottomSheetModal';
 import { atom, useAtom } from 'jotai';
 import React, { useCallback } from 'react';
-import { getActiveDappState } from '@/core/bridges/state';
 
 const ids = new Set<string>();
 const idAtom = atom<string | null>(null);
@@ -23,13 +25,17 @@ const clearPopup = (idToClear: string | null) => {
 export const useApprovalPopup = () => {
   const [id, setId] = useAtom(idAtom);
 
-  const showPopup = useCallback(() => {
-    const _id = createGlobalBottomSheetModal({
-      name: MODAL_NAMES.APPROVAL,
-    });
-    setId(_id);
-    ids.add(_id);
-  }, [setId]);
+  const showPopup = useCallback(
+    (approvalComponent?: APPROVAL_MODAL_NAMES) => {
+      const _id = createGlobalBottomSheetModal({
+        name: MODAL_NAMES.APPROVAL,
+        approvalComponent,
+      });
+      setId(_id);
+      ids.add(_id);
+    },
+    [setId],
+  );
 
   const enablePopup = useCallback((type: string) => {
     if (type) {


### PR DESCRIPTION
## Summary
- make global bottom sheet modals singleton by modal name by default
- add allowMultipleInstances and singletonKey escape hatches
- cover legacy and 2024 appWin singleton behavior with tests

## Release note
This was already included in tmp/20260508, and has now also been merged into tmp/20260515.

## Tests
- corepack yarn workspace rabby-mobile test src/core/services/appWin.test.ts src/core/services2024/appWin.test.ts --runInBand