### PR TITLE
feat: switch to token tab on net worth press

### DIFF
--- a/apps/mobile/src/screens/Address/components/MultiAssets/RenderRow/CurveChart.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/RenderRow/CurveChart.tsx
@@ -134,9 +134,11 @@ export const MultiChart = memo(function MultiChart({
   hideType,
   style,
   onPressNetWorth,
+  onPressWalletList,
 }: {
   hideType: BALANCE_HIDE_TYPE;
   onPressNetWorth?: () => void;
+  onPressWalletList?: () => void;
 } & RNViewProps) {
   const { styles } = useTheme2024({ getStyle });
   const {
@@ -186,6 +188,7 @@ export const MultiChart = memo(function MultiChart({
             showBalanceLoadingWithoutLocal={showBalanceLoadingWithoutLocal}
             showChangeLoadingWithoutLocal={showChangeLoadingWithoutLocal}
             onPressNetWorth={onPressNetWorth}
+            onPressWalletList={onPressWalletList}
           />
           <ChartContent
             data={chartsData}
@@ -210,6 +213,7 @@ interface IHeaderProps {
   showBalanceLoadingWithoutLocal: boolean;
   showChangeLoadingWithoutLocal: boolean;
   onPressNetWorth?: () => void;
+  onPressWalletList?: () => void;
 }
 const ChartHeader = React.memo(
   ({
@@ -223,6 +227,7 @@ const ChartHeader = React.memo(
     showBalanceLoadingWithoutLocal,
     showChangeLoadingWithoutLocal,
     onPressNetWorth,
+    onPressWalletList,
   }: IHeaderProps) => {
     const { reanimatedStyles, styles, colors2024 } = useTheme2024({ getStyle });
     const rStyles = {
@@ -406,7 +411,13 @@ const ChartHeader = React.memo(
             LinearGradientComponent={LoadingLinear}
           />
 
-          <View style={[styles.accountBg]}>
+          <Pressable
+            style={({ pressed }) => [
+              styles.accountBg,
+              pressed && { opacity: 0.6 },
+            ]}
+            onPress={onPressWalletList}
+            hitSlop={8}>
             <RcIconSmallWalletCC color={colors2024['neutral-title-1']} />
             <Text style={styles.accountText}>
               {matteredAccountCount && matteredAccountCount >= 10
@@ -414,7 +425,7 @@ const ChartHeader = React.memo(
                 : matteredAccountCount}
             </Text>
             <RcIconSmallArrowCC color={colors2024['neutral-title-1']} />
-          </View>
+          </Pressable>
         </View>
         {showChangeLoading ? (
           <Skeleton

--- a/apps/mobile/src/screens/Address/components/MultiAssets/RenderRow/CurveChart.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/RenderRow/CurveChart.tsx
@@ -133,8 +133,10 @@ const ChartContent = memo(function ChartContent({
 export const MultiChart = memo(function MultiChart({
   hideType,
   style,
+  onPressNetWorth,
 }: {
   hideType: BALANCE_HIDE_TYPE;
+  onPressNetWorth?: () => void;
 } & RNViewProps) {
   const { styles } = useTheme2024({ getStyle });
   const {
@@ -183,6 +185,7 @@ export const MultiChart = memo(function MultiChart({
             matteredAccountCount={matteredAccountLength}
             showBalanceLoadingWithoutLocal={showBalanceLoadingWithoutLocal}
             showChangeLoadingWithoutLocal={showChangeLoadingWithoutLocal}
+            onPressNetWorth={onPressNetWorth}
           />
           <ChartContent
             data={chartsData}
@@ -206,6 +209,7 @@ interface IHeaderProps {
   matteredAccountCount?: number;
   showBalanceLoadingWithoutLocal: boolean;
   showChangeLoadingWithoutLocal: boolean;
+  onPressNetWorth?: () => void;
 }
 const ChartHeader = React.memo(
   ({
@@ -218,6 +222,7 @@ const ChartHeader = React.memo(
     matteredAccountCount,
     showBalanceLoadingWithoutLocal,
     showChangeLoadingWithoutLocal,
+    onPressNetWorth,
   }: IHeaderProps) => {
     const { reanimatedStyles, styles, colors2024 } = useTheme2024({ getStyle });
     const rStyles = {
@@ -373,11 +378,12 @@ const ChartHeader = React.memo(
     return (
       <Animated.View style={rStyles.charHeader}>
         <View style={styles.netWorthContainer}>
-          <View
+          <Pressable
             style={[
               styles.netWorthTextContainer,
               showNetWorthLoading ? styles.hidden : undefined,
             ]}
+            onPress={onPressNetWorth}
             {...makeTestIDProps(E2E_ID.home.portfolioBalanceValue)}>
             <AnimateableText
               style={[
@@ -387,7 +393,7 @@ const ChartHeader = React.memo(
               ]}
               animatedProps={netWorthAnimatedProps}
             />
-          </View>
+          </Pressable>
 
           <Skeleton
             {...makeTestIDProps(E2E_ID.home.portfolioBalanceLoading)}

--- a/apps/mobile/src/screens/Home/components/MultiAddressHomeHeader.tsx
+++ b/apps/mobile/src/screens/Home/components/MultiAddressHomeHeader.tsx
@@ -33,6 +33,7 @@ import {
   createGlobalBottomSheetModal2024,
   removeGlobalBottomSheetModal2024,
 } from '@/components2024/GlobalBottomSheetModal';
+import { apisHomeTabIndex } from '@/hooks/navigation';
 import { MODAL_NAMES } from '@/components2024/GlobalBottomSheetModal/types';
 import { apiGlobalModal } from '@/components2024/GlobalBottomSheetModal/apiGlobalModal';
 import { computeBalanceChange } from '@/core/apis/balance';
@@ -290,6 +291,9 @@ export function MultiAddressHomeHeader(
             }}>
             <MultiChart
               hideType={hideType}
+              onPressNetWorth={() => {
+                apisHomeTabIndex.homeTabScrollerRef.current?.setIndex(1);
+              }}
               style={[
                 styles.multiChart,
                 !pinnedAccountList?.length && styles.multiChartNoAccountsFollow,

--- a/apps/mobile/src/screens/Home/components/MultiAddressHomeHeader.tsx
+++ b/apps/mobile/src/screens/Home/components/MultiAddressHomeHeader.tsx
@@ -280,20 +280,18 @@ export function MultiAddressHomeHeader(
               isAnimRunning && styles.curveCardGradientBgWithAnim,
             ]}
           />
-          <TouchableOpacity
+          <View
             style={[
               styles.curveCard,
               styles.shadowView,
               // !pinnedAccountList.length && styles.noAddressCard,
-            ]}
-            onPress={() => {
-              handleWalletsListPress();
-            }}>
+            ]}>
             <MultiChart
               hideType={hideType}
               onPressNetWorth={() => {
                 apisHomeTabIndex.homeTabScrollerRef.current?.setIndex(1);
               }}
+              onPressWalletList={handleWalletsListPress}
               style={[
                 styles.multiChart,
                 !pinnedAccountList?.length && styles.multiChartNoAccountsFollow,
@@ -305,7 +303,7 @@ export function MultiAddressHomeHeader(
                 pinnedAccountList={pinnedAccountList}
               />
             ) : null}
-          </TouchableOpacity>
+          </View>
         </View>
       </BlurShadowView>
     </View>


### PR DESCRIPTION
## Summary
- Pressing the net worth text on the home portfolio chart navigates to the second (token) tab
- Added optional `onPressNetWorth` callback prop to `MultiChart` → `ChartHeader`
- Wired the handler in `MultiAddressHomeHeader` via `apisHomeTabIndex.homeTabScrollerRef`