### PR TITLE
chore(mobile): default keychain to v9

### DIFF
--- a/apps/mobile/src/hooks/appSettings.ts
+++ b/apps/mobile/src/hooks/appSettings.ts
@@ -26,7 +26,7 @@ export const CURRENT_KEYCHAIN_VERSION_VALUES = ['8.2.0-fork', '9.0.0'] as const;
 export type CurrentKeychainVersion =
   (typeof CURRENT_KEYCHAIN_VERSION_VALUES)[number];
 
-const DEFAULT_CURRENT_KEYCHAIN_VERSION: CurrentKeychainVersion = '8.2.0-fork';
+const DEFAULT_CURRENT_KEYCHAIN_VERSION: CurrentKeychainVersion = '9.0.0';
 const DEFAULT_DEBUG_KEYCHAIN_STORAGE: KeychainStorageType =
   DEFAULT_KEYCHAIN_STORAGE_TYPE;
 


### PR DESCRIPTION
## Summary
- Switch the production default keychain implementation from the Rabby 8.2.0 fork to `react-native-keychain@9.0.0`.
- Keep the non-public debug switch and both implementations available for migration testing.

## Verification
- `corepack yarn workspace rabby-mobile test apps/mobile/src/core/apis/keychain.test.ts --runInBand`
- `corepack yarn workspace rabby-mobile typecheck`

## Notes
- `corepack yarn build` still reports the existing `@types/inquirer` generic constraint errors during workspace dist bootstrap, but emitted the dist files needed for local Jest bootstrap.
