### PR TITLE
Revert 1641 and 1720 for 0.6.71

### DIFF
--- a/apps/mobile/src/components2024/Button/index.tsx
+++ b/apps/mobile/src/components2024/Button/index.tsx
@@ -52,7 +52,6 @@ export type ButtonProps = Omit<
       noShadow?: boolean;
       icon?: ReactNode | ((ctx: { titleStyle?: TextStyle }) => ReactNode);
       iconRight?: ReactNode | ((ctx: { titleStyle?: TextStyle }) => ReactNode);
-      balanceIconSpacing?: boolean;
       showTextOnLoading?: boolean;
       loadingType?: 'indicator' | 'circle';
     },
@@ -77,7 +76,6 @@ export const Button = ({
   disabledTitleStyle,
   icon,
   iconRight,
-  balanceIconSpacing = false,
   ViewComponent = View,
   ...rest
 }: ButtonProps) => {
@@ -240,13 +238,6 @@ export const Button = ({
     return i;
   }, [icon, iconRight, titleStyle]);
 
-  const hiddenIconNode = useMemo(() => {
-    if (!React.isValidElement(iconNode)) {
-      return iconNode;
-    }
-    return React.cloneElement(iconNode);
-  }, [iconNode]);
-
   return (
     <View
       style={StyleSheet.flatten([
@@ -296,18 +287,6 @@ export const Button = ({
                 renderText(textNode, {
                   style: titleStyle,
                 })}
-              {balanceIconSpacing && iconNode && !iconRight && !!textNode && (
-                <View
-                  pointerEvents="none"
-                  accessibilityElementsHidden
-                  importantForAccessibility="no-hide-descendants"
-                  style={StyleSheet.flatten([
-                    styles.iconContainer,
-                    styles.hiddenIconContainer,
-                  ])}>
-                  {hiddenIconNode}
-                </View>
-              )}
               {iconNode && iconRight && (
                 <View style={StyleSheet.flatten([styles.iconContainer])}>
                   {iconNode}
@@ -355,9 +334,6 @@ const getStyle = createGetStyles2024(ctx => ({
   },
   iconContainer: {
     marginHorizontal: 8,
-  },
-  hiddenIconContainer: {
-    opacity: 0,
   },
   loading: {
     marginVertical: 2,

--- a/apps/mobile/src/screens/Address/components/MultiAssets/RenderRow/CurveChart.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/RenderRow/CurveChart.tsx
@@ -146,7 +146,6 @@ export const MultiChart = memo(function MultiChart({
     changeData,
     totalBalance,
     matteredAccountLength,
-    isPendingMatteredAccountLength,
     showBalanceLoadingWithoutLocal,
     showChangeLoadingWithoutLocal,
     isCurveAnyAddrLoading,
@@ -156,7 +155,6 @@ export const MultiChart = memo(function MultiChart({
       changeData: state.changeData,
       totalBalance: state.totalBalance,
       matteredAccountLength: state.matteredAccountLength,
-      isPendingMatteredAccountLength: state.isPendingMatteredAccountLength,
       showBalanceLoadingWithoutLocal: state.showBalanceLoadingWithoutLocal,
       showChangeLoadingWithoutLocal: state.showChangeLoadingWithoutLocal,
       isCurveAnyAddrLoading: state.isCurveAnyAddrLoading,
@@ -187,7 +185,6 @@ export const MultiChart = memo(function MultiChart({
             data={chartsData}
             hideType={hideType}
             matteredAccountCount={matteredAccountLength}
-            isMatteredAccountCountPending={isPendingMatteredAccountLength}
             showBalanceLoadingWithoutLocal={showBalanceLoadingWithoutLocal}
             showChangeLoadingWithoutLocal={showChangeLoadingWithoutLocal}
             onPressNetWorth={onPressNetWorth}
@@ -212,8 +209,7 @@ interface IHeaderProps {
   isLoss: boolean;
   data: CurvePoint[];
   hideType: BALANCE_HIDE_TYPE;
-  matteredAccountCount: number;
-  isMatteredAccountCountPending: boolean;
+  matteredAccountCount?: number;
   showBalanceLoadingWithoutLocal: boolean;
   showChangeLoadingWithoutLocal: boolean;
   onPressNetWorth?: () => void;
@@ -228,7 +224,6 @@ const ChartHeader = React.memo(
     hideType,
     data: _data,
     matteredAccountCount,
-    isMatteredAccountCountPending,
     showBalanceLoadingWithoutLocal,
     showChangeLoadingWithoutLocal,
     onPressNetWorth,
@@ -247,8 +242,6 @@ const ChartHeader = React.memo(
     const changePercent = useDebouncedValue(_changePercent, 300);
     const showChangeLoading =
       showNetWorthLoading || showChangeLoadingWithoutLocal;
-    const displayMatteredAccountCount =
-      matteredAccountCount >= 10 ? '10' : String(matteredAccountCount);
 
     const netWorth = useMemo(() => {
       return formatSmallCurrencyValueParts(rawNetWorth, { currency }).text;
@@ -426,18 +419,11 @@ const ChartHeader = React.memo(
             onPress={onPressWalletList}
             hitSlop={8}>
             <RcIconSmallWalletCC color={colors2024['neutral-title-1']} />
-            {isMatteredAccountCountPending ? (
-              <Skeleton
-                width={18}
-                height={16}
-                style={styles.accountCountSkeleton}
-                LinearGradientComponent={LoadingLinear}
-              />
-            ) : (
-              <Text style={styles.accountText}>
-                {displayMatteredAccountCount}
-              </Text>
-            )}
+            <Text style={styles.accountText}>
+              {matteredAccountCount && matteredAccountCount >= 10
+                ? '10'
+                : matteredAccountCount}
+            </Text>
             <RcIconSmallArrowCC color={colors2024['neutral-title-1']} />
           </Pressable>
         </View>
@@ -645,10 +631,6 @@ const getStyle = createGetStyles2024(
       lineHeight: 20,
       fontFamily: 'SF Pro Rounded',
       paddingLeft: 6,
-    },
-    accountCountSkeleton: {
-      marginLeft: 6,
-      borderRadius: 4,
     },
     percentChangeContainer: {
       // flexDirection: 'row',

--- a/apps/mobile/src/screens/Address/components/MultiAssets/RenderRow/CurveChart.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/RenderRow/CurveChart.tsx
@@ -6,7 +6,7 @@ import {
   formatCurrencyValueParts,
   formatSmallCurrencyValueParts,
 } from '@/utils/currency';
-import React, { memo, useEffect, useMemo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { Dimensions, Pressable, useWindowDimensions, View } from 'react-native';
 import { createGetStyles2024 } from '@/utils/styles';
 import Animated, {
@@ -146,7 +146,6 @@ export const MultiChart = memo(function MultiChart({
     changeData,
     totalBalance,
     matteredAccountLength,
-    canToggle24hCurve,
     showBalanceLoadingWithoutLocal,
     showChangeLoadingWithoutLocal,
     isCurveAnyAddrLoading,
@@ -156,7 +155,6 @@ export const MultiChart = memo(function MultiChart({
       changeData: state.changeData,
       totalBalance: state.totalBalance,
       matteredAccountLength: state.matteredAccountLength,
-      canToggle24hCurve: state.canToggle24hCurve,
       showBalanceLoadingWithoutLocal: state.showBalanceLoadingWithoutLocal,
       showChangeLoadingWithoutLocal: state.showChangeLoadingWithoutLocal,
       isCurveAnyAddrLoading: state.isCurveAnyAddrLoading,
@@ -166,12 +164,6 @@ export const MultiChart = memo(function MultiChart({
   useRendererDetect({ name: 'MultiAssets-MultiChart' });
 
   const chartsData = curveList;
-
-  useEffect(() => {
-    if (!canToggle24hCurve) {
-      setIsFoldMultiChart(true);
-    }
-  }, [canToggle24hCurve]);
 
   return (
     <View
@@ -193,7 +185,6 @@ export const MultiChart = memo(function MultiChart({
             data={chartsData}
             hideType={hideType}
             matteredAccountCount={matteredAccountLength}
-            canToggle24hCurve={canToggle24hCurve}
             showBalanceLoadingWithoutLocal={showBalanceLoadingWithoutLocal}
             showChangeLoadingWithoutLocal={showChangeLoadingWithoutLocal}
             onPressNetWorth={onPressNetWorth}
@@ -219,7 +210,6 @@ interface IHeaderProps {
   data: CurvePoint[];
   hideType: BALANCE_HIDE_TYPE;
   matteredAccountCount?: number;
-  canToggle24hCurve: boolean;
   showBalanceLoadingWithoutLocal: boolean;
   showChangeLoadingWithoutLocal: boolean;
   onPressNetWorth?: () => void;
@@ -234,7 +224,6 @@ const ChartHeader = React.memo(
     hideType,
     data: _data,
     matteredAccountCount,
-    canToggle24hCurve,
     showBalanceLoadingWithoutLocal,
     showChangeLoadingWithoutLocal,
     onPressNetWorth,
@@ -449,11 +438,7 @@ const ChartHeader = React.memo(
         ) : (
           <Pressable
             {...makeTestIDProps(E2E_ID.home.portfolioCurveToggle)}
-            disabled={!canToggle24hCurve}
             onPress={e => {
-              if (!canToggle24hCurve) {
-                return;
-              }
               e.stopPropagation();
               const nextValue = !svIsFoldMultiChart.value;
               svIsFoldMultiChart.value = nextValue;
@@ -482,24 +467,22 @@ const ChartHeader = React.memo(
                   style={styles.changeTime}
                   animatedProps={dateTimeAnimatedProps}
                 />
-                {canToggle24hCurve ? (
-                  <View style={styles.percentChangeContainer}>
-                    <AnimatedSVG
-                      style={animatedSvgStyle}
-                      width={16}
-                      height={16}
-                      viewBox="0 0 24 24"
-                      fill="none">
-                      <AnimatedPath
-                        d="M8.4 4.80005L15.6 12L8.4 19.2"
-                        strokeWidth={2}
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        animatedProps={arrowStrokeProps}
-                      />
-                    </AnimatedSVG>
-                  </View>
-                ) : null}
+                <View style={styles.percentChangeContainer}>
+                  <AnimatedSVG
+                    style={animatedSvgStyle}
+                    width={16}
+                    height={16}
+                    viewBox="0 0 24 24"
+                    fill="none">
+                    <AnimatedPath
+                      d="M8.4 4.80005L15.6 12L8.4 19.2"
+                      strokeWidth={2}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      animatedProps={arrowStrokeProps}
+                    />
+                  </AnimatedSVG>
+                </View>
               </>
             )}
           </Pressable>

--- a/apps/mobile/src/screens/Address/components/MultiAssets/RenderRow/CurveChart.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/RenderRow/CurveChart.tsx
@@ -146,6 +146,7 @@ export const MultiChart = memo(function MultiChart({
     changeData,
     totalBalance,
     matteredAccountLength,
+    isPendingMatteredAccountLength,
     showBalanceLoadingWithoutLocal,
     showChangeLoadingWithoutLocal,
     isCurveAnyAddrLoading,
@@ -155,6 +156,7 @@ export const MultiChart = memo(function MultiChart({
       changeData: state.changeData,
       totalBalance: state.totalBalance,
       matteredAccountLength: state.matteredAccountLength,
+      isPendingMatteredAccountLength: state.isPendingMatteredAccountLength,
       showBalanceLoadingWithoutLocal: state.showBalanceLoadingWithoutLocal,
       showChangeLoadingWithoutLocal: state.showChangeLoadingWithoutLocal,
       isCurveAnyAddrLoading: state.isCurveAnyAddrLoading,
@@ -185,6 +187,7 @@ export const MultiChart = memo(function MultiChart({
             data={chartsData}
             hideType={hideType}
             matteredAccountCount={matteredAccountLength}
+            isMatteredAccountCountPending={isPendingMatteredAccountLength}
             showBalanceLoadingWithoutLocal={showBalanceLoadingWithoutLocal}
             showChangeLoadingWithoutLocal={showChangeLoadingWithoutLocal}
             onPressNetWorth={onPressNetWorth}
@@ -209,7 +212,8 @@ interface IHeaderProps {
   isLoss: boolean;
   data: CurvePoint[];
   hideType: BALANCE_HIDE_TYPE;
-  matteredAccountCount?: number;
+  matteredAccountCount: number;
+  isMatteredAccountCountPending: boolean;
   showBalanceLoadingWithoutLocal: boolean;
   showChangeLoadingWithoutLocal: boolean;
   onPressNetWorth?: () => void;
@@ -224,6 +228,7 @@ const ChartHeader = React.memo(
     hideType,
     data: _data,
     matteredAccountCount,
+    isMatteredAccountCountPending,
     showBalanceLoadingWithoutLocal,
     showChangeLoadingWithoutLocal,
     onPressNetWorth,
@@ -242,6 +247,8 @@ const ChartHeader = React.memo(
     const changePercent = useDebouncedValue(_changePercent, 300);
     const showChangeLoading =
       showNetWorthLoading || showChangeLoadingWithoutLocal;
+    const displayMatteredAccountCount =
+      matteredAccountCount >= 10 ? '10' : String(matteredAccountCount);
 
     const netWorth = useMemo(() => {
       return formatSmallCurrencyValueParts(rawNetWorth, { currency }).text;
@@ -419,11 +426,18 @@ const ChartHeader = React.memo(
             onPress={onPressWalletList}
             hitSlop={8}>
             <RcIconSmallWalletCC color={colors2024['neutral-title-1']} />
-            <Text style={styles.accountText}>
-              {matteredAccountCount && matteredAccountCount >= 10
-                ? '10'
-                : matteredAccountCount}
-            </Text>
+            {isMatteredAccountCountPending ? (
+              <Skeleton
+                width={18}
+                height={16}
+                style={styles.accountCountSkeleton}
+                LinearGradientComponent={LoadingLinear}
+              />
+            ) : (
+              <Text style={styles.accountText}>
+                {displayMatteredAccountCount}
+              </Text>
+            )}
             <RcIconSmallArrowCC color={colors2024['neutral-title-1']} />
           </Pressable>
         </View>
@@ -631,6 +645,10 @@ const getStyle = createGetStyles2024(
       lineHeight: 20,
       fontFamily: 'SF Pro Rounded',
       paddingLeft: 6,
+    },
+    accountCountSkeleton: {
+      marginLeft: 6,
+      borderRadius: 4,
     },
     percentChangeContainer: {
       // flexDirection: 'row',

--- a/apps/mobile/src/screens/Bridge/components/BridgeContent.tsx
+++ b/apps/mobile/src/screens/Bridge/components/BridgeContent.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from 'react-i18next';
 import { TwpStepApproveModal } from '@/screens/Swap/components/TwoStepApproveModal';
 import BigNumber from 'bignumber.js';
 import { QuoteList } from './BridgeQuotes';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSafeSetNavigationOptions } from '@/components/AppStatusBar';
 import { BridgeHeader, BridgeHeaderRef } from './BridgeHeader';
 import { openapi } from '@/core/request';
@@ -80,12 +81,6 @@ import {
   type QuotePollingPauseReasonState,
   updateQuotePollingPauseReason,
 } from '@/utils/quotePolling';
-import { useSafeSizes } from '@/hooks/useAppLayout';
-
-const FOOTER_BUTTON_HEIGHT = 56;
-const FOOTER_PADDING_TOP = 16;
-const FOOTER_PADDING_BOTTOM = 24;
-const FOOTER_RISK_TIP_HEIGHT = 40;
 
 /** Bridge form snapshot for validation during auth */
 export interface BridgeFormSnapshot {
@@ -100,12 +95,7 @@ const getStyle = createGetStyles2024(({ colors2024, colors }) => ({
   },
   container: {
     flex: 1,
-    overflow: 'visible',
-  },
-  scrollContent: {
-    flexGrow: 1,
     paddingTop: 16,
-    paddingBottom: 24,
     overflow: 'visible',
   },
   noRecoomedTokenText: {
@@ -206,11 +196,13 @@ const getStyle = createGetStyles2024(({ colors2024, colors }) => ({
     color: colors['neutral-foot'],
   },
   buttonContainer: {
-    flexShrink: 0,
+    position: 'absolute',
+    left: 0,
+    bottom: 0,
+    // height: 140,
     backgroundColor: colors2024['neutral-bg-1'],
     width: '100%',
-    paddingHorizontal: 20,
-    paddingTop: FOOTER_PADDING_TOP,
+    padding: 20,
   },
   btnTitle: {
     color: colors['neutral-title-2'],
@@ -222,7 +214,7 @@ const getStyle = createGetStyles2024(({ colors2024, colors }) => ({
 
 export const BridgeContent = ({ isForMultipleAddress = false }) => {
   const { t } = useTranslation();
-  const { safeOffBottom } = useSafeSizes();
+  const { bottom } = useSafeAreaInsets();
   const { styles } = useTheme2024({ getStyle });
   const headerRef = useRef<BridgeHeaderRef>(null);
   const { setNavigationOptions } = useSafeSetNavigationOptions();
@@ -1006,16 +998,6 @@ export const BridgeContent = ({ isForMultipleAddress = false }) => {
 
   const showRiskTips =
     isSlippageHigh || isSlippageLow || showLoss || miniSignGasFeeTooHigh;
-  const showDirectSignRiskTips =
-    showRiskTips && !btnDisabled && !miniSignLoading;
-  const footerMinHeight =
-    FOOTER_BUTTON_HEIGHT +
-    FOOTER_PADDING_TOP +
-    FOOTER_PADDING_BOTTOM +
-    safeOffBottom +
-    (canShowDirectSubmit && showDirectSignRiskTips
-      ? FOOTER_RISK_TIP_HEIGHT
-      : 0);
 
   const [scrollEnabled, setScrollEnabled] = useState(true);
 
@@ -1027,7 +1009,9 @@ export const BridgeContent = ({ isForMultipleAddress = false }) => {
         )}
         <KeyboardAwareScrollView
           style={styles.container}
-          contentContainerStyle={styles.scrollContent}
+          contentContainerStyle={{
+            paddingBottom: 150 + bottom + (showRiskTips ? 26 : 0),
+          }}
           enableOnAndroid
           scrollEnabled={scrollEnabled}
           extraHeight={200}
@@ -1217,8 +1201,7 @@ export const BridgeContent = ({ isForMultipleAddress = false }) => {
           style={[
             styles.buttonContainer,
             {
-              minHeight: footerMinHeight,
-              paddingBottom: FOOTER_PADDING_BOTTOM + safeOffBottom,
+              paddingBottom: Math.max(bottom, 50),
             },
           ]}>
           <Tip
@@ -1251,7 +1234,7 @@ export const BridgeContent = ({ isForMultipleAddress = false }) => {
                 }}
                 account={currentAccount}
                 showHardWalletProcess
-                showRiskTips={showDirectSignRiskTips}
+                showRiskTips={showRiskTips && !btnDisabled && !miniSignLoading}
                 loading={miniSignLoading}
                 showTextOnLoading
               />

--- a/apps/mobile/src/screens/Home/hooks/useHomePortfolioSummary.ts
+++ b/apps/mobile/src/screens/Home/hooks/useHomePortfolioSummary.ts
@@ -20,7 +20,6 @@ type HomePortfolioState = {
   hasFetchedAccounts: boolean;
   isFetchingAccounts: boolean;
   matteredAccountLength: number;
-  isPendingMatteredAccountLength: boolean;
   isPendingDisplayAddresses: boolean;
   totalBalance: number;
   changeData: HomeChangeData;
@@ -92,7 +91,6 @@ function buildInitialState(): HomePortfolioState {
     hasFetchedAccounts: false,
     isFetchingAccounts: false,
     matteredAccountLength: 0,
-    isPendingMatteredAccountLength: true,
     isPendingDisplayAddresses: true,
     totalBalance: 0,
     changeData: EMPTY_HOME_CHANGE_DATA,
@@ -115,8 +113,6 @@ function isSameState(prev: HomePortfolioState, next: HomePortfolioState) {
     prev.hasFetchedAccounts === next.hasFetchedAccounts &&
     prev.isFetchingAccounts === next.isFetchingAccounts &&
     prev.matteredAccountLength === next.matteredAccountLength &&
-    prev.isPendingMatteredAccountLength ===
-      next.isPendingMatteredAccountLength &&
     prev.isPendingDisplayAddresses === next.isPendingDisplayAddresses &&
     prev.totalBalance === next.totalBalance &&
     prev.changeData.rawChange === next.changeData.rawChange &&
@@ -192,8 +188,6 @@ function buildHomePortfolioState(): HomePortfolioState {
     hasFetchedAccounts: accountState.hasFetchedAccounts,
     isFetchingAccounts: accountState.isFetchingAccounts,
     matteredAccountLength: balanceState.matteredAccountLength,
-    isPendingMatteredAccountLength:
-      !balanceState.hasResolvedMatteredAccountLength,
     isPendingDisplayAddresses,
     totalBalance: balanceState.totalBalance,
     changeData,

--- a/apps/mobile/src/screens/Home/hooks/useHomePortfolioSummary.ts
+++ b/apps/mobile/src/screens/Home/hooks/useHomePortfolioSummary.ts
@@ -20,6 +20,7 @@ type HomePortfolioState = {
   hasFetchedAccounts: boolean;
   isFetchingAccounts: boolean;
   matteredAccountLength: number;
+  isPendingMatteredAccountLength: boolean;
   isPendingDisplayAddresses: boolean;
   totalBalance: number;
   changeData: HomeChangeData;
@@ -91,6 +92,7 @@ function buildInitialState(): HomePortfolioState {
     hasFetchedAccounts: false,
     isFetchingAccounts: false,
     matteredAccountLength: 0,
+    isPendingMatteredAccountLength: true,
     isPendingDisplayAddresses: true,
     totalBalance: 0,
     changeData: EMPTY_HOME_CHANGE_DATA,
@@ -113,6 +115,8 @@ function isSameState(prev: HomePortfolioState, next: HomePortfolioState) {
     prev.hasFetchedAccounts === next.hasFetchedAccounts &&
     prev.isFetchingAccounts === next.isFetchingAccounts &&
     prev.matteredAccountLength === next.matteredAccountLength &&
+    prev.isPendingMatteredAccountLength ===
+      next.isPendingMatteredAccountLength &&
     prev.isPendingDisplayAddresses === next.isPendingDisplayAddresses &&
     prev.totalBalance === next.totalBalance &&
     prev.changeData.rawChange === next.changeData.rawChange &&
@@ -188,6 +192,8 @@ function buildHomePortfolioState(): HomePortfolioState {
     hasFetchedAccounts: accountState.hasFetchedAccounts,
     isFetchingAccounts: accountState.isFetchingAccounts,
     matteredAccountLength: balanceState.matteredAccountLength,
+    isPendingMatteredAccountLength:
+      !balanceState.hasResolvedMatteredAccountLength,
     isPendingDisplayAddresses,
     totalBalance: balanceState.totalBalance,
     changeData,

--- a/apps/mobile/src/screens/Home/hooks/useHomePortfolioSummary.ts
+++ b/apps/mobile/src/screens/Home/hooks/useHomePortfolioSummary.ts
@@ -20,7 +20,6 @@ type HomePortfolioState = {
   hasFetchedAccounts: boolean;
   isFetchingAccounts: boolean;
   matteredAccountLength: number;
-  canToggle24hCurve: boolean;
   isPendingDisplayAddresses: boolean;
   totalBalance: number;
   changeData: HomeChangeData;
@@ -92,7 +91,6 @@ function buildInitialState(): HomePortfolioState {
     hasFetchedAccounts: false,
     isFetchingAccounts: false,
     matteredAccountLength: 0,
-    canToggle24hCurve: false,
     isPendingDisplayAddresses: true,
     totalBalance: 0,
     changeData: EMPTY_HOME_CHANGE_DATA,
@@ -115,7 +113,6 @@ function isSameState(prev: HomePortfolioState, next: HomePortfolioState) {
     prev.hasFetchedAccounts === next.hasFetchedAccounts &&
     prev.isFetchingAccounts === next.isFetchingAccounts &&
     prev.matteredAccountLength === next.matteredAccountLength &&
-    prev.canToggle24hCurve === next.canToggle24hCurve &&
     prev.isPendingDisplayAddresses === next.isPendingDisplayAddresses &&
     prev.totalBalance === next.totalBalance &&
     prev.changeData.rawChange === next.changeData.rawChange &&
@@ -158,8 +155,6 @@ function buildHomePortfolioState(): HomePortfolioState {
   const scene24hAddrLoading = displayAddresses.some(address => {
     return !!scene24hState.sceneAddrLoading[`Home-${address.toLowerCase()}`];
   });
-  const canToggle24hCurve =
-    balanceState.hasResolvedSelection && displayAddresses.length > 0;
   const isChangeAnyLoading =
     !is24hSceneMatched ||
     scene24hState.sceneLoading.Home ||
@@ -193,7 +188,6 @@ function buildHomePortfolioState(): HomePortfolioState {
     hasFetchedAccounts: accountState.hasFetchedAccounts,
     isFetchingAccounts: accountState.isFetchingAccounts,
     matteredAccountLength: balanceState.matteredAccountLength,
-    canToggle24hCurve,
     isPendingDisplayAddresses,
     totalBalance: balanceState.totalBalance,
     changeData,

--- a/apps/mobile/src/screens/Send/Send.tsx
+++ b/apps/mobile/src/screens/Send/Send.tsx
@@ -10,6 +10,7 @@ import {
   View,
   TouchableWithoutFeedback,
   Keyboard,
+  ScrollView,
 } from 'react-native';
 import { useTheme2024 } from '@/hooks/theme';
 import {
@@ -93,7 +94,18 @@ import { type ITokenCheck } from '@/components/Token/TokenSelectorSheetModal';
 import { useRendererDetect } from '@/components/Perf/PerfDetector';
 import { E2E_ID } from '@/constant/e2e';
 import { makeTestIDProps } from '@/utils/makeTestIDProps';
+import Animated, {
+  runOnJS,
+  useAnimatedReaction,
+  useAnimatedRef,
+  useAnimatedStyle,
+  useSharedValue,
+} from 'react-native-reanimated';
 import { DirectSignBtnMethods } from '@/components2024/DirectSignBtn';
+
+const AnimatedKeyboardAwareScrollView = Animated.createAnimatedComponent(
+  KeyboardAwareScrollView,
+);
 
 const EMPTY_TOKEN_ITEM = {
   decimals: 18,
@@ -238,6 +250,7 @@ function SendScreen({
     setReloadTxRefreshPaused,
     onBottomAreaLayout,
     scrollViewRef,
+    scrollViewStyle,
     scrollToBottom,
 
     checkCexSupport,
@@ -546,17 +559,13 @@ function SendScreen({
                 sendTokenEvents.emit(SendTokenEvents.ON_PRESS_DISMISS);
                 Keyboard.dismiss();
               }}>
-              <View style={styles.sendScreen}>
-                <KeyboardAwareScrollView
+              <ScrollView contentContainerStyle={styles.sendScreen}>
+                <AnimatedKeyboardAwareScrollView
                   innerRef={instance => {
                     scrollViewRef.current =
                       instance as unknown as KeyboardAwareScrollView;
                   }}
-                  style={styles.scrollArea}
-                  contentContainerStyle={styles.mainContent}
-                  enableOnAndroid
-                  extraHeight={200}
-                  keyboardOpeningTime={0}>
+                  contentContainerStyle={[styles.mainContent, scrollViewStyle]}>
                   {/* FromToSection */}
                   <View>
                     {/* From */}
@@ -586,9 +595,9 @@ function SendScreen({
                       clearLocalPendingTxData={clearLocalPendingTxData}
                     />
                   )}
-                </KeyboardAwareScrollView>
+                </AnimatedKeyboardAwareScrollView>
                 <BottomArea account={currentAccount} />
-              </View>
+              </ScrollView>
             </TouchableWithoutFeedback>
             <TokenInfoPopup />
             <BlockedAddressDialog
@@ -636,16 +645,16 @@ const getStyle = createGetStyles2024(({ colors2024 }) =>
       marginTop: 8,
     },
     sendScreen: {
-      flex: 1,
       flexDirection: 'column',
-      paddingTop: 16,
-    },
-    scrollArea: {
+      justifyContent: 'space-between',
       flex: 1,
+      paddingTop: 16,
+      position: 'relative',
+      height: '100%',
     },
     mainContent: {
       paddingHorizontal: 24,
-      paddingBottom: 24,
+      paddingBottom: 280,
     },
     balance: {
       marginTop: 24,

--- a/apps/mobile/src/screens/Send/components/BottomArea.tsx
+++ b/apps/mobile/src/screens/Send/components/BottomArea.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { View } from 'react-native';
+import { Platform, TouchableOpacity, View } from 'react-native';
 import { useTheme2024 } from '@/hooks/theme';
 import {
   apiSendToken,
@@ -9,11 +9,15 @@ import {
   useSendTokenInternalContext,
   useSendTokenScreenChainToken,
 } from '../hooks/useSendToken';
-import { createGetStyles2024 } from '@/utils/styles';
+import {
+  createGetStyles2024,
+  makeDebugBorder,
+  makeDevOnlyStyle,
+} from '@/utils/styles';
 import { ModalConfirmAllowTransfer } from '@/components/Address/SheetModalConfirmAllowTransfer';
 import { ModalAddToContacts } from '@/components/Address/SheetModalAddToContacts';
 import { apiBalance } from '@/core/apis';
-import { useSafeSizes } from '@/hooks/useAppLayout';
+import { useSafeAndroidBottomSizes, useSafeSizes } from '@/hooks/useAppLayout';
 import { Button } from '@/components2024/Button';
 import { useTranslation } from 'react-i18next';
 
@@ -32,10 +36,11 @@ import { makeTestIDProps } from '@/utils/makeTestIDProps';
 import { Text } from '@/components/Typography';
 import { isGasAccountDepositFlowActive } from '@/screens/GasAccount/utils/depositFlowRuntime';
 
+const isAndroid = Platform.OS === 'android';
+
 export default function BottomArea({ account }: { account: Account | null }) {
   const { t } = useTranslation();
-  const { styles } = useTheme2024({ getStyle });
-  const { safeOffBottom } = useSafeSizes();
+  const { styles, colors2024 } = useTheme2024({ getStyle });
 
   const { handleSubmit } = useSendTokenFormik();
 
@@ -202,12 +207,7 @@ export default function BottomArea({ account }: { account: Account | null }) {
     !canSubmit || (!!mostImportantRisks.length && !agreeRequiredChecked);
 
   return (
-    <View
-      onLayout={onBottomAreaLayout}
-      style={[
-        styles.bottomDockArea,
-        { paddingBottom: SIZES.containerPb + safeOffBottom },
-      ]}>
+    <View onLayout={onBottomAreaLayout} style={[styles.bottomDockArea]}>
       <BottomRiskTip
         loadingRisks={loadingRisks}
         mostImportantRisks={mostImportantRisks}
@@ -260,7 +260,6 @@ export default function BottomArea({ account }: { account: Account | null }) {
           }
           loading={isSubmitLoading}
           type={'primary'}
-          balanceIconSpacing
           syncUnlockTime
           account={account}
           showHardWalletProcess
@@ -312,21 +311,32 @@ export default function BottomArea({ account }: { account: Account | null }) {
 
 const SIZES = {
   containerPt: 16,
-  containerPb: 24,
+  containerPb: 48,
+  // height: 220,
+  bottom: 48,
 };
 
-const getStyle = createGetStyles2024(({ isLight, colors, colors2024 }) => {
-  return {
-    bottomDockArea: {
-      width: '100%',
-      paddingHorizontal: 24,
-      flexShrink: 0,
-      paddingTop: SIZES.containerPt,
-      backgroundColor: resolveBgColorByType('bg1', {
-        isLight: isLight ?? true,
-        colors,
-        colors2024,
-      }),
-    },
-  };
-});
+const getStyle = createGetStyles2024(
+  ({ safeAreaInsets, isLight, colors, colors2024 }) => {
+    return {
+      bottomDockArea: {
+        bottom: 0,
+        width: '100%',
+        paddingHorizontal: 24,
+        position: 'absolute',
+        paddingTop: SIZES.containerPt,
+        paddingBottom: SIZES.containerPb + safeAreaInsets.bottom,
+        backgroundColor: resolveBgColorByType('bg1', {
+          isLight: isLight ?? true,
+          colors,
+          colors2024,
+        }),
+        // ...makeDebugBorder(),
+        // ...makeDevOnlyStyle({
+        //   backgroundColor: 'blue',
+        // }),
+        // height: SIZES.height,
+      },
+    };
+  },
+);

--- a/apps/mobile/src/screens/SendNFT/SendNFT.tsx
+++ b/apps/mobile/src/screens/SendNFT/SendNFT.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import { View } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
+import Animated, {
+  runOnJS,
+  useAnimatedReaction,
+  useAnimatedRef,
+  useAnimatedStyle,
+  useSharedValue,
+} from 'react-native-reanimated';
 
 import NormalScreenContainer2024 from '@/components2024/ScreenContainer/NormalScreenContainer';
 import { SignatureInstanceProvider } from '@/components2024/MiniSignV2/state/SignatureInstanceContext';
@@ -8,7 +15,7 @@ import { RootNames } from '@/constant/layout';
 import { useTheme2024 } from '@/hooks/theme';
 import { StackActions, useRoute } from '@react-navigation/native';
 import { GetNestedScreenRouteProp } from '@/navigation-type';
-import { NFTSection } from './Section';
+import { NFTSection, SendNFTSection } from './Section';
 import ToAddressControl2024 from '@/screens/SendNFT/components/ToAddressControl2024';
 import FromAddressControl2024 from '@/screens/SendNFT/components/FromAddressControl';
 import {
@@ -26,6 +33,11 @@ import { AccountSwitcherModal } from '@/components/AccountSwitcher/Modal';
 import { createGetStyles2024 } from '@/utils/styles';
 import { ShowMoreOnSendNFT } from './components/ShowMoreOnSendNFT';
 import { useSceneAccountInfo } from '@/hooks/accountsSwitcher';
+import { Text } from '@/components/Typography';
+
+const AnimatedKeyboardAwareScrollView = Animated.createAnimatedComponent(
+  KeyboardAwareScrollView,
+);
 
 export default function SendNFT() {
   const { styles } = useTheme2024({ getStyle: getStyles });
@@ -69,6 +81,7 @@ export default function SendNFT() {
     scrollviewRef,
     handleIgnoreGasFeeChange,
     onBottomAreaLayout,
+    scrollViewStyle,
     scrollToBottom,
 
     whitelistEnabled,
@@ -171,16 +184,12 @@ export default function SendNFT() {
         <NormalScreenContainer2024 type="bg1">
           <AccountSwitcherModal forScene="SendNFT" inScreen />
           <View style={styles.sendNFTScreen}>
-            <KeyboardAwareScrollView
+            <AnimatedKeyboardAwareScrollView
               innerRef={instance => {
                 scrollviewRef.current =
                   instance as unknown as KeyboardAwareScrollView;
               }}
-              style={styles.scrollArea}
-              contentContainerStyle={styles.mainContent}
-              enableOnAndroid
-              extraHeight={200}
-              keyboardOpeningTime={0}>
+              contentContainerStyle={[styles.mainContent, scrollViewStyle]}>
               {/* From */}
               <FromAddressControl2024 disableSwitch={true} />
 
@@ -194,7 +203,7 @@ export default function SendNFT() {
                 chainItem={chainItem}
               />
               <ShowMoreOnSendNFT chainServeId={chainItem?.serverId || ''} />
-            </KeyboardAwareScrollView>
+            </AnimatedKeyboardAwareScrollView>
             <BottomArea account={account} />
           </View>
         </NormalScreenContainer2024>
@@ -212,16 +221,14 @@ const getStyles = createGetStyles2024(({ colors2024 }) => ({
   },
   sendNFTScreen: {
     width: '100%',
-    flex: 1,
+    height: '100%',
     flexDirection: 'column',
     backgroundColor: colors2024['neutral-bg-1'],
-  },
-  scrollArea: {
-    flex: 1,
+    justifyContent: 'space-between',
   },
   mainContent: {
     paddingHorizontal: 20,
-    paddingBottom: 24,
+    paddingBottom: 308,
   },
 
   buttonContainer: {

--- a/apps/mobile/src/screens/SendNFT/components/BottomArea.tsx
+++ b/apps/mobile/src/screens/SendNFT/components/BottomArea.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 import { Button } from '@/components2024/Button';
 import {
   useSendNFTFormik,
@@ -10,10 +10,10 @@ import { useTranslation } from 'react-i18next';
 import { ModalConfirmAllowTransfer } from '@/components/Address/SheetModalConfirmAllowTransfer';
 import { ModalAddToContacts } from '@/components/Address/SheetModalAddToContacts';
 import { apiBalance } from '@/core/apis';
-import { useSafeSizes } from '@/hooks/useAppLayout';
+import { useSafeAndroidBottomSizes } from '@/hooks/useAppLayout';
 import { useTheme2024 } from '@/hooks/theme';
 
-import { createGetStyles2024 } from '@/utils/styles';
+import { createGetStyles2024, makeDebugBorder } from '@/utils/styles';
 import { useSignatureStore } from '@/components2024/MiniSignV2/state/useSignatureStore';
 import { DirectSignBtn } from '@/components2024/DirectSignBtn';
 import { Account } from '@/core/services/preference';
@@ -28,7 +28,6 @@ export default function BottomArea({ account }: { account: Account | null }) {
   const { t } = useTranslation();
 
   const { styles } = useTheme2024({ getStyle: getStyles });
-  const { safeOffBottom } = useSafeSizes();
 
   const { handleSubmit } = useSendNFTFormik();
 
@@ -159,12 +158,7 @@ export default function BottomArea({ account }: { account: Account | null }) {
     !canSubmit || (!!mostImportantRisks.length && !agreeRequiredChecked);
 
   return (
-    <View
-      onLayout={onBottomAreaLayout}
-      style={[
-        styles.bottomDockArea,
-        { paddingBottom: SIZES.containerPb + safeOffBottom },
-      ]}>
+    <View onLayout={onBottomAreaLayout} style={[styles.bottomDockArea]}>
       <BottomRiskTip
         loadingRisks={loadingRisks}
         mostImportantRisks={mostImportantRisks}
@@ -200,7 +194,6 @@ export default function BottomArea({ account }: { account: Account | null }) {
           }
           loading={isSubmitLoading}
           type={'primary'}
-          balanceIconSpacing
           syncUnlockTime
           account={account}
           showHardWalletProcess
@@ -250,21 +243,28 @@ export default function BottomArea({ account }: { account: Account | null }) {
 
 export const SIZES = {
   containerPt: 16,
-  containerPb: 24,
+  containerPb: 48,
+  // height: 308,
+  bottom: 48,
 };
 
-const getStyles = createGetStyles2024(({ colors2024, isLight, colors }) => {
-  return {
-    bottomDockArea: {
-      width: '100%',
-      paddingHorizontal: 24,
-      flexShrink: 0,
-      paddingTop: SIZES.containerPt,
-      backgroundColor: resolveBgColorByType('bg1', {
-        isLight: isLight ?? true,
-        colors,
-        colors2024,
-      }),
-    },
-  };
-});
+const getStyles = createGetStyles2024(
+  ({ colors2024, safeAreaInsets, isLight, colors }) => {
+    return {
+      bottomDockArea: {
+        bottom: 0,
+        width: '100%',
+        paddingHorizontal: 24,
+        position: 'absolute',
+        paddingTop: SIZES.containerPt,
+        paddingBottom: SIZES.containerPb + safeAreaInsets.bottom,
+        backgroundColor: resolveBgColorByType('bg1', {
+          isLight: isLight ?? true,
+          colors,
+          colors2024,
+        }),
+        // ...makeDebugBorder(),
+      },
+    };
+  },
+);

--- a/apps/mobile/src/screens/Swap/index.tsx
+++ b/apps/mobile/src/screens/Swap/index.tsx
@@ -119,11 +119,6 @@ import {
 } from '@/utils/quotePolling';
 const isAndroid = Platform.OS === 'android';
 
-const FOOTER_BUTTON_HEIGHT = 56;
-const FOOTER_PADDING_TOP = 16;
-const FOOTER_PADDING_BOTTOM = 24;
-const FOOTER_RISK_TIP_HEIGHT = 40;
-
 type SwapRouteProps = CompositeScreenProps<
   NativeStackScreenProps<TransactionNavigatorParamList, 'Swap'>,
   NativeStackScreenProps<RootStackParamsList>
@@ -985,15 +980,6 @@ const Swap = ({
 
   const showRiskTips =
     isSlippageLow || isSlippageHigh || showLoss || miniSignGasFeeTooHigh;
-  const showDirectSignRiskTips = showRiskTips && !swapBtnDisabled;
-  const footerMinHeight =
-    FOOTER_BUTTON_HEIGHT +
-    FOOTER_PADDING_TOP +
-    FOOTER_PADDING_BOTTOM +
-    safeOffBottom +
-    (canShowDirectSubmit && showDirectSignRiskTips
-      ? FOOTER_RISK_TIP_HEIGHT
-      : 0);
   const shouldPauseMiniSignerEffects =
     useMiniSignerEffectPause(miniSignLoading);
 
@@ -1163,9 +1149,18 @@ const Swap = ({
           <AccountSwitcherModal forScene="MakeTransactionAbout" inScreen />
         )}
         <KeyboardAwareScrollView
-          style={styles.container}
+          style={[
+            styles.container,
+
+            {
+              marginBottom:
+                112 +
+                (isAndroid ? 20 + safeOffBottom : 0) +
+                (showRiskTips ? 26 : 0),
+            },
+          ]}
           ref={keyboardAwareRef}
-          contentContainerStyle={styles.scrollContent}
+          // contentContainerStyle={styles.container}
           enableOnAndroid
           extraHeight={200}
           keyboardOpeningTime={0}>
@@ -1401,10 +1396,7 @@ const Swap = ({
         <View
           style={[
             styles.buttonContainer,
-            {
-              minHeight: footerMinHeight,
-              paddingBottom: FOOTER_PADDING_BOTTOM + safeOffBottom,
-            },
+            isAndroid && { paddingBottom: safeOffBottom },
           ]}>
           <Tip
             content={
@@ -1445,7 +1437,7 @@ const Swap = ({
                   }}
                   account={currentAccount}
                   showHardWalletProcess
-                  showRiskTips={showDirectSignRiskTips}
+                  showRiskTips={showRiskTips && !swapBtnDisabled}
                 />
               ) : (
                 <Button
@@ -1556,9 +1548,6 @@ Swap.ForMultipleAddress = ForMultipleAddress;
 const getStyle = createGetStyles2024(({ colors2024 }) => ({
   container: {
     flex: 1,
-  },
-  scrollContent: {
-    flexGrow: 1,
   },
   content: {
     minHeight: 300,
@@ -1701,11 +1690,13 @@ const getStyle = createGetStyles2024(({ colors2024 }) => ({
   },
 
   buttonContainer: {
-    flexShrink: 0,
+    position: 'absolute',
+    left: 0,
+    bottom: 0,
     paddingHorizontal: 24,
-    paddingTop: FOOTER_PADDING_TOP,
     backgroundColor: colors2024['neutral-bg-1'],
     width: '100%',
+    marginBottom: 56,
   },
   approveContainer: {
     flexDirection: 'row',

--- a/apps/mobile/src/store/balance.ts
+++ b/apps/mobile/src/store/balance.ts
@@ -965,7 +965,6 @@ export type AccountsBalanceState = {
   balance: Record<string, BalanceAccountType>;
   selectedAddresses: string[];
   hasResolvedSelection: boolean;
-  hasResolvedMatteredAccountLength: boolean;
   matteredAccountLength: number;
   totalBalance: number;
   hasAnyBalanceValue: boolean;
@@ -1014,7 +1013,6 @@ export const balanceAccountsStore = zCreate(
     balance: {},
     selectedAddresses: getCachedHomeTop10Addresses(),
     hasResolvedSelection: false,
-    hasResolvedMatteredAccountLength: false,
     matteredAccountLength: 0,
     totalBalance: 0,
     hasAnyBalanceValue: false,
@@ -1256,7 +1254,6 @@ export async function applyAccountBalanceSelectionSnapshot(
       balance: nextBalance,
       selectedAddresses,
       hasResolvedSelection: true,
-      hasResolvedMatteredAccountLength: true,
       matteredAccountLength,
       ...buildSelectedBalanceDerivedState(selectedAddresses, nextBalance),
     }),

--- a/apps/mobile/src/store/balance.ts
+++ b/apps/mobile/src/store/balance.ts
@@ -965,6 +965,7 @@ export type AccountsBalanceState = {
   balance: Record<string, BalanceAccountType>;
   selectedAddresses: string[];
   hasResolvedSelection: boolean;
+  hasResolvedMatteredAccountLength: boolean;
   matteredAccountLength: number;
   totalBalance: number;
   hasAnyBalanceValue: boolean;
@@ -1013,6 +1014,7 @@ export const balanceAccountsStore = zCreate(
     balance: {},
     selectedAddresses: getCachedHomeTop10Addresses(),
     hasResolvedSelection: false,
+    hasResolvedMatteredAccountLength: false,
     matteredAccountLength: 0,
     totalBalance: 0,
     hasAnyBalanceValue: false,
@@ -1254,6 +1256,7 @@ export async function applyAccountBalanceSelectionSnapshot(
       balance: nextBalance,
       selectedAddresses,
       hasResolvedSelection: true,
+      hasResolvedMatteredAccountLength: true,
       matteredAccountLength,
       ...buildSelectedBalanceDerivedState(selectedAddresses, nextBalance),
     }),

--- a/apps/mobile/src/store/balanceAccountSelection.ts
+++ b/apps/mobile/src/store/balanceAccountSelection.ts
@@ -1,8 +1,13 @@
 import { unionBy } from 'lodash';
 
-import { filterOutTop10Accounts, getAccountList } from '@/core/apis/account';
+import {
+  filterMyAccounts,
+  filterOutTop10Accounts,
+  getAccountList,
+  sortAccountList,
+} from '@/core/apis/account';
 import { keyringService } from '@/core/services';
-import type { Account } from '@/types/account';
+import type { Account, IPinAddress } from '@/types/account';
 import accountStore from './account';
 import {
   type AccountBalanceSelectionSnapshot,
@@ -11,9 +16,7 @@ import {
   startProcessAddressBalanceEvents,
 } from './balance';
 
-async function pickSelectedAccountsFromSortedAccounts(
-  sortedAccounts: Account[],
-) {
+function pickSelectedAccountsFromSortedAccounts(sortedAccounts: Account[]) {
   const { top10Accounts, top10Addresses } = filterOutTop10Accounts(
     sortedAccounts,
     {
@@ -31,15 +34,32 @@ async function pickSelectedAccountsFromSortedAccounts(
 
 async function getMatteredAccountsSnapshot(): Promise<AccountBalanceSelectionSnapshot> {
   const { sortedAccounts } = await getAccountList({ filter: 'onlyMine' });
+  return buildMatteredAccountsSnapshotFromSortedAccounts(sortedAccounts);
+}
+
+function buildMatteredAccountsSnapshotFromSortedAccounts(
+  sortedAccounts: Account[],
+): AccountBalanceSelectionSnapshot {
   const matteredAccountLength = sortedAccounts.length;
   const { selectedAccounts, selectedAddresses } =
-    await pickSelectedAccountsFromSortedAccounts(sortedAccounts);
+    pickSelectedAccountsFromSortedAccounts(sortedAccounts);
 
   return {
     selectedAccounts,
     selectedAddresses,
     matteredAccountLength,
   };
+}
+
+function buildMatteredAccountsSnapshotFromStoreAccounts(
+  accounts: Account[],
+  pinnedAddresses: IPinAddress[],
+) {
+  const sortedAccounts = sortAccountList(filterMyAccounts(accounts), {
+    highlightedAddresses: pinnedAddresses,
+  });
+
+  return buildMatteredAccountsSnapshotFromSortedAccounts(sortedAccounts);
 }
 
 setAccountBalanceSelectionSnapshotGetter(getMatteredAccountsSnapshot);
@@ -54,8 +74,18 @@ async function initAccountBalanceSelectionLifecycle() {
   console.time('initAccountBalanceSelectionLifecycle');
 
   try {
-    const syncSelectionFromAccounts = async () => {
-      const snapshot = await getMatteredAccountsSnapshot();
+    const syncSelectionFromAccounts = async (
+      accountState = accountStore.getState(),
+    ) => {
+      const canUseStoreSnapshot =
+        accountState.hasFetchedAccounts || accountState.accounts.length > 0;
+      const snapshot = canUseStoreSnapshot
+        ? buildMatteredAccountsSnapshotFromStoreAccounts(
+            accountState.accounts,
+            accountState.pinnedAddresses,
+          )
+        : await getMatteredAccountsSnapshot();
+
       await applyAccountBalanceSelectionSnapshot(snapshot, {
         hydrate: true,
         source: 'accounts_changed',
@@ -89,7 +119,7 @@ async function initAccountBalanceSelectionLifecycle() {
 
         accountBalanceSelectionLifecycleStateRef.prevSelectionSignature =
           nextSignature;
-        void syncSelectionFromAccounts();
+        void syncSelectionFromAccounts(state);
       });
     }
 


### PR DESCRIPTION
## Summary
- Revert #1641 home 24h toggle change from the publish branch
- Revert #1720 transaction bottom action layout change from the publish branch
- Keep wallet count in a pending skeleton state until the resolved count is available, avoiding a transient 0 on the home card

## Checks
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- DISABLE_APP_TYPE_CHECK=true corepack yarn workspace rabby-mobile typecheck