### PR TITLE
chore(mobile): reset default keychain to v9

### DIFF
--- a/apps/mobile/src/hooks/appSettings.ts
+++ b/apps/mobile/src/hooks/appSettings.ts
@@ -26,6 +26,9 @@ export const CURRENT_KEYCHAIN_VERSION_VALUES = ['8.2.0-fork', '9.0.0'] as const;
 export type CurrentKeychainVersion =
   (typeof CURRENT_KEYCHAIN_VERSION_VALUES)[number];
 
+export const DEBUG_CURRENT_KEYCHAIN_VERSION_FIELD =
+  'debugCurrentKeychainVersion20260518' as const;
+
 const DEFAULT_CURRENT_KEYCHAIN_VERSION: CurrentKeychainVersion = '9.0.0';
 const DEFAULT_DEBUG_KEYCHAIN_STORAGE: KeychainStorageType =
   DEFAULT_KEYCHAIN_STORAGE_TYPE;
@@ -70,7 +73,7 @@ type ScreenshotSettings = {
   blockSubmitIfFormChangedOnAuth: boolean;
   toastOpenApiHttpErrorStatus: boolean;
   debugSwapHistorySkipLocalLookup: boolean;
-  debugCurrentKeychainVersion: CurrentKeychainVersion;
+  [DEBUG_CURRENT_KEYCHAIN_VERSION_FIELD]: CurrentKeychainVersion;
   debugKeychainStorageByVersion: DebugKeychainStorageByVersion;
 };
 const experimentalSettingsStore = zustandByMMKV<ScreenshotSettings>(
@@ -89,7 +92,7 @@ const experimentalSettingsStore = zustandByMMKV<ScreenshotSettings>(
     blockSubmitIfFormChangedOnAuth: false,
     toastOpenApiHttpErrorStatus: false,
     debugSwapHistorySkipLocalLookup: false,
-    debugCurrentKeychainVersion: DEFAULT_CURRENT_KEYCHAIN_VERSION,
+    [DEBUG_CURRENT_KEYCHAIN_VERSION_FIELD]: DEFAULT_CURRENT_KEYCHAIN_VERSION,
     debugKeychainStorageByVersion: makeDefaultDebugKeychainStorageByVersion(),
   },
 );
@@ -130,7 +133,7 @@ export function getCurrentKeychainVersion(): CurrentKeychainVersion {
   }
 
   return coerceCurrentKeychainVersion(
-    experimentalSettingsStore.getState().debugCurrentKeychainVersion,
+    experimentalSettingsStore.getState()[DEBUG_CURRENT_KEYCHAIN_VERSION_FIELD],
   );
 }
 
@@ -143,7 +146,7 @@ export function setCurrentKeychainVersion(version: CurrentKeychainVersion) {
 
   setExpSettingData(prev => ({
     ...prev,
-    debugCurrentKeychainVersion: nextVersion,
+    [DEBUG_CURRENT_KEYCHAIN_VERSION_FIELD]: nextVersion,
   }));
 
   return nextVersion;
@@ -571,7 +574,7 @@ export function useDebugSwapHistorySkipLocalLookup() {
 
 export function useCurrentKeychainVersion() {
   const debugCurrentKeychainVersion = experimentalSettingsStore(
-    s => s.debugCurrentKeychainVersion,
+    s => s[DEBUG_CURRENT_KEYCHAIN_VERSION_FIELD],
   );
 
   const setDebugCurrentKeychainVersion = useCallback(
@@ -589,6 +592,7 @@ export function useCurrentKeychainVersion() {
     canSwitchCurrentKeychainVersion: isNonPublicProductionEnv,
     setCurrentKeychainVersion: setDebugCurrentKeychainVersion,
     currentKeychainVersionOptions: CURRENT_KEYCHAIN_VERSION_VALUES,
+    debugCurrentKeychainVersionField: DEBUG_CURRENT_KEYCHAIN_VERSION_FIELD,
   };
 }
 

--- a/apps/mobile/src/screens/Testkits/DevDataKeychain.tsx
+++ b/apps/mobile/src/screens/Testkits/DevDataKeychain.tsx
@@ -255,6 +255,7 @@ type KeychainDebugExportPayload = {
   current: {
     effectiveVersion: CurrentKeychainVersion;
     configuredVersion: CurrentKeychainVersion;
+    configuredVersionField: string;
     canSwitchCurrentKeychainVersion: boolean;
     sourceLabel: string;
     defaultAndroidAuthPromptPolicy: AndroidAuthPromptPolicy;
@@ -1191,6 +1192,7 @@ export default function DevDataKeychain(): JSX.Element {
   const {
     currentKeychainVersion,
     debugCurrentKeychainVersion,
+    debugCurrentKeychainVersionField,
     canSwitchCurrentKeychainVersion,
     setCurrentKeychainVersion,
   } = useCurrentKeychainVersion();
@@ -2103,6 +2105,7 @@ export default function DevDataKeychain(): JSX.Element {
       current: {
         effectiveVersion: currentKeychainVersion,
         configuredVersion: debugCurrentKeychainVersion,
+        configuredVersionField: debugCurrentKeychainVersionField,
         canSwitchCurrentKeychainVersion,
         sourceLabel: apisKeychain.getCurrentKeychainSourceLabel(),
         defaultAndroidAuthPromptPolicy:
@@ -2186,6 +2189,7 @@ export default function DevDataKeychain(): JSX.Element {
       currentKeychainVersion,
       debugKeychainStorageByVersion,
       debugCurrentKeychainVersion,
+      debugCurrentKeychainVersionField,
       effectiveStorageByVersion,
       includeSecretFieldsInExport,
       rabbitCode,
@@ -3140,6 +3144,11 @@ export default function DevDataKeychain(): JSX.Element {
             />
           </View>
           <StatusRow label="Effective" value={currentKeychainVersion} />
+          <StatusRow
+            label="Debug Field"
+            value={debugCurrentKeychainVersionField}
+            selectable
+          />
           <StatusRow
             label="Source"
             value={apisKeychain.getCurrentKeychainSourceLabel()}


### PR DESCRIPTION
## Summary
- reset the non-public keychain debug setting field with a date suffix
- default the current keychain version to 9.0.0 for next package installs
- show the persisted field name on the keychain dev screen

## Validation
- corepack yarn workspace rabby-mobile typecheck
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check