### PR TITLE
Fix transaction bottom action layout

### DIFF
--- a/apps/mobile/src/components2024/Button/index.tsx
+++ b/apps/mobile/src/components2024/Button/index.tsx
@@ -52,6 +52,7 @@ export type ButtonProps = Omit<
       noShadow?: boolean;
       icon?: ReactNode | ((ctx: { titleStyle?: TextStyle }) => ReactNode);
       iconRight?: ReactNode | ((ctx: { titleStyle?: TextStyle }) => ReactNode);
+      balanceIconSpacing?: boolean;
       showTextOnLoading?: boolean;
       loadingType?: 'indicator' | 'circle';
     },
@@ -76,6 +77,7 @@ export const Button = ({
   disabledTitleStyle,
   icon,
   iconRight,
+  balanceIconSpacing = false,
   ViewComponent = View,
   ...rest
 }: ButtonProps) => {
@@ -238,6 +240,13 @@ export const Button = ({
     return i;
   }, [icon, iconRight, titleStyle]);
 
+  const hiddenIconNode = useMemo(() => {
+    if (!React.isValidElement(iconNode)) {
+      return iconNode;
+    }
+    return React.cloneElement(iconNode);
+  }, [iconNode]);
+
   return (
     <View
       style={StyleSheet.flatten([
@@ -287,6 +296,18 @@ export const Button = ({
                 renderText(textNode, {
                   style: titleStyle,
                 })}
+              {balanceIconSpacing && iconNode && !iconRight && !!textNode && (
+                <View
+                  pointerEvents="none"
+                  accessibilityElementsHidden
+                  importantForAccessibility="no-hide-descendants"
+                  style={StyleSheet.flatten([
+                    styles.iconContainer,
+                    styles.hiddenIconContainer,
+                  ])}>
+                  {hiddenIconNode}
+                </View>
+              )}
               {iconNode && iconRight && (
                 <View style={StyleSheet.flatten([styles.iconContainer])}>
                   {iconNode}
@@ -334,6 +355,9 @@ const getStyle = createGetStyles2024(ctx => ({
   },
   iconContainer: {
     marginHorizontal: 8,
+  },
+  hiddenIconContainer: {
+    opacity: 0,
   },
   loading: {
     marginVertical: 2,

--- a/apps/mobile/src/screens/Bridge/components/BridgeContent.tsx
+++ b/apps/mobile/src/screens/Bridge/components/BridgeContent.tsx
@@ -22,7 +22,6 @@ import { useTranslation } from 'react-i18next';
 import { TwpStepApproveModal } from '@/screens/Swap/components/TwoStepApproveModal';
 import BigNumber from 'bignumber.js';
 import { QuoteList } from './BridgeQuotes';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSafeSetNavigationOptions } from '@/components/AppStatusBar';
 import { BridgeHeader, BridgeHeaderRef } from './BridgeHeader';
 import { openapi } from '@/core/request';
@@ -76,6 +75,12 @@ import {
 } from '@/utils/form';
 import { buildTx as buildBridgeTx } from '@rabby-wallet/rabby-bridge';
 import { useMiniSignerEffectPause } from '@/hooks/useMiniSignerEffectPause';
+import { useSafeSizes } from '@/hooks/useAppLayout';
+
+const FOOTER_BUTTON_HEIGHT = 56;
+const FOOTER_PADDING_TOP = 16;
+const FOOTER_PADDING_BOTTOM = 24;
+const FOOTER_RISK_TIP_HEIGHT = 40;
 
 /** Bridge form snapshot for validation during auth */
 export interface BridgeFormSnapshot {
@@ -90,7 +95,12 @@ const getStyle = createGetStyles2024(({ colors2024, colors }) => ({
   },
   container: {
     flex: 1,
+    overflow: 'visible',
+  },
+  scrollContent: {
+    flexGrow: 1,
     paddingTop: 16,
+    paddingBottom: 24,
     overflow: 'visible',
   },
   noRecoomedTokenText: {
@@ -191,13 +201,11 @@ const getStyle = createGetStyles2024(({ colors2024, colors }) => ({
     color: colors['neutral-foot'],
   },
   buttonContainer: {
-    position: 'absolute',
-    left: 0,
-    bottom: 0,
-    // height: 140,
+    flexShrink: 0,
     backgroundColor: colors2024['neutral-bg-1'],
     width: '100%',
-    padding: 20,
+    paddingHorizontal: 20,
+    paddingTop: FOOTER_PADDING_TOP,
   },
   btnTitle: {
     color: colors['neutral-title-2'],
@@ -209,7 +217,7 @@ const getStyle = createGetStyles2024(({ colors2024, colors }) => ({
 
 export const BridgeContent = ({ isForMultipleAddress = false }) => {
   const { t } = useTranslation();
-  const { bottom } = useSafeAreaInsets();
+  const { safeOffBottom } = useSafeSizes();
   const { styles } = useTheme2024({ getStyle });
   const headerRef = useRef<BridgeHeaderRef>(null);
   const { setNavigationOptions } = useSafeSetNavigationOptions();
@@ -948,6 +956,16 @@ export const BridgeContent = ({ isForMultipleAddress = false }) => {
 
   const showRiskTips =
     isSlippageHigh || isSlippageLow || showLoss || miniSignGasFeeTooHigh;
+  const showDirectSignRiskTips =
+    showRiskTips && !btnDisabled && !miniSignLoading;
+  const footerMinHeight =
+    FOOTER_BUTTON_HEIGHT +
+    FOOTER_PADDING_TOP +
+    FOOTER_PADDING_BOTTOM +
+    safeOffBottom +
+    (canShowDirectSubmit && showDirectSignRiskTips
+      ? FOOTER_RISK_TIP_HEIGHT
+      : 0);
 
   const [scrollEnabled, setScrollEnabled] = useState(true);
 
@@ -959,9 +977,7 @@ export const BridgeContent = ({ isForMultipleAddress = false }) => {
         )}
         <KeyboardAwareScrollView
           style={styles.container}
-          contentContainerStyle={{
-            paddingBottom: 150 + bottom + (showRiskTips ? 26 : 0),
-          }}
+          contentContainerStyle={styles.scrollContent}
           enableOnAndroid
           scrollEnabled={scrollEnabled}
           extraHeight={200}
@@ -1144,7 +1160,8 @@ export const BridgeContent = ({ isForMultipleAddress = false }) => {
           style={[
             styles.buttonContainer,
             {
-              paddingBottom: Math.max(bottom, 50),
+              minHeight: footerMinHeight,
+              paddingBottom: FOOTER_PADDING_BOTTOM + safeOffBottom,
             },
           ]}>
           <Tip
@@ -1177,7 +1194,7 @@ export const BridgeContent = ({ isForMultipleAddress = false }) => {
                 }}
                 account={currentAccount}
                 showHardWalletProcess
-                showRiskTips={showRiskTips && !btnDisabled && !miniSignLoading}
+                showRiskTips={showDirectSignRiskTips}
                 loading={miniSignLoading}
                 showTextOnLoading
               />

--- a/apps/mobile/src/screens/Send/Send.tsx
+++ b/apps/mobile/src/screens/Send/Send.tsx
@@ -10,7 +10,6 @@ import {
   View,
   TouchableWithoutFeedback,
   Keyboard,
-  ScrollView,
 } from 'react-native';
 import { useTheme2024 } from '@/hooks/theme';
 import {
@@ -94,18 +93,7 @@ import { type ITokenCheck } from '@/components/Token/TokenSelectorSheetModal';
 import { useRendererDetect } from '@/components/Perf/PerfDetector';
 import { E2E_ID } from '@/constant/e2e';
 import { makeTestIDProps } from '@/utils/makeTestIDProps';
-import Animated, {
-  runOnJS,
-  useAnimatedReaction,
-  useAnimatedRef,
-  useAnimatedStyle,
-  useSharedValue,
-} from 'react-native-reanimated';
 import { DirectSignBtnMethods } from '@/components2024/DirectSignBtn';
-
-const AnimatedKeyboardAwareScrollView = Animated.createAnimatedComponent(
-  KeyboardAwareScrollView,
-);
 
 const EMPTY_TOKEN_ITEM = {
   decimals: 18,
@@ -250,7 +238,6 @@ function SendScreen({
     setReloadTxRefreshPaused,
     onBottomAreaLayout,
     scrollViewRef,
-    scrollViewStyle,
     scrollToBottom,
 
     checkCexSupport,
@@ -559,13 +546,17 @@ function SendScreen({
                 sendTokenEvents.emit(SendTokenEvents.ON_PRESS_DISMISS);
                 Keyboard.dismiss();
               }}>
-              <ScrollView contentContainerStyle={styles.sendScreen}>
-                <AnimatedKeyboardAwareScrollView
+              <View style={styles.sendScreen}>
+                <KeyboardAwareScrollView
                   innerRef={instance => {
                     scrollViewRef.current =
                       instance as unknown as KeyboardAwareScrollView;
                   }}
-                  contentContainerStyle={[styles.mainContent, scrollViewStyle]}>
+                  style={styles.scrollArea}
+                  contentContainerStyle={styles.mainContent}
+                  enableOnAndroid
+                  extraHeight={200}
+                  keyboardOpeningTime={0}>
                   {/* FromToSection */}
                   <View>
                     {/* From */}
@@ -594,9 +585,9 @@ function SendScreen({
                       clearLocalPendingTxData={clearLocalPendingTxData}
                     />
                   )}
-                </AnimatedKeyboardAwareScrollView>
+                </KeyboardAwareScrollView>
                 <BottomArea account={currentAccount} />
-              </ScrollView>
+              </View>
             </TouchableWithoutFeedback>
             <TokenInfoPopup />
             <BlockedAddressDialog
@@ -644,16 +635,16 @@ const getStyle = createGetStyles2024(({ colors2024 }) =>
       marginTop: 8,
     },
     sendScreen: {
-      flexDirection: 'column',
-      justifyContent: 'space-between',
       flex: 1,
+      flexDirection: 'column',
       paddingTop: 16,
-      position: 'relative',
-      height: '100%',
+    },
+    scrollArea: {
+      flex: 1,
     },
     mainContent: {
       paddingHorizontal: 24,
-      paddingBottom: 280,
+      paddingBottom: 24,
     },
     balance: {
       marginTop: 24,

--- a/apps/mobile/src/screens/Send/components/BottomArea.tsx
+++ b/apps/mobile/src/screens/Send/components/BottomArea.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Platform, TouchableOpacity, View } from 'react-native';
+import { View } from 'react-native';
 import { useTheme2024 } from '@/hooks/theme';
 import {
   apiSendToken,
@@ -9,15 +9,11 @@ import {
   useSendTokenInternalContext,
   useSendTokenScreenChainToken,
 } from '../hooks/useSendToken';
-import {
-  createGetStyles2024,
-  makeDebugBorder,
-  makeDevOnlyStyle,
-} from '@/utils/styles';
+import { createGetStyles2024 } from '@/utils/styles';
 import { ModalConfirmAllowTransfer } from '@/components/Address/SheetModalConfirmAllowTransfer';
 import { ModalAddToContacts } from '@/components/Address/SheetModalAddToContacts';
 import { apiBalance } from '@/core/apis';
-import { useSafeAndroidBottomSizes, useSafeSizes } from '@/hooks/useAppLayout';
+import { useSafeSizes } from '@/hooks/useAppLayout';
 import { Button } from '@/components2024/Button';
 import { useTranslation } from 'react-i18next';
 
@@ -36,11 +32,10 @@ import { makeTestIDProps } from '@/utils/makeTestIDProps';
 import { Text } from '@/components/Typography';
 import { isGasAccountDepositFlowActive } from '@/screens/GasAccount/utils/depositFlowRuntime';
 
-const isAndroid = Platform.OS === 'android';
-
 export default function BottomArea({ account }: { account: Account | null }) {
   const { t } = useTranslation();
-  const { styles, colors2024 } = useTheme2024({ getStyle });
+  const { styles } = useTheme2024({ getStyle });
+  const { safeOffBottom } = useSafeSizes();
 
   const { handleSubmit } = useSendTokenFormik();
 
@@ -207,7 +202,12 @@ export default function BottomArea({ account }: { account: Account | null }) {
     !canSubmit || (!!mostImportantRisks.length && !agreeRequiredChecked);
 
   return (
-    <View onLayout={onBottomAreaLayout} style={[styles.bottomDockArea]}>
+    <View
+      onLayout={onBottomAreaLayout}
+      style={[
+        styles.bottomDockArea,
+        { paddingBottom: SIZES.containerPb + safeOffBottom },
+      ]}>
       <BottomRiskTip
         loadingRisks={loadingRisks}
         mostImportantRisks={mostImportantRisks}
@@ -260,6 +260,7 @@ export default function BottomArea({ account }: { account: Account | null }) {
           }
           loading={isSubmitLoading}
           type={'primary'}
+          balanceIconSpacing
           syncUnlockTime
           account={account}
           showHardWalletProcess
@@ -311,32 +312,21 @@ export default function BottomArea({ account }: { account: Account | null }) {
 
 const SIZES = {
   containerPt: 16,
-  containerPb: 48,
-  // height: 220,
-  bottom: 48,
+  containerPb: 24,
 };
 
-const getStyle = createGetStyles2024(
-  ({ safeAreaInsets, isLight, colors, colors2024 }) => {
-    return {
-      bottomDockArea: {
-        bottom: 0,
-        width: '100%',
-        paddingHorizontal: 24,
-        position: 'absolute',
-        paddingTop: SIZES.containerPt,
-        paddingBottom: SIZES.containerPb + safeAreaInsets.bottom,
-        backgroundColor: resolveBgColorByType('bg1', {
-          isLight: isLight ?? true,
-          colors,
-          colors2024,
-        }),
-        // ...makeDebugBorder(),
-        // ...makeDevOnlyStyle({
-        //   backgroundColor: 'blue',
-        // }),
-        // height: SIZES.height,
-      },
-    };
-  },
-);
+const getStyle = createGetStyles2024(({ isLight, colors, colors2024 }) => {
+  return {
+    bottomDockArea: {
+      width: '100%',
+      paddingHorizontal: 24,
+      flexShrink: 0,
+      paddingTop: SIZES.containerPt,
+      backgroundColor: resolveBgColorByType('bg1', {
+        isLight: isLight ?? true,
+        colors,
+        colors2024,
+      }),
+    },
+  };
+});

--- a/apps/mobile/src/screens/SendNFT/SendNFT.tsx
+++ b/apps/mobile/src/screens/SendNFT/SendNFT.tsx
@@ -1,13 +1,6 @@
 import React from 'react';
 import { View } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
-import Animated, {
-  runOnJS,
-  useAnimatedReaction,
-  useAnimatedRef,
-  useAnimatedStyle,
-  useSharedValue,
-} from 'react-native-reanimated';
 
 import NormalScreenContainer2024 from '@/components2024/ScreenContainer/NormalScreenContainer';
 import { SignatureInstanceProvider } from '@/components2024/MiniSignV2/state/SignatureInstanceContext';
@@ -15,7 +8,7 @@ import { RootNames } from '@/constant/layout';
 import { useTheme2024 } from '@/hooks/theme';
 import { StackActions, useRoute } from '@react-navigation/native';
 import { GetNestedScreenRouteProp } from '@/navigation-type';
-import { NFTSection, SendNFTSection } from './Section';
+import { NFTSection } from './Section';
 import ToAddressControl2024 from '@/screens/SendNFT/components/ToAddressControl2024';
 import FromAddressControl2024 from '@/screens/SendNFT/components/FromAddressControl';
 import {
@@ -33,11 +26,6 @@ import { AccountSwitcherModal } from '@/components/AccountSwitcher/Modal';
 import { createGetStyles2024 } from '@/utils/styles';
 import { ShowMoreOnSendNFT } from './components/ShowMoreOnSendNFT';
 import { useSceneAccountInfo } from '@/hooks/accountsSwitcher';
-import { Text } from '@/components/Typography';
-
-const AnimatedKeyboardAwareScrollView = Animated.createAnimatedComponent(
-  KeyboardAwareScrollView,
-);
 
 export default function SendNFT() {
   const { styles } = useTheme2024({ getStyle: getStyles });
@@ -81,7 +69,6 @@ export default function SendNFT() {
     scrollviewRef,
     handleIgnoreGasFeeChange,
     onBottomAreaLayout,
-    scrollViewStyle,
     scrollToBottom,
 
     whitelistEnabled,
@@ -184,12 +171,16 @@ export default function SendNFT() {
         <NormalScreenContainer2024 type="bg1">
           <AccountSwitcherModal forScene="SendNFT" inScreen />
           <View style={styles.sendNFTScreen}>
-            <AnimatedKeyboardAwareScrollView
+            <KeyboardAwareScrollView
               innerRef={instance => {
                 scrollviewRef.current =
                   instance as unknown as KeyboardAwareScrollView;
               }}
-              contentContainerStyle={[styles.mainContent, scrollViewStyle]}>
+              style={styles.scrollArea}
+              contentContainerStyle={styles.mainContent}
+              enableOnAndroid
+              extraHeight={200}
+              keyboardOpeningTime={0}>
               {/* From */}
               <FromAddressControl2024 disableSwitch={true} />
 
@@ -203,7 +194,7 @@ export default function SendNFT() {
                 chainItem={chainItem}
               />
               <ShowMoreOnSendNFT chainServeId={chainItem?.serverId || ''} />
-            </AnimatedKeyboardAwareScrollView>
+            </KeyboardAwareScrollView>
             <BottomArea account={account} />
           </View>
         </NormalScreenContainer2024>
@@ -221,14 +212,16 @@ const getStyles = createGetStyles2024(({ colors2024 }) => ({
   },
   sendNFTScreen: {
     width: '100%',
-    height: '100%',
+    flex: 1,
     flexDirection: 'column',
     backgroundColor: colors2024['neutral-bg-1'],
-    justifyContent: 'space-between',
+  },
+  scrollArea: {
+    flex: 1,
   },
   mainContent: {
     paddingHorizontal: 20,
-    paddingBottom: 308,
+    paddingBottom: 24,
   },
 
   buttonContainer: {

--- a/apps/mobile/src/screens/SendNFT/components/BottomArea.tsx
+++ b/apps/mobile/src/screens/SendNFT/components/BottomArea.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Platform, View } from 'react-native';
+import { View } from 'react-native';
 import { Button } from '@/components2024/Button';
 import {
   useSendNFTFormik,
@@ -10,10 +10,10 @@ import { useTranslation } from 'react-i18next';
 import { ModalConfirmAllowTransfer } from '@/components/Address/SheetModalConfirmAllowTransfer';
 import { ModalAddToContacts } from '@/components/Address/SheetModalAddToContacts';
 import { apiBalance } from '@/core/apis';
-import { useSafeAndroidBottomSizes } from '@/hooks/useAppLayout';
+import { useSafeSizes } from '@/hooks/useAppLayout';
 import { useTheme2024 } from '@/hooks/theme';
 
-import { createGetStyles2024, makeDebugBorder } from '@/utils/styles';
+import { createGetStyles2024 } from '@/utils/styles';
 import { useSignatureStore } from '@/components2024/MiniSignV2/state/useSignatureStore';
 import { DirectSignBtn } from '@/components2024/DirectSignBtn';
 import { Account } from '@/core/services/preference';
@@ -28,6 +28,7 @@ export default function BottomArea({ account }: { account: Account | null }) {
   const { t } = useTranslation();
 
   const { styles } = useTheme2024({ getStyle: getStyles });
+  const { safeOffBottom } = useSafeSizes();
 
   const { handleSubmit } = useSendNFTFormik();
 
@@ -158,7 +159,12 @@ export default function BottomArea({ account }: { account: Account | null }) {
     !canSubmit || (!!mostImportantRisks.length && !agreeRequiredChecked);
 
   return (
-    <View onLayout={onBottomAreaLayout} style={[styles.bottomDockArea]}>
+    <View
+      onLayout={onBottomAreaLayout}
+      style={[
+        styles.bottomDockArea,
+        { paddingBottom: SIZES.containerPb + safeOffBottom },
+      ]}>
       <BottomRiskTip
         loadingRisks={loadingRisks}
         mostImportantRisks={mostImportantRisks}
@@ -194,6 +200,7 @@ export default function BottomArea({ account }: { account: Account | null }) {
           }
           loading={isSubmitLoading}
           type={'primary'}
+          balanceIconSpacing
           syncUnlockTime
           account={account}
           showHardWalletProcess
@@ -243,28 +250,21 @@ export default function BottomArea({ account }: { account: Account | null }) {
 
 export const SIZES = {
   containerPt: 16,
-  containerPb: 48,
-  // height: 308,
-  bottom: 48,
+  containerPb: 24,
 };
 
-const getStyles = createGetStyles2024(
-  ({ colors2024, safeAreaInsets, isLight, colors }) => {
-    return {
-      bottomDockArea: {
-        bottom: 0,
-        width: '100%',
-        paddingHorizontal: 24,
-        position: 'absolute',
-        paddingTop: SIZES.containerPt,
-        paddingBottom: SIZES.containerPb + safeAreaInsets.bottom,
-        backgroundColor: resolveBgColorByType('bg1', {
-          isLight: isLight ?? true,
-          colors,
-          colors2024,
-        }),
-        // ...makeDebugBorder(),
-      },
-    };
-  },
-);
+const getStyles = createGetStyles2024(({ colors2024, isLight, colors }) => {
+  return {
+    bottomDockArea: {
+      width: '100%',
+      paddingHorizontal: 24,
+      flexShrink: 0,
+      paddingTop: SIZES.containerPt,
+      backgroundColor: resolveBgColorByType('bg1', {
+        isLight: isLight ?? true,
+        colors,
+        colors2024,
+      }),
+    },
+  };
+});

--- a/apps/mobile/src/screens/Swap/index.tsx
+++ b/apps/mobile/src/screens/Swap/index.tsx
@@ -34,7 +34,7 @@ import React, {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Platform, View } from 'react-native';
+import { Alert, View } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import useMount from 'react-use/lib/useMount';
 import { ChainInfo2024 } from '../Send/components/ChainInfo2024';
@@ -115,9 +115,12 @@ import {
   createAmountComparer,
   shouldIgnoreAmountChangeInMaxMode,
 } from '@/utils/form';
-import { Alert } from 'react-native';
 import { useMiniSignerEffectPause } from '@/hooks/useMiniSignerEffectPause';
-const isAndroid = Platform.OS === 'android';
+
+const FOOTER_BUTTON_HEIGHT = 56;
+const FOOTER_PADDING_TOP = 16;
+const FOOTER_PADDING_BOTTOM = 24;
+const FOOTER_RISK_TIP_HEIGHT = 40;
 
 type SwapRouteProps = CompositeScreenProps<
   NativeStackScreenProps<TransactionNavigatorParamList, 'Swap'>,
@@ -939,6 +942,15 @@ const Swap = ({
 
   const showRiskTips =
     isSlippageLow || isSlippageHigh || showLoss || miniSignGasFeeTooHigh;
+  const showDirectSignRiskTips = showRiskTips && !swapBtnDisabled;
+  const footerMinHeight =
+    FOOTER_BUTTON_HEIGHT +
+    FOOTER_PADDING_TOP +
+    FOOTER_PADDING_BOTTOM +
+    safeOffBottom +
+    (canShowDirectSubmit && showDirectSignRiskTips
+      ? FOOTER_RISK_TIP_HEIGHT
+      : 0);
   const shouldPauseMiniSignerEffects =
     useMiniSignerEffectPause(miniSignLoading);
 
@@ -1108,18 +1120,9 @@ const Swap = ({
           <AccountSwitcherModal forScene="MakeTransactionAbout" inScreen />
         )}
         <KeyboardAwareScrollView
-          style={[
-            styles.container,
-
-            {
-              marginBottom:
-                112 +
-                (isAndroid ? 20 + safeOffBottom : 0) +
-                (showRiskTips ? 26 : 0),
-            },
-          ]}
+          style={styles.container}
           ref={keyboardAwareRef}
-          // contentContainerStyle={styles.container}
+          contentContainerStyle={styles.scrollContent}
           enableOnAndroid
           extraHeight={200}
           keyboardOpeningTime={0}>
@@ -1348,7 +1351,10 @@ const Swap = ({
         <View
           style={[
             styles.buttonContainer,
-            isAndroid && { paddingBottom: safeOffBottom },
+            {
+              minHeight: footerMinHeight,
+              paddingBottom: FOOTER_PADDING_BOTTOM + safeOffBottom,
+            },
           ]}>
           <Tip
             content={
@@ -1389,7 +1395,7 @@ const Swap = ({
                   }}
                   account={currentAccount}
                   showHardWalletProcess
-                  showRiskTips={showRiskTips && !swapBtnDisabled}
+                  showRiskTips={showDirectSignRiskTips}
                 />
               ) : (
                 <Button
@@ -1502,6 +1508,9 @@ Swap.ForMultipleAddress = ForMultipleAddress;
 const getStyle = createGetStyles2024(({ colors2024 }) => ({
   container: {
     flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
   },
   content: {
     minHeight: 300,
@@ -1644,13 +1653,11 @@ const getStyle = createGetStyles2024(({ colors2024 }) => ({
   },
 
   buttonContainer: {
-    position: 'absolute',
-    left: 0,
-    bottom: 0,
+    flexShrink: 0,
     paddingHorizontal: 24,
+    paddingTop: FOOTER_PADDING_TOP,
     backgroundColor: colors2024['neutral-bg-1'],
     width: '100%',
-    marginBottom: 56,
   },
   approveContainer: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- keep Send, SendNFT, Swap, and Bridge bottom actions in normal page flow instead of absolute positioning
- make the main transaction content a scrollable area while the footer reserves fixed safe-area-aware space
- fix Send/SendNFT auth button text centering when a biometric/lock icon is shown in Chinese and other languages

## Validation
- corepack yarn workspace rabby-mobile typecheck
- git diff --check
- Android regression build succeeded: app-regression.apk, SHA256 9c3db5e5e8417edad33c728d40564348dca540fb54dc7f9490e2529a96727f53

Note: PR created for review; not merged on GitHub.