### PR TITLE
fix(mobile): scope swap quote sheet visibility

### DIFF
--- a/apps/mobile/src/screens/Swap/components/QuoteItem.tsx
+++ b/apps/mobile/src/screens/Swap/components/QuoteItem.tsx
@@ -11,7 +11,6 @@ import {
   QuotePreExecResultInfo,
   QuoteProvider,
   isSwapWrapToken,
-  useSetQuoteVisible,
   useSwapSettings,
 } from '../hooks';
 
@@ -48,6 +47,7 @@ export interface QuoteItemProps {
   >;
   sortIncludeGasFee: boolean;
   onPress?: () => void;
+  onCloseQuoteList?: () => void;
 }
 
 export const DexQuoteItem = (
@@ -80,12 +80,11 @@ export const DexQuoteItem = (
     onErrQuote,
     onlyShow,
     onPress,
+    onCloseQuoteList,
   } = props;
 
   const { styles, colors2024 } = useTheme2024({ getStyle });
   const { t } = useTranslation();
-
-  const openSwapQuote = useSetQuoteVisible();
 
   const { sortIncludeGasFee } = useSwapSettings();
 
@@ -298,7 +297,7 @@ export const DexQuoteItem = (
       preExecResult: preExecResult,
     });
 
-    openSwapQuote(false);
+    onCloseQuoteList?.();
   }, [
     gasFeeTooHigh,
     inSufficient,
@@ -308,7 +307,7 @@ export const DexQuoteItem = (
     quote,
     preExecResult,
     receiveToken.decimals,
-    openSwapQuote,
+    onCloseQuoteList,
     handleTips,
   ]);
 

--- a/apps/mobile/src/screens/Swap/components/Quotes.tsx
+++ b/apps/mobile/src/screens/Swap/components/Quotes.tsx
@@ -53,6 +53,8 @@ export const Quotes = ({
   list,
   activeName,
   inSufficient,
+  visible: _visible,
+  onClose,
   ...other
 }: QuotesProps) => {
   const colors = useThemeColors();
@@ -153,6 +155,7 @@ export const Quotes = ({
               name: t('page.swap.wrap-contract'),
               logo: other?.receiveToken?.logo_url,
             }}
+            onCloseQuoteList={onClose}
             {...other}
           />
         ) : (
@@ -199,6 +202,7 @@ export const Quotes = ({
               quoteProviderInfo={
                 DEX_WITH_WRAP[name as keyof typeof DEX_WITH_WRAP]
               }
+              onCloseQuoteList={onClose}
               {...other}
             />
           );
@@ -285,6 +289,7 @@ export const Quotes = ({
               quoteProviderInfo={
                 DEX_WITH_WRAP[name as keyof typeof DEX_WITH_WRAP]
               }
+              onCloseQuoteList={onClose}
               {...other}
             />
           );
@@ -297,6 +302,7 @@ export const Quotes = ({
 export const QuoteList = (props: QuotesProps) => {
   const { visible, onClose, loading } = props;
   const bottomRef = useRef<BottomSheetModalMethods>(null);
+  const presentedRef = useRef(false);
 
   const refresh = useSetAtom(refreshIdAtom);
 
@@ -310,11 +316,19 @@ export const QuoteList = (props: QuotesProps) => {
 
   useEffect(() => {
     if (visible) {
-      bottomRef.current?.present();
-    } else {
+      if (!presentedRef.current) {
+        presentedRef.current = true;
+        bottomRef.current?.present();
+      }
+    } else if (presentedRef.current) {
       bottomRef.current?.dismiss();
     }
   }, [visible]);
+
+  const handleDismiss = React.useCallback(() => {
+    presentedRef.current = false;
+    onClose();
+  }, [onClose]);
 
   const {
     styles,
@@ -347,7 +361,7 @@ export const QuoteList = (props: QuotesProps) => {
     <AppBottomSheetModal
       snapPoints={['90%']}
       ref={bottomRef}
-      onDismiss={onClose}
+      onDismiss={handleDismiss}
       enableDismissOnClose
       {...makeBottomSheetProps({
         colors: colors2024,

--- a/apps/mobile/src/screens/Swap/hooks/atom.tsx
+++ b/apps/mobile/src/screens/Swap/hooks/atom.tsx
@@ -2,18 +2,13 @@ import {
   TokenItem,
   TokenItemWithEntity,
 } from '@rabby-wallet/rabby-api/dist/types';
-import { atom, useAtom, useSetAtom } from 'jotai';
+import { atom, useAtom } from 'jotai';
 
-const quoteVisibleAtom = atom(false);
 const rabbyFeeVisibleAtom = atom({ visible: false } as {
   visible: boolean;
   dexFeeDesc?: string;
   dexName?: string;
 });
-
-export const useQuoteVisible = () => useAtom(quoteVisibleAtom);
-
-export const useSetQuoteVisible = () => useSetAtom(quoteVisibleAtom);
 
 export const useRabbyFeeVisible = () => useAtom(rabbyFeeVisibleAtom);
 

--- a/apps/mobile/src/screens/Swap/hooks/token.tsx
+++ b/apps/mobile/src/screens/Swap/hooks/token.tsx
@@ -11,7 +11,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { refreshIdAtom, useSetQuoteVisible } from './atom';
+import { refreshIdAtom } from './atom';
 import useAsync from 'react-use/lib/useAsync';
 import { openapi } from '@/core/request';
 import useDebounce from 'react-use/lib/useDebounce';
@@ -128,6 +128,7 @@ export const useTokenPair = ({ account }: { account: Account }) => {
   const setRefreshId = useSetAtom(refreshIdAtom);
 
   const [showMoreVisible, setShowMoreVisible] = useState(false);
+  const [quotesListVisible, setQuotesListVisible] = useState(false);
 
   const {
     initialSelectedChain,
@@ -799,12 +800,14 @@ export const useTokenPair = ({ account }: { account: Account }) => {
 
   const { setSwapSortIncludeGasFee } = useSwapSettings();
 
-  const openQuote = useSetQuoteVisible();
-
   const openQuotesList = useCallback(() => {
-    openQuote(true);
+    setQuotesListVisible(true);
     setSwapSortIncludeGasFee(true);
-  }, [openQuote, setSwapSortIncludeGasFee]);
+  }, [setSwapSortIncludeGasFee]);
+
+  const closeQuotesList = useCallback(() => {
+    setQuotesListVisible(false);
+  }, []);
 
   useEffect(() => {
     if (expiredTimer.current) {
@@ -1040,6 +1043,8 @@ export const useTokenPair = ({ account }: { account: Account }) => {
 
     //quote
     openQuotesList,
+    closeQuotesList,
+    quotesListVisible,
     quoteLoading,
     quoteList,
     currentProvider,

--- a/apps/mobile/src/screens/Swap/index.tsx
+++ b/apps/mobile/src/screens/Swap/index.tsx
@@ -51,7 +51,6 @@ import {
 } from './hooks';
 import {
   refreshIdAtom,
-  useQuoteVisible,
   useRabbyFeeVisible,
 } from './hooks/atom';
 import { buildDexSwap, dexSwap } from './hooks/swap';
@@ -181,8 +180,6 @@ const Swap = ({
   const [twoStepApproveModalVisible, setTwoStepApproveModalVisible] =
     useState(false);
 
-  const [visible, setVisible] = useQuoteVisible();
-
   const [unlimitedAllowance] = useSwapUnlimitedAllowance();
 
   const userAddress = currentAccount?.address;
@@ -214,6 +211,8 @@ const Swap = ({
     feeRate,
 
     openQuotesList,
+    closeQuotesList,
+    quotesListVisible,
     quoteLoading,
     quoteList,
 
@@ -1438,10 +1437,8 @@ const Swap = ({
           <QuoteList
             list={quoteList}
             loading={quoteLoading}
-            visible={visible}
-            onClose={() => {
-              setVisible(false);
-            }}
+            visible={quotesListVisible}
+            onClose={closeQuotesList}
             userAddress={userAddress}
             chain={chain}
             slippage={slippage}

--- a/apps/mobile/src/screens/Swap/index.tsx
+++ b/apps/mobile/src/screens/Swap/index.tsx
@@ -49,10 +49,7 @@ import {
   useSwapUnlimitedAllowance,
   useTokenPair,
 } from './hooks';
-import {
-  refreshIdAtom,
-  useRabbyFeeVisible,
-} from './hooks/atom';
+import { refreshIdAtom, useRabbyFeeVisible } from './hooks/atom';
 import { buildDexSwap, dexSwap } from './hooks/swap';
 import { Button } from '@/components2024/Button';
 import {
@@ -1151,7 +1148,9 @@ const Swap = ({
                 onChangeSlider={onChangeSlider}
                 value={payAmount}
                 onValueChange={value => {
-                  if (directSignBtnRef.current?.isAuthInProgress()) return;
+                  if (directSignBtnRef.current?.isAuthInProgress()) {
+                    return;
+                  }
                   handleAmountChange(value);
                 }}
                 token={payToken}


### PR DESCRIPTION
## Summary
- keep Swap quote sheet visibility scoped to the current Swap screen instance
- close the current quote sheet through props instead of the previous module-level atom
- guard the local quote BottomSheet against duplicate present calls

## Verification
- git diff --check