### PR TITLE
perf: lighten defi and nft list rows

### DIFF
--- a/apps/mobile/src/screens/Address/components/MultiAssets/NFTList.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/NFTList.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, ViewStyle } from 'react-native';
 
 import {
   ASSETS_ITEM_HEIGHT_NEW,
@@ -18,12 +18,12 @@ import {
   NftRow,
   TokenRowSectionHeader,
 } from '@/screens/Home/components/AssetRenderItems';
-import { ActionItem, DisplayNftItem } from '@/screens/Home/types';
+import { DisplayNftItem } from '@/screens/Home/types';
 import { createGetStyles2024 } from '@/utils/styles';
 import { ItemLoader } from '@/screens/Search/components/Skeleton';
 import { EmptyAssets } from '@/screens/Home/components/AssetRenderItems/EmptyAssets';
 import { useTriggerTagAssets } from '@/screens/Home/hooks/refresh';
-import { GestureDetector, RefreshControl } from 'react-native-gesture-handler';
+import { GestureDetector } from 'react-native-gesture-handler';
 import {
   pulldownRefreshSizes,
   RefreshPlaceholderIOS,
@@ -32,11 +32,7 @@ import {
   usePulldownRefreshStyles,
 } from '@/components/customized/ScrollViewLike/RefreshPlaceholderIOS';
 import { RNGHRefreshControl } from '@/components/customized/reexports';
-import { getItemId } from '@/screens/Home/utils/listRenderId';
-import {
-  NftItemWithCollection,
-  varyNftListByFold,
-} from '@/screens/Home/hooks/nft';
+import type { NftItemWithCollection } from '@/screens/Home/hooks/nft';
 import { useCurrentTabScrollY } from 'react-native-collapsible-tab-view';
 import { useFocusedTab } from 'react-native-collapsible-tab-view';
 import { TabsFlatList } from '@/components/customized/react-native-collapsible-tab-view/FlatList';
@@ -54,7 +50,17 @@ import {
   useIsFocusedCurrentTab,
 } from './hooks/share';
 import { isTabsSwiping, useAccountInfo } from './hooks';
-import nftListStore, { combinedNfts, useOnNftRefresh } from '@/store/nfts';
+import type { KeyringAccountWithAlias } from '@/hooks/account';
+import nftListStore, {
+  getMultiNftsCacheKey,
+  getNftAssetsIndexRowKey,
+  NftAssetsIndexResult,
+  NftAssetsIndexRow,
+  useNftCollection,
+  useNftEntity,
+  useNftListComputedStore,
+  useOnNftRefresh,
+} from '@/store/nfts';
 import { useSelectedChainItem } from '@/screens/Home/useChainInfo';
 import {
   HOME_TOP_HEADER_SIZES,
@@ -62,6 +68,7 @@ import {
 } from '@/constant/home';
 import { IS_ANDROID } from '@/core/native/utils';
 import { useAppForeground } from '@/hooks/useAppForeground';
+import { useShallow } from 'zustand/react/shallow';
 
 export const MemoizedNFTItemLoader = React.memo((props: RNViewProps) => {
   const { styles } = useTheme2024({ getStyle: getStyles });
@@ -71,6 +78,64 @@ export const MemoizedNFTItemLoader = React.memo((props: RNViewProps) => {
     </View>
   );
 });
+
+const emptyNftIndexResult: NftAssetsIndexResult = {
+  unFoldRows: [],
+  foldRows: [],
+};
+
+type NFTListItem =
+  | {
+      type: 'unfold_nft' | 'fold_nft';
+      row: NftAssetsIndexRow;
+    }
+  | {
+      type: 'toggle_nft_fold';
+    }
+  | {
+      type: 'empty-nft';
+      data: string;
+    }
+  | {
+      type: 'loading-skeleton';
+      data: string;
+    };
+
+const NftResourceRow = React.memo(
+  ({
+    row,
+    style,
+    getAccountByAddress,
+    onPress,
+  }: {
+    row: NftAssetsIndexRow;
+    style?: ViewStyle;
+    getAccountByAddress(address: string): KeyringAccountWithAlias | undefined;
+    onPress(item: NftItemWithCollection): void;
+  }) => {
+    const nft = useNftEntity(row.type === 'nft' ? row.nftId : undefined);
+    const collection = useNftCollection(
+      row.type === 'collection' ? row.collectionId : undefined,
+    );
+    const item = row.type === 'collection' ? collection : nft;
+
+    if (!item) {
+      return <MemoizedNFTItemLoader />;
+    }
+
+    return (
+      <NftRow
+        style={style}
+        logoSize={40}
+        chainLogoSize={16}
+        disableMenu
+        item={item}
+        account={getAccountByAddress(item.address || '')}
+        onPress={() => onPress(item)}
+      />
+    );
+  },
+);
 
 const NFTListInner = () => {
   const { t } = useTranslation();
@@ -93,57 +158,58 @@ const NFTListInner = () => {
   });
 
   const isLoading = nftListStore(s => s.isLoading);
-  const nftsMap = nftListStore(s => s.nftsMap);
   const batchGetNFTList = nftListStore(s => s.batchGetNFTList);
-
-  const _rawNftList = useMemo(
-    () => combinedNfts(nftsMap, myTop10Addresses),
-    [nftsMap, myTop10Addresses],
+  const registerMultiNfts = useNftListComputedStore(
+    state => state.registerMultiNfts,
   );
 
-  const nftList = useMemo(() => {
-    return _rawNftList?.filter(item =>
-      chain && item?.chain ? item.chain === chain : true,
-    );
-  }, [_rawNftList, chain]);
+  const multiNftsKey = useMemo(() => {
+    return getMultiNftsCacheKey(myTop10Addresses, chain);
+  }, [chain, myTop10Addresses]);
 
-  const { foldNftList, unFoldNftList } = useMemo(() => {
-    const result = varyNftListByFold<ActionItem>(
-      nftList,
-      (collection, item) => ({
-        type: item._isFold ? 'fold_nft' : 'unfold_nft',
-        data: collection,
-      }),
-    );
+  useEffect(() => {
+    registerMultiNfts(myTop10Addresses, chain);
+  }, [chain, myTop10Addresses, registerMultiNfts]);
 
-    return {
-      foldNftList: result.foldList,
-      unFoldNftList: result.unFoldList,
-    };
-  }, [nftList]);
+  const { unFoldRows, foldRows } = useNftListComputedStore(
+    useShallow(
+      state => state.multiNftsIndexCache[multiNftsKey] || emptyNftIndexResult,
+    ),
+  );
 
   const dataList = useMemo(() => {
     const itemData: Array<{
       show: boolean;
-      data: ActionItem[];
+      data: NFTListItem[];
     }> = [
       {
         show: true,
-        data: [...unFoldNftList],
+        data: unFoldRows.map(row => ({
+          type: 'unfold_nft',
+          row,
+        })),
       },
       {
-        show: !!foldNftList.length,
-        data: [{ type: 'toggle_nft_fold' }, ...(foldNft ? [] : foldNftList)],
+        show: !!foldRows.length,
+        data: [
+          { type: 'toggle_nft_fold' },
+          ...(foldNft
+            ? []
+            : foldRows.map(row => ({
+                type: 'fold_nft' as const,
+                row,
+              }))),
+        ],
       },
       {
-        show: !!isLoading && !nftList.length,
+        show: !!isLoading && !unFoldRows.length && !foldRows.length,
         data: Array.from({ length: 5 }, (_, index) => ({
           type: 'loading-skeleton',
           data: 'index-nft' + index.toString(),
         })),
       },
       {
-        show: !isLoading && nftList?.length === 0,
+        show: !isLoading && unFoldRows.length === 0 && foldRows.length === 0,
         data: [
           {
             type: 'empty-nft',
@@ -158,11 +224,16 @@ const NFTListInner = () => {
       .filter(item => item.show)
       .map(item => item.data)
       .flat();
-  }, [foldNft, foldNftList, isLoading, nftList.length, t, unFoldNftList]);
+  }, [foldNft, foldRows, isLoading, t, unFoldRows]);
 
   const hasNotAssets = useMemo(() => {
-    return nftList.length === 0 && !isLoading && isFocused;
-  }, [nftList.length, isLoading, isFocused]);
+    return (
+      unFoldRows.length === 0 &&
+      foldRows.length === 0 &&
+      !isLoading &&
+      isFocused
+    );
+  }, [foldRows.length, isLoading, isFocused, unFoldRows.length]);
 
   const handlePressNft = useCallback(
     (item: NftItemWithCollection) => {
@@ -211,30 +282,27 @@ const NFTListInner = () => {
 
   const renderItem = useCallback(
     ({ item }) => {
-      const { type, data } = item;
+      const { type } = item as NFTListItem;
       switch (type) {
         case 'unfold_nft':
         case 'fold_nft':
           return (
             <View style={styles.rowWrap}>
-              <NftRow
+              <NftResourceRow
                 style={StyleSheet.flatten([
                   styles.renderItemWrapper,
                   !isLight && styles.bg2,
                 ])}
-                logoSize={40}
-                chainLogoSize={16}
-                disableMenu
-                item={data}
-                account={getAccountByAddress(data.address)}
-                onPress={() => handlePressNft(data)}
+                row={item.row}
+                getAccountByAddress={getAccountByAddress}
+                onPress={handlePressNft}
               />
             </View>
           );
         case 'toggle_nft_fold':
           return (
             <TokenRowSectionHeader
-              str={'' + foldNftList.length}
+              str={'' + foldRows.length}
               fold={foldNft}
               style={styles.sectionHeader}
               buttonStyle={StyleSheet.flatten([
@@ -246,7 +314,11 @@ const NFTListInner = () => {
           );
         case 'empty-nft':
           return (
-            <EmptyAssets style={styles.emptyAssets} desc={data} type={type} />
+            <EmptyAssets
+              style={styles.emptyAssets}
+              desc={item.data}
+              type={type}
+            />
           );
         case 'loading-skeleton':
           return <MemoizedNFTItemLoader style={styles.loadingItem} />;
@@ -256,13 +328,23 @@ const NFTListInner = () => {
     },
     [
       foldNft,
-      foldNftList.length,
+      foldRows.length,
       getAccountByAddress,
       handlePressNft,
       isLight,
       styles,
     ],
   );
+
+  const keyExtractor = useCallback((item: NFTListItem) => {
+    if (item.type === 'unfold_nft' || item.type === 'fold_nft') {
+      return `${item.type}-${getNftAssetsIndexRowKey(item.row)}`;
+    }
+    if (item.type === 'loading-skeleton') {
+      return `loading-${item.data}`;
+    }
+    return `${item.type}-${'data' in item ? item.data || '' : ''}`;
+  }, []);
 
   const onRefresh = useCallback(async () => {
     try {
@@ -324,7 +406,7 @@ const NFTListInner = () => {
   return (
     <GestureDetector gesture={panGestureRef.current}>
       <TabsFlatList
-        keyExtractor={getItemId}
+        keyExtractor={keyExtractor}
         data={
           hasNotAssets
             ? [

--- a/apps/mobile/src/screens/Address/components/MultiAssets/ProtocolList.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/ProtocolList.tsx
@@ -1,31 +1,27 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Tabs, useCurrentTabScrollY } from 'react-native-collapsible-tab-view';
+import { useCurrentTabScrollY } from 'react-native-collapsible-tab-view';
 
 import { useTheme2024 } from '@/hooks/theme';
 import {
   FullDefiRenderItem,
   TokenRowSectionHeader,
 } from '@/screens/Home/components/AssetRenderItems';
-import { ActionItem } from '@/screens/Home/types';
 import { createGetStyles2024 } from '@/utils/styles';
 import { EmptyAssets } from '@/screens/Home/components/AssetRenderItems/EmptyAssets';
 import { DefiItemLoader } from '@/screens/Home/components/Skeleton';
-import { GestureDetector, RefreshControl } from 'react-native-gesture-handler';
-import { getItemId } from '@/screens/Home/utils/listRenderId';
+import { GestureDetector } from 'react-native-gesture-handler';
 import { KeyringAccountWithAlias } from '@/hooks/account';
 import useLoadMoreData from './hooks/useLoadMoreData';
 import { HomeTabName as TabName } from '@/hooks/navigation';
-import {
-  ListRenderFooter as ListRenderFooterComponent,
-  ListRenderSeparator,
-} from './RenderRow/Common';
+import { ListRenderSeparator } from './RenderRow/Common';
 import { useFindAccountByAddress, useIsFocusedCurrentTab } from './hooks/share';
-import { getAllDefiCount } from '@/screens/Home/utils/converAssets';
 import { useSelectedChainItem } from '@/screens/Home/useChainInfo';
 import useProtocols, {
   getMultiProtocolsCacheKey,
-  ICacheProtocolItem,
+  ProtocolAssetsIndexResult,
+  ProtocolEntityId,
+  useProtocolEntity,
   useProtocolListComputedStore,
 } from '@/store/protocols';
 import { useShallow } from 'zustand/react/shallow';
@@ -47,9 +43,10 @@ import {
 import { RNGHRefreshControl } from '@/components/customized/reexports';
 import { useAppForeground } from '@/hooks/useAppForeground';
 
-const emptyCacheProtocolItem: ICacheProtocolItem = {
-  fold: [],
-  unFold: [],
+const emptyProtocolIndexResult: ProtocolAssetsIndexResult = {
+  foldIds: [],
+  unFoldIds: [],
+  foldDeFiValue: '',
 };
 
 const MemoizedFullDefiRenderItem = React.memo(FullDefiRenderItem);
@@ -58,6 +55,63 @@ const MemoizedEmptyAssets = React.memo(EmptyAssets);
 export const MemoizedDefiItemLoader = React.memo(DefiItemLoader);
 
 const { batchGetProtocols } = useProtocols.getState();
+
+type ProtocolListItem =
+  | {
+      type: 'unfold_defi' | 'fold_defi';
+      protocolId: ProtocolEntityId;
+    }
+  | {
+      type: 'toggle_defi_fold';
+      data: string;
+    }
+  | {
+      type: 'empty-defi';
+      data: string;
+    }
+  | {
+      type: 'loading-defi-skeleton';
+      data: string;
+    };
+
+const ProtocolResourceRow = React.memo(
+  ({
+    protocolId,
+    showAccount,
+    style,
+    disableAction,
+    defaultExpand,
+    getAccountByAddress,
+  }: {
+    protocolId: ProtocolEntityId;
+    showAccount: boolean;
+    style?: React.ComponentProps<typeof FullDefiRenderItem>['style'];
+    disableAction: boolean;
+    defaultExpand: boolean;
+    getAccountByAddress(address?: string): KeyringAccountWithAlias | undefined;
+  }) => {
+    const data = useProtocolEntity(protocolId);
+
+    if (!data) {
+      return <MemoizedDefiItemLoader />;
+    }
+
+    return (
+      <MemoizedFullDefiRenderItem
+        data={data}
+        showAccount={showAccount}
+        style={style}
+        disableAction={disableAction}
+        defaultExpand={defaultExpand}
+        account={
+          getAccountByAddress(
+            data.owner_addr,
+          ) as unknown as KeyringAccountWithAlias
+        }
+      />
+    );
+  },
+);
 
 export const ProtocolList = () => {
   const { t } = useTranslation();
@@ -83,50 +137,46 @@ export const ProtocolList = () => {
   const multiProtocols = useProtocolListComputedStore(
     useShallow(
       state =>
-        state.multiProtocolsCache[multiProtocolsKey] || emptyCacheProtocolItem,
+        state.multiProtocolsIndexCache[multiProtocolsKey] ||
+        emptyProtocolIndexResult,
     ),
   );
 
   const isLoading = useProtocols(state => state.isLoading);
 
-  const {
-    data: portfoliosData,
-    loadMore: loadMorePortfolios,
-    hasMore: hasMorePortfolios,
-  } = useLoadMoreData(multiProtocols.unFold);
+  const { data: unFoldProtocolIds, loadMore: loadMorePortfolios } =
+    useLoadMoreData(multiProtocols.unFoldIds);
 
   const shouldDefaultExpand = useMemo(
-    () => multiProtocols.unFold.length <= 5,
-    [multiProtocols.unFold.length],
+    () => multiProtocols.unFoldIds.length <= 5,
+    [multiProtocols.unFoldIds.length],
   );
 
   const portfolioListData = useMemo(() => {
-    const foldDeFiList: ActionItem[] = multiProtocols.fold.map(item => ({
-      type: 'fold_defi',
-      data: item,
-    }));
-
-    const foldDeFiValue = getAllDefiCount(multiProtocols.fold);
+    const foldDeFiList: ProtocolListItem[] = multiProtocols.foldIds.map(
+      protocolId => ({
+        type: 'fold_defi',
+        protocolId,
+      }),
+    );
 
     const itemData: Array<{
       show: boolean;
-      data: ActionItem[];
+      data: ProtocolListItem[];
     }> = [
       {
         show: true,
-        data: [
-          ...portfoliosData.map(item => ({
-            type: 'unfold_defi' as const,
-            data: item,
-          })),
-        ],
+        data: unFoldProtocolIds.map(protocolId => ({
+          type: 'unfold_defi',
+          protocolId,
+        })),
       },
       {
         show: !!foldDeFiList.length,
         data: [
           {
             type: 'toggle_defi_fold',
-            data: foldDeFiValue,
+            data: multiProtocols.foldDeFiValue,
           },
           ...(foldDefi ? [] : foldDeFiList),
         ],
@@ -134,8 +184,8 @@ export const ProtocolList = () => {
       {
         show:
           !!isLoading &&
-          !multiProtocols.unFold.length &&
-          !multiProtocols.fold.length,
+          !multiProtocols.unFoldIds.length &&
+          !multiProtocols.foldIds.length,
         data: Array.from({ length: 2 }, (_, index) => ({
           type: 'loading-defi-skeleton',
           data: index.toString(),
@@ -144,8 +194,8 @@ export const ProtocolList = () => {
       {
         show:
           !isLoading &&
-          multiProtocols.unFold.length === 0 &&
-          multiProtocols.fold.length === 0,
+          multiProtocols.unFoldIds.length === 0 &&
+          multiProtocols.foldIds.length === 0,
         data: [
           {
             type: 'empty-defi',
@@ -164,21 +214,22 @@ export const ProtocolList = () => {
     foldDefi,
     isLoading,
     t,
-    multiProtocols.fold,
-    multiProtocols.unFold.length,
-    portfoliosData,
+    multiProtocols.foldDeFiValue,
+    multiProtocols.foldIds,
+    multiProtocols.unFoldIds.length,
+    unFoldProtocolIds,
   ]);
 
   const hasNotAssets = useMemo(() => {
     return (
-      multiProtocols.unFold.length === 0 &&
-      multiProtocols.fold.length === 0 &&
+      multiProtocols.unFoldIds.length === 0 &&
+      multiProtocols.foldIds.length === 0 &&
       !isLoading &&
       isFocused
     );
   }, [
-    multiProtocols.fold.length,
-    multiProtocols.unFold.length,
+    multiProtocols.foldIds.length,
+    multiProtocols.unFoldIds.length,
     isLoading,
     isFocused,
   ]);
@@ -206,29 +257,25 @@ export const ProtocolList = () => {
 
   const renderItem = useCallback(
     ({ item }) => {
-      const { type, data } = item as ActionItem;
+      const { type } = item as ProtocolListItem;
       switch (type) {
         case 'unfold_defi':
         case 'fold_defi':
           return (
-            <MemoizedFullDefiRenderItem
-              data={data}
+            <ProtocolResourceRow
+              protocolId={item.protocolId}
               showAccount
               style={styles.fullDefi}
               disableAction={isLoading}
               defaultExpand={type === 'fold_defi' ? false : shouldDefaultExpand}
-              account={
-                getAccountByAddress(
-                  data?.owner_addr,
-                ) as unknown as KeyringAccountWithAlias
-              }
+              getAccountByAddress={getAccountByAddress}
             />
           );
         case 'toggle_defi_fold':
           return (
             <TokenRowSectionHeader
               style={styles.tokenSectionHeader}
-              str={data}
+              str={item.data}
               fold={foldDefi}
               onPressFold={() => setFoldDefi(pre => !pre)}
             />
@@ -237,7 +284,7 @@ export const ProtocolList = () => {
           return (
             <MemoizedEmptyAssets
               style={styles.emptyAssets}
-              desc={data}
+              desc={item.data}
               type={type}
             />
           );
@@ -259,13 +306,12 @@ export const ProtocolList = () => {
     ],
   );
 
-  const ListRenderFooter = useCallback(() => {
-    return hasMorePortfolios ? (
-      <MemoizedDefiItemLoader style={[styles.loadingMore]} />
-    ) : (
-      <ListRenderFooterComponent />
-    );
-  }, [hasMorePortfolios, styles.loadingMore]);
+  const keyExtractor = useCallback((item: ProtocolListItem) => {
+    if (item.type === 'unfold_defi' || item.type === 'fold_defi') {
+      return `${item.type}-${item.protocolId}`;
+    }
+    return `${item.type}-${'data' in item ? item.data || '' : ''}`;
+  }, []);
 
   const onRefresh = useCallback(async () => {
     try {
@@ -319,7 +365,7 @@ export const ProtocolList = () => {
   return (
     <GestureDetector gesture={panGestureRef.current}>
       <TabsFlatList
-        keyExtractor={getItemId}
+        keyExtractor={keyExtractor}
         data={
           hasNotAssets
             ? [
@@ -348,7 +394,6 @@ export const ProtocolList = () => {
             />
           </>
         }
-        // ListFooterComponent={ListRenderFooter}
         showsVerticalScrollIndicator={false}
         showsHorizontalScrollIndicator={false}
         style={[

--- a/apps/mobile/src/screens/Address/components/MultiAssets/TokenList.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/TokenList.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ListRenderItem, View, Dimensions } from 'react-native';
+import { ListRenderItem, View, Dimensions, ViewStyle } from 'react-native';
 import { useCurrentTabScrollY } from 'react-native-collapsible-tab-view';
 import { useShallow } from 'zustand/shallow';
 
@@ -26,7 +26,13 @@ import { EmptyAssets } from '@/screens/Home/components/AssetRenderItems/EmptyAss
 import { HomeTabName as TabName } from '@/hooks/navigation';
 import useTokenList, {
   getMultiAssetsCacheKey,
+  getTokenAssetsIndexRowKey,
   ITokenItem,
+  TokenAssetsIndexRow,
+  TokenGroupResourceValue,
+  tokenEntityResourceStore,
+  useTokenEntity,
+  useTokenGroup,
   useTokenListComputedStore,
 } from '@/store/tokens';
 import { formatNetworth } from '@/utils/math';
@@ -61,10 +67,68 @@ export const MemoizedTokenItemLoader = React.memo((props: RNViewProps) => {
   );
 });
 
+const TokenResourceRow = React.memo(
+  ({
+    row,
+    tokenDisplayMode,
+    getAccountByAddress,
+    onTokenPress,
+    onGroupPress,
+    style,
+    hideChainLogo,
+  }: {
+    row: TokenAssetsIndexRow;
+    tokenDisplayMode: string;
+    getAccountByAddress(address?: string): KeyringAccountWithAlias | undefined;
+    onTokenPress(token: ITokenItem): void;
+    onGroupPress(group: TokenGroupResourceValue): void;
+    style?: ViewStyle;
+    hideChainLogo?: boolean;
+  }) => {
+    const token = useTokenEntity(
+      row.type === 'token' ? row.tokenId : undefined,
+    );
+    const group = useTokenGroup(row.type === 'group' ? row.groupId : undefined);
+    const data = row.type === 'group' ? group?.summary : token;
+    const account =
+      tokenDisplayMode === 'byAddress' && data
+        ? getAccountByAddress(data.owner_addr)
+        : undefined;
+
+    const handlePress = useCallback(() => {
+      if (!data) {
+        return;
+      }
+      if (row.type === 'group' && group) {
+        onGroupPress(group);
+        return;
+      }
+      onTokenPress(data);
+    }, [data, group, onGroupPress, onTokenPress, row]);
+
+    if (!data) {
+      return <MemoizedItemLoader />;
+    }
+
+    return (
+      <MemoizedTokenRow
+        data={data}
+        onTokenPress={handlePress}
+        logoSize={46}
+        style={style}
+        chainLogoSize={18}
+        hideChainLogo={hideChainLogo}
+        account={account}
+        scene="portfolio"
+      />
+    );
+  },
+);
+
 type TokenListItem =
   | {
       type: 'unfold_token' | 'fold_token';
-      data: ITokenItem;
+      row: TokenAssetsIndexRow;
       isLast?: boolean;
     }
   | {
@@ -106,9 +170,11 @@ export const TokenList = () => {
 
   const emptyResult = useMemo(
     () => ({
-      unFoldTokens: [] as ITokenItem[],
-      foldTokens: [] as ITokenItem[],
-      scamTokens: [] as ITokenItem[],
+      unFoldRows: [] as TokenAssetsIndexRow[],
+      foldRows: [] as TokenAssetsIndexRow[],
+      scamRows: [] as TokenAssetsIndexRow[],
+      scamTokenPreviewLogoUrls: [] as string[],
+      foldCoreUsdValue: 0,
     }),
     [],
   );
@@ -144,23 +210,23 @@ export const TokenList = () => {
   ]);
 
   const {
-    unFoldTokens: tokens,
-    foldTokens,
-    scamTokens,
+    unFoldRows: tokenRows,
+    foldRows,
+    scamRows,
+    scamTokenPreviewLogoUrls,
+    foldCoreUsdValue,
   } = useTokenListComputedStore(
-    useShallow(state => state.multiAssetsCache[multiAssetsKey] || emptyResult),
+    useShallow(
+      state => state.multiAssetsIndexCache[multiAssetsKey] || emptyResult,
+    ),
   );
 
   const isLoading = useTokenList(s => s.isLoading);
 
-  const foldTokenUsdValue = useMemo(() => {
-    const usdValue = foldTokens
-      .filter(item => item.is_core)
-      .reduce((total, item) => {
-        return total + item.usd_value;
-      }, 0);
-    return formatNetworth(usdValue);
-  }, [foldTokens]);
+  const foldTokenUsdValue = useMemo(
+    () => formatNetworth(foldCoreUsdValue),
+    [foldCoreUsdValue],
+  );
 
   useEffect(() => {
     batchGetTokenList(myTop10Addresses);
@@ -180,7 +246,7 @@ export const TokenList = () => {
   });
 
   const hasNoAssets =
-    tokens.length + foldTokens.length + scamTokens.length === 0 &&
+    tokenRows.length + foldRows.length + scamRows.length === 0 &&
     !isLoading &&
     isFocused;
 
@@ -204,13 +270,29 @@ export const TokenList = () => {
       if (isTabsSwiping.value) {
         return;
       }
-      if (tokenDisplayMode === 'byAddress') {
-        handleOpenTokenDetail(token, getAccountByAddress(token.owner_addr));
+
+      handleOpenTokenDetail(
+        token,
+        tokenDisplayMode === 'byAddress'
+          ? getAccountByAddress(token.owner_addr)
+          : undefined,
+      );
+    },
+    [getAccountByAddress, handleOpenTokenDetail, tokenDisplayMode],
+  );
+
+  const handleGroupPress = useCallback(
+    (group: TokenGroupResourceValue) => {
+      if (isTabsSwiping.value) {
         return;
       }
-      const groupItems = (token as { groupItems?: ITokenItem[] }).groupItems;
-      if (!groupItems?.length) {
-        handleOpenTokenDetail(token);
+
+      const groupItems = group.memberTokenIds
+        .map(tokenId => tokenEntityResourceStore.getValue(tokenId))
+        .filter((token): token is ITokenItem => !!token);
+
+      if (!groupItems.length) {
+        handleOpenTokenDetail(group.summary);
         return;
       }
       if (groupItems.length === 1) {
@@ -240,7 +322,7 @@ export const TokenList = () => {
         },
       });
     },
-    [colors2024, getAccountByAddress, handleOpenTokenDetail, tokenDisplayMode],
+    [colors2024, getAccountByAddress, handleOpenTokenDetail],
   );
 
   const handleOpenScamToken = useCallback(() => {
@@ -284,81 +366,80 @@ export const TokenList = () => {
       return items;
     }
 
-    tokens.forEach((token, index) => {
+    tokenRows.forEach((row, index) => {
       items.push({
         type: 'unfold_token',
-        data: token,
-        isLast: index === tokens.length - 1,
+        row,
+        isLast: index === tokenRows.length - 1,
       });
     });
 
     items.push({ type: 'toggle_token_fold' });
 
     if (!foldHideList) {
-      foldTokens.forEach(token => {
-        items.push({ type: 'fold_token', data: token });
+      foldRows.forEach(row => {
+        items.push({ type: 'fold_token', row });
       });
 
-      if (scamTokens.length > 0) {
+      if (scamRows.length > 0) {
         if (foldScam) {
           items.push({
             type: 'scam_header',
             data: {
-              total: scamTokens.length,
-              logoUrls: scamTokens.slice(0, 3).map(i => i.logo_url),
+              total: scamRows.length,
+              logoUrls: scamTokenPreviewLogoUrls,
             },
           });
         } else {
-          scamTokens.forEach(token => {
-            items.push({ type: 'fold_token', data: token });
+          scamRows.forEach(row => {
+            items.push({ type: 'fold_token', row });
           });
         }
       }
     }
 
     return items;
-  }, [foldTokens, scamTokens, tokens, foldHideList, foldScam, hasNoAssets, t]);
+  }, [
+    foldRows,
+    scamRows,
+    tokenRows,
+    foldHideList,
+    foldScam,
+    hasNoAssets,
+    scamTokenPreviewLogoUrls,
+    t,
+  ]);
 
   const renderItem = useCallback<ListRenderItem<TokenListItem>>(
     ({ item }) => {
       switch (item.type) {
         case 'unfold_token': {
-          const account =
-            tokenDisplayMode === 'byAddress'
-              ? getAccountByAddress(item.data.owner_addr)
-              : undefined;
           return (
             <View
               style={[styles.rowWrap, item.isLast ? styles.lastRowWrap : null]}>
-              <MemoizedTokenRow
-                data={item.data}
+              <TokenResourceRow
+                row={item.row}
+                tokenDisplayMode={tokenDisplayMode}
+                getAccountByAddress={getAccountByAddress}
                 onTokenPress={handleTokenPress}
-                logoSize={46}
+                onGroupPress={handleGroupPress}
                 style={styles.renderItemWrapper}
-                chainLogoSize={18}
                 hideChainLogo={tokenDisplayMode === 'bySymbol'}
-                account={account}
-                scene="portfolio"
               />
             </View>
           );
         }
         case 'fold_token': {
-          const foldAccount =
-            tokenDisplayMode === 'byAddress'
-              ? getAccountByAddress(item.data.owner_addr)
-              : undefined;
           return (
             <View style={styles.foldRowWrap}>
-              <MemoizedTokenRow
-                data={item.data}
+              <TokenResourceRow
+                row={item.row}
+                tokenDisplayMode={tokenDisplayMode}
+                getAccountByAddress={getAccountByAddress}
                 onTokenPress={handleTokenPress}
-                logoSize={46}
+                onGroupPress={handleGroupPress}
                 style={styles.renderItemWrapper}
-                chainLogoSize={18}
                 hideChainLogo={tokenDisplayMode === 'bySymbol'}
-                account={foldAccount}
-                scene="portfolio"
               />
             </View>
           );
@@ -402,6 +483,7 @@ export const TokenList = () => {
       foldHideList,
       foldTokenUsdValue,
       getAccountByAddress,
+      handleGroupPress,
       handleOpenScamToken,
       handleTokenPress,
       handleToggleTokenFold,
@@ -412,11 +494,7 @@ export const TokenList = () => {
 
   const keyExtractor = useCallback((item: TokenListItem) => {
     if (item.type === 'unfold_token' || item.type === 'fold_token') {
-      const groupKey = (item.data as { groupKey?: string }).groupKey;
-      if (groupKey) {
-        return `${item.type}-${groupKey}`;
-      }
-      return `${item.type}-${item.data.owner_addr}-${item.data.chain}-${item.data.id}`;
+      return `${item.type}-${getTokenAssetsIndexRowKey(item.row)}`;
     }
     if (item.type === 'scam_header') {
       return `scam-header-${item.data.total}`;

--- a/apps/mobile/src/screens/ConvertDust/hooks/useConvertDustTokens.ts
+++ b/apps/mobile/src/screens/ConvertDust/hooks/useConvertDustTokens.ts
@@ -5,6 +5,8 @@ import { openapi } from '@/core/request';
 import useTokenList, {
   getSingleAssetsCacheKey,
   ITokenItem,
+  TokenEntityId,
+  tokenEntityResourceStore,
   useTokenListComputedStore,
 } from '@/store/tokens';
 import type { DustFilter } from '../constant';
@@ -26,9 +28,9 @@ export function useConvertDustTokenList({
 
   const emptyResult = useMemo(
     () => ({
-      unFoldTokens: [] as ITokenItem[],
-      foldTokens: [] as ITokenItem[],
-      scamTokens: [] as ITokenItem[],
+      unFoldTokenIds: [] as TokenEntityId[],
+      foldTokenIds: [] as TokenEntityId[],
+      scamTokenIds: [] as TokenEntityId[],
       hasFoldTokens: false,
     }),
     [],
@@ -52,13 +54,20 @@ export function useConvertDustTokenList({
     registerSingleAssets(address, chainServerId, false);
   }, [address, chainServerId, registerSingleAssets]);
 
-  const { unFoldTokens, foldTokens, scamTokens } = useTokenListComputedStore(
-    useShallow(state =>
-      singleAssetsKey
-        ? state.singleAssetsCache[singleAssetsKey] || emptyResult
-        : emptyResult,
-    ),
-  );
+  const { unFoldTokenIds, foldTokenIds, scamTokenIds } =
+    useTokenListComputedStore(
+      useShallow(state =>
+        singleAssetsKey
+          ? state.singleAssetsIndexCache[singleAssetsKey] || emptyResult
+          : emptyResult,
+      ),
+    );
+
+  const tokens = useMemo(() => {
+    return [...unFoldTokenIds, ...foldTokenIds, ...scamTokenIds]
+      .map(tokenId => tokenEntityResourceStore.getValue(tokenId))
+      .filter((token): token is ITokenItem => !!token);
+  }, [foldTokenIds, scamTokenIds, unFoldTokenIds]);
 
   const isLoading = useTokenList(state => {
     if (!lowerAddress) {
@@ -74,10 +83,6 @@ export function useConvertDustTokenList({
     }
     getTokenList(address);
   }, [address, getTokenList]);
-
-  const tokens = useMemo(() => {
-    return [...unFoldTokens, ...foldTokens, ...scamTokens];
-  }, [unFoldTokens, foldTokens, scamTokens]);
 
   const threshold = selectedFilter.value;
 

--- a/apps/mobile/src/screens/Home/NFTList.tsx
+++ b/apps/mobile/src/screens/Home/NFTList.tsx
@@ -5,12 +5,12 @@ import React, {
   useEffect,
   useRef,
 } from 'react';
-import { ListRenderItem, StyleSheet, View } from 'react-native';
+import { ListRenderItem, StyleSheet, View, ViewStyle } from 'react-native';
 import { RefreshControl } from 'react-native-gesture-handler';
 
 import { navigateDeprecated } from '@/utils/navigation';
 import { createGetStyles2024 } from '@/utils/styles';
-import { ActionItem, DisplayNftItem } from './types';
+import { DisplayNftItem } from './types';
 import {
   ASSETS_ITEM_HEIGHT_NEW,
   ASSETS_SECTION_HEADER,
@@ -25,11 +25,7 @@ import {
   removeGlobalBottomSheetModal2024,
 } from '@/components2024/GlobalBottomSheetModal';
 import { MODAL_NAMES } from '@/components2024/GlobalBottomSheetModal/types';
-import {
-  varyNftListByFold,
-  NftItemWithCollection,
-  useQueryNft,
-} from './hooks/nft';
+import type { NftItemWithCollection } from './hooks/nft';
 import { EmptyAssets } from './components/AssetRenderItems/EmptyAssets';
 import { ItemLoader } from './components/Skeleton';
 import {
@@ -39,10 +35,23 @@ import {
 } from 'react-native-collapsible-tab-view';
 import { useAnimatedReaction } from 'react-native-reanimated';
 import { runOnJS } from 'react-native-reanimated';
-import { getItemId } from './utils/listRenderId';
 import { useSingleHomeAccount, useSingleHomeChain } from './hooks/singleHome';
-import { Text } from '@/components/Typography';
 import { useAppForeground } from '@/hooks/useAppForeground';
+import { debounce } from 'lodash';
+import { isSameAddress } from '@rabby-wallet/base-utils/dist/isomorphic/address';
+import { useAppOrmSyncEvents } from '@/databases/sync/_event';
+import { apisAddrChainStatics } from './useChainInfo';
+import nftListStore, {
+  getNftAssetsIndexRowKey,
+  getSingleNftsCacheKey,
+  NftAssetsIndexResult,
+  NftAssetsIndexRow,
+  useNftCollection,
+  useNftEntity,
+  useNftListComputedStore,
+} from '@/store/nfts';
+import { useShallow } from 'zustand/react/shallow';
+import { useSingleNftRefresh } from './hooks/refresh';
 
 interface Props {
   onForeground?: () => void;
@@ -51,6 +60,64 @@ interface Props {
 }
 const FOOTER_HEIGHT = 220;
 const SPACING_HEIGHT = 8;
+
+const emptyNftIndexResult: NftAssetsIndexResult = {
+  unFoldRows: [],
+  foldRows: [],
+};
+
+type NFTListItem =
+  | {
+      type: 'unfold_nft' | 'fold_nft';
+      row: NftAssetsIndexRow;
+    }
+  | {
+      type: 'toggle_nft_fold';
+    }
+  | {
+      type: 'empty-nft' | 'empty-assets';
+      data: string;
+    }
+  | {
+      type: 'loading-skeleton';
+      data: string;
+    };
+
+const NftResourceRow = React.memo(
+  ({
+    row,
+    style,
+    logoSize,
+    chainLogoSize,
+    onPress,
+  }: {
+    row: NftAssetsIndexRow;
+    style?: ViewStyle;
+    logoSize: number;
+    chainLogoSize: number;
+    onPress(item: NftItemWithCollection): void;
+  }) => {
+    const nft = useNftEntity(row.type === 'nft' ? row.nftId : undefined);
+    const collection = useNftCollection(
+      row.type === 'collection' ? row.collectionId : undefined,
+    );
+    const item = row.type === 'collection' ? collection : nft;
+
+    if (!item) {
+      return <ItemLoader />;
+    }
+
+    return (
+      <NftRow
+        style={style}
+        logoSize={logoSize}
+        chainLogoSize={chainLogoSize}
+        item={item}
+        onPress={() => onPress(item)}
+      />
+    );
+  },
+);
 
 const NFTListInner = ({
   onForeground,
@@ -72,11 +139,124 @@ const NFTListInner = ({
   const isFocused = focusedTab === 'nft';
 
   const userAddr = currentAccount?.address?.toLowerCase();
-  const {
-    list: _rawNftList,
-    reload: reloadNftList,
-    isLoading: loadingNft,
-  } = useQueryNft(userAddr, false);
+  const [loadingNft, setLoadingNft] = useState(true);
+  const getNFTListWithCache = nftListStore(s => s.getNFTListWithCache);
+  const batchLoadCacheNFT = nftListStore(s => s.batchLoadCacheNFT);
+  const refreshTagNftByStore = nftListStore(s => s.refreshTagNft);
+  const registerSingleNfts = useNftListComputedStore(
+    state => state.registerSingleNfts,
+  );
+
+  const singleNftsKey = useMemo(() => {
+    if (!userAddr) {
+      return null;
+    }
+    return getSingleNftsCacheKey(userAddr, selectedChain);
+  }, [selectedChain, userAddr]);
+
+  useEffect(() => {
+    if (!userAddr) {
+      return;
+    }
+    registerSingleNfts(userAddr, selectedChain);
+  }, [registerSingleNfts, selectedChain, userAddr]);
+
+  const { unFoldRows, foldRows } = useNftListComputedStore(
+    useShallow(state =>
+      singleNftsKey
+        ? state.singleNftsIndexCache[singleNftsKey] || emptyNftIndexResult
+        : emptyNftIndexResult,
+    ),
+  );
+
+  const loadingNftRef = useRef(loadingNft);
+  useEffect(() => {
+    loadingNftRef.current = loadingNft;
+  }, [loadingNft]);
+
+  const reloadNftList = useCallback(
+    async (force?: boolean) => {
+      if (!userAddr) {
+        setLoadingNft(false);
+        return;
+      }
+      setLoadingNft(true);
+      try {
+        await getNFTListWithCache(userAddr, force);
+      } catch (e) {
+        console.error('ServiceErrorType.NFT', e);
+      } finally {
+        setLoadingNft(false);
+      }
+    },
+    [getNFTListWithCache, userAddr],
+  );
+
+  useEffect(() => {
+    if (!userAddr) {
+      return;
+    }
+
+    const updateNftChainStatics = (
+      state: ReturnType<typeof nftListStore.getState> = nftListStore.getState(),
+    ) => {
+      apisAddrChainStatics.updateNft(userAddr, state.nftsMap[userAddr] || []);
+    };
+
+    updateNftChainStatics();
+    const unsubscribe = nftListStore.subscribe(updateNftChainStatics);
+    return unsubscribe;
+  }, [userAddr]);
+
+  const batchLocalData = useCallback(async () => {
+    if (!userAddr) {
+      return;
+    }
+    try {
+      await batchLoadCacheNFT([userAddr]);
+    } catch (e) {
+      console.error('nft batchLocalData error', e);
+    }
+  }, [batchLoadCacheNFT, userAddr]);
+
+  const debounceReloadNftList = useMemo(
+    () => debounce(batchLocalData, 2000),
+    [batchLocalData],
+  );
+
+  useEffect(() => {
+    return () => {
+      debounceReloadNftList.cancel();
+    };
+  }, [debounceReloadNftList]);
+
+  useAppOrmSyncEvents({
+    taskFor: ['nfts'],
+    onRemoteDataUpserted: useCallback(
+      ctx => {
+        if (
+          !userAddr ||
+          !isSameAddress(ctx.owner_addr, userAddr) ||
+          !ctx.success ||
+          loadingNftRef.current
+        ) {
+          return;
+        }
+        const currentList = nftListStore.getState().nftsMap[userAddr] || [];
+        const currentUpdateCount =
+          ctx.syncDetails.batchSize * ctx.syncDetails.round +
+          ctx.syncDetails.count;
+
+        if (
+          currentUpdateCount >= ctx.syncDetails.total ||
+          currentUpdateCount > currentList.length
+        ) {
+          debounceReloadNftList();
+        }
+      },
+      [debounceReloadNftList, userAddr],
+    ),
+  });
 
   const refreshNftList = useCallback(() => {
     reloadNftList?.();
@@ -99,50 +279,43 @@ const NFTListInner = ({
     },
   });
 
-  const nftList = useMemo(() => {
-    return _rawNftList.filter(item =>
-      selectedChain && item?.chain ? item.chain === selectedChain : true,
-    );
-  }, [_rawNftList, selectedChain]);
-
-  const { foldNftList, unFoldNftList } = useMemo(() => {
-    const result = varyNftListByFold<ActionItem>(
-      nftList,
-      (collection, item) => ({
-        type: item._isFold ? 'fold_nft' : 'unfold_nft',
-        data: collection,
-      }),
-      { forSingleAddress: true },
-    );
-
-    return {
-      foldNftList: result.foldList,
-      unFoldNftList: result.unFoldList,
-    };
-  }, [nftList]);
+  useSingleNftRefresh({
+    onRefresh: refreshTagNftByStore,
+  });
 
   const dataList = useMemo(() => {
     const itemData: Array<{
       show: boolean;
-      data: ActionItem[];
+      data: NFTListItem[];
     }> = [
       {
         show: true,
-        data: [...unFoldNftList],
+        data: unFoldRows.map(row => ({
+          type: 'unfold_nft',
+          row,
+        })),
       },
       {
-        show: !!foldNftList.length,
-        data: [{ type: 'toggle_nft_fold' }, ...(foldNft ? [] : foldNftList)],
+        show: !!foldRows.length,
+        data: [
+          { type: 'toggle_nft_fold' },
+          ...(foldNft
+            ? []
+            : foldRows.map(row => ({
+                type: 'fold_nft' as const,
+                row,
+              }))),
+        ],
       },
       {
-        show: !!loadingNft && !nftList.length,
+        show: !!loadingNft && !unFoldRows.length && !foldRows.length,
         data: Array.from({ length: 5 }, (_, index) => ({
           type: 'loading-skeleton',
           data: 'index-nft' + index.toString(),
         })),
       },
       {
-        show: !loadingNft && nftList.length === 0,
+        show: !loadingNft && unFoldRows.length === 0 && foldRows.length === 0,
         data: [
           {
             type: 'empty-nft',
@@ -157,7 +330,7 @@ const NFTListInner = ({
       .filter(item => item.show)
       .map(item => item.data)
       .flat();
-  }, [foldNft, foldNftList, loadingNft, nftList.length, t, unFoldNftList]);
+  }, [foldNft, foldRows, loadingNft, t, unFoldRows]);
 
   const handlePressNft = useCallback(
     (item: NftItemWithCollection) => {
@@ -196,36 +369,30 @@ const NFTListInner = ({
     [colors2024, currentAccount],
   );
 
-  const renderItem = useCallback<ListRenderItem<ActionItem>>(
+  const renderItem = useCallback<ListRenderItem<NFTListItem>>(
     ({ item }) => {
-      const { type, data } = item;
+      const { type } = item;
       switch (type) {
         case 'unfold_nft':
         case 'fold_nft':
           return (
             <View style={styles.rowWrap}>
-              <NftRow
+              <NftResourceRow
                 style={StyleSheet.flatten([
                   styles.renderItemWrapper,
                   !isLight && styles.bg2,
                 ])}
                 logoSize={46}
                 chainLogoSize={18}
-                item={data}
-                onPress={() => handlePressNft(data)}
+                row={item.row}
+                onPress={handlePressNft}
               />
             </View>
-          );
-        case 'nft_header':
-          return (
-            <Text style={styles.symbol}>
-              {t('page.singleHome.sectionHeader.Nft')}
-            </Text>
           );
         case 'toggle_nft_fold':
           return (
             <TokenRowSectionHeader
-              str={'' + foldNftList.length}
+              str={'' + foldRows.length}
               fold={foldNft}
               style={styles.sectionHeader}
               buttonStyle={StyleSheet.flatten([
@@ -238,7 +405,11 @@ const NFTListInner = ({
         case 'empty-assets':
         case 'empty-nft':
           return (
-            <EmptyAssets style={styles.emptyAssets} desc={data} type={type} />
+            <EmptyAssets
+              style={styles.emptyAssets}
+              desc={item.data}
+              type={type}
+            />
           );
         case 'loading-skeleton':
           return (
@@ -250,8 +421,18 @@ const NFTListInner = ({
           return null;
       }
     },
-    [foldNft, foldNftList.length, handlePressNft, isLight, styles, t],
+    [foldNft, foldRows.length, handlePressNft, isLight, styles],
   );
+
+  const keyExtractor = useCallback((item: NFTListItem) => {
+    if (item.type === 'unfold_nft' || item.type === 'fold_nft') {
+      return `${item.type}-${getNftAssetsIndexRowKey(item.row)}`;
+    }
+    if (item.type === 'loading-skeleton') {
+      return `loading-${item.data}`;
+    }
+    return `${item.type}-${'data' in item ? item.data || '' : ''}`;
+  }, []);
   const ListRenderSeparator = useCallback(() => {
     return <View style={{ height: SPACING_HEIGHT }} />;
   }, []);
@@ -283,7 +464,7 @@ const NFTListInner = ({
     <View style={styles.container}>
       <Tabs.FlatList
         data={dataList}
-        keyExtractor={getItemId}
+        keyExtractor={keyExtractor}
         renderItem={renderItem}
         // estimatedItemSize={ASSETS_ITEM_HEIGHT_NEW + ASSETS_SEPARATOR_HEIGHT}
         ItemSeparatorComponent={ListRenderSeparator}

--- a/apps/mobile/src/screens/Home/PortfolioList.tsx
+++ b/apps/mobile/src/screens/Home/PortfolioList.tsx
@@ -3,7 +3,6 @@ import { ListRenderItem, View } from 'react-native';
 import { RefreshControl } from 'react-native-gesture-handler';
 
 import { createGetStyles2024 } from '@/utils/styles';
-import { ActionItem } from './types';
 import {
   ASSETS_ITEM_HEIGHT_NEW,
   ASSETS_SECTION_HEADER,
@@ -24,24 +23,75 @@ import {
 } from 'react-native-collapsible-tab-view';
 import { useAnimatedReaction } from 'react-native-reanimated';
 import { runOnJS } from 'react-native-reanimated';
-import { getItemId } from './utils/listRenderId';
 import useLoadMoreData from '../Address/components/MultiAssets/hooks/useLoadMoreData';
 import { useSingleHomeAccount, useSingleHomeChain } from './hooks/singleHome';
-import { getAllDefiCount } from './utils/converAssets';
 import useProtocols, {
   getSingleProtocolsCacheKey,
-  ICacheProtocolItem,
+  ProtocolAssetsIndexResult,
+  ProtocolEntityId,
+  useProtocolEntity,
   useProtocolListComputedStore,
 } from '@/store/protocols';
 import { useShallow } from 'zustand/react/shallow';
 import { useAppForeground } from '@/hooks/useAppForeground';
 
-const emptyCacheProtocolItem: ICacheProtocolItem = {
-  fold: [],
-  unFold: [],
+const emptyProtocolIndexResult: ProtocolAssetsIndexResult = {
+  foldIds: [],
+  unFoldIds: [],
+  foldDeFiValue: '',
 };
 
 const MemoFullDefiRenderItem = memo(FullDefiRenderItem);
+
+type PortfolioListItem =
+  | {
+      type: 'unfold_defi' | 'fold_defi';
+      protocolId: ProtocolEntityId;
+    }
+  | {
+      type: 'toggle_defi_fold';
+      data: string;
+    }
+  | {
+      type: 'empty-defi';
+      data: string;
+    }
+  | {
+      type: 'loading-defi-skeleton';
+      data: string;
+    };
+
+const ProtocolResourceRow = memo(
+  ({
+    protocolId,
+    showAccount,
+    disableAction,
+    defaultExpand,
+    account,
+  }: {
+    protocolId: ProtocolEntityId;
+    showAccount: boolean;
+    disableAction: boolean;
+    defaultExpand: boolean;
+    account?: React.ComponentProps<typeof FullDefiRenderItem>['account'];
+  }) => {
+    const data = useProtocolEntity(protocolId);
+
+    if (!data) {
+      return <DefiItemLoader />;
+    }
+
+    return (
+      <MemoFullDefiRenderItem
+        data={data}
+        showAccount={showAccount}
+        disableAction={disableAction}
+        defaultExpand={defaultExpand}
+        account={account}
+      />
+    );
+  },
+);
 
 interface Props {
   onForeground?: () => void;
@@ -98,53 +148,46 @@ export const PortfolioList = ({
     state => state.registerSingleProtocols,
   );
 
-  const _portfolios = useProtocolListComputedStore(
+  const protocolIndexResult = useProtocolListComputedStore(
     useShallow(state =>
       singleProtocolsKey
-        ? state.singleProtocolsCache[singleProtocolsKey] ||
-          emptyCacheProtocolItem
-        : emptyCacheProtocolItem,
+        ? state.singleProtocolsIndexCache[singleProtocolsKey] ||
+          emptyProtocolIndexResult
+        : emptyProtocolIndexResult,
     ),
   );
 
-  const filteredPortfolios = useMemo(() => {
-    const foldList = _portfolios?.fold || [];
-    const unFoldList = _portfolios?.unFold || [];
-    const foldDeFiValue = getAllDefiCount(foldList);
-    return {
-      unFoldList,
-      foldList,
-      foldDeFiValue,
-    };
-  }, [_portfolios]);
-
   const {
-    data: portfolios,
+    data: unFoldProtocolIds,
     loadMore: loadMorePortfolios,
     hasMore: hasMorePortfolios,
-  } = useLoadMoreData(filteredPortfolios.unFoldList);
+  } = useLoadMoreData(protocolIndexResult.unFoldIds);
 
   const shouldDefaultExpand = useMemo(
-    () => filteredPortfolios.unFoldList.length <= 5,
-    [filteredPortfolios.unFoldList.length],
+    () => protocolIndexResult.unFoldIds.length <= 5,
+    [protocolIndexResult.unFoldIds.length],
   );
 
   const dataList = useMemo(() => {
-    const unFoldDefiList: ActionItem[] = portfolios.map(item => ({
-      type: 'unfold_defi',
-      data: item,
-    }));
+    const hasProtocolRows =
+      unFoldProtocolIds.length > 0 || protocolIndexResult.foldIds.length > 0;
+    const unFoldDefiList: PortfolioListItem[] = unFoldProtocolIds.map(
+      protocolId => ({
+        type: 'unfold_defi',
+        protocolId,
+      }),
+    );
 
-    const foldDeFiList: ActionItem[] = filteredPortfolios.foldList.map(
-      item => ({
+    const foldDeFiList: PortfolioListItem[] = protocolIndexResult.foldIds.map(
+      protocolId => ({
         type: 'fold_defi',
-        data: item,
+        protocolId,
       }),
     );
 
     const itemData: Array<{
       show: boolean;
-      data: ActionItem[];
+      data: PortfolioListItem[];
     }> = [
       {
         show: true,
@@ -155,24 +198,20 @@ export const PortfolioList = ({
         data: [
           {
             type: 'toggle_defi_fold',
-            data: filteredPortfolios.foldDeFiValue,
+            data: protocolIndexResult.foldDeFiValue,
           },
           ...(foldDefi ? [] : foldDeFiList),
         ],
       },
       {
-        show:
-          !!loadingPortfolio && !portfolios.length && !unFoldDefiList.length,
+        show: !!loadingPortfolio && !hasProtocolRows,
         data: Array.from({ length: 2 }, (_, index) => ({
           type: 'loading-defi-skeleton',
           data: 'index-defi' + index.toString(),
         })),
       },
       {
-        show:
-          !loadingPortfolio &&
-          portfolios.length === 0 &&
-          unFoldDefiList.length === 0,
+        show: !loadingPortfolio && !hasProtocolRows,
         data: [
           {
             type: 'empty-defi',
@@ -188,12 +227,12 @@ export const PortfolioList = ({
       .map(item => item.data)
       .flat();
   }, [
-    filteredPortfolios.foldDeFiValue,
-    filteredPortfolios.foldList,
     foldDefi,
     loadingPortfolio,
-    portfolios,
+    protocolIndexResult.foldDeFiValue,
+    protocolIndexResult.foldIds,
     t,
+    unFoldProtocolIds,
   ]);
 
   const refreshPortfolioList = useCallback(() => {
@@ -227,15 +266,15 @@ export const PortfolioList = ({
     registerSingleProtocols(lowerAddress, selectedChain);
   }, [lowerAddress, selectedChain, registerSingleProtocols]);
 
-  const renderItem = useCallback<ListRenderItem<ActionItem>>(
+  const renderItem = useCallback<ListRenderItem<PortfolioListItem>>(
     props => {
       const { item: _data } = props;
-      const { type, data } = _data;
+      const { type } = _data;
       switch (type) {
         case 'unfold_defi':
           return (
-            <MemoFullDefiRenderItem
-              data={data}
+            <ProtocolResourceRow
+              protocolId={_data.protocolId}
               showAccount={false}
               disableAction={loadingPortfolio}
               defaultExpand={shouldDefaultExpand}
@@ -246,15 +285,15 @@ export const PortfolioList = ({
           return (
             <TokenRowSectionHeader
               style={styles.tokenSectionHeader}
-              str={data}
+              str={_data.data}
               fold={foldDefi}
               onPressFold={() => setFoldDefi(pre => !pre)}
             />
           );
         case 'fold_defi':
           return (
-            <MemoFullDefiRenderItem
-              data={data}
+            <ProtocolResourceRow
+              protocolId={_data.protocolId}
               showAccount={false}
               disableAction={loadingPortfolio}
               defaultExpand={false}
@@ -265,7 +304,7 @@ export const PortfolioList = ({
           return (
             <EmptyAssets
               style={styles.emptyAssets}
-              desc={data || ''}
+              desc={_data.data || ''}
               type={type}
             />
           );
@@ -284,6 +323,13 @@ export const PortfolioList = ({
       styles.tokenSectionHeader,
     ],
   );
+
+  const keyExtractor = useCallback((item: PortfolioListItem) => {
+    if (item.type === 'unfold_defi' || item.type === 'fold_defi') {
+      return `${item.type}-${item.protocolId}`;
+    }
+    return `${item.type}-${'data' in item ? item.data || '' : ''}`;
+  }, []);
   const ListRenderSeparator = useCallback(() => {
     return <View style={{ height: SPACING_HEIGHT }} />;
   }, []);
@@ -319,7 +365,7 @@ export const PortfolioList = ({
     <View style={styles.container}>
       <Tabs.FlatList
         data={dataList}
-        keyExtractor={getItemId}
+        keyExtractor={keyExtractor}
         renderItem={renderItem}
         // estimatedItemSize={ASSETS_ITEM_HEIGHT_NEW + ASSETS_SEPARATOR_HEIGHT}
         ItemSeparatorComponent={ListRenderSeparator}

--- a/apps/mobile/src/screens/Home/TokenList.tsx
+++ b/apps/mobile/src/screens/Home/TokenList.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { ListRenderItem, StyleSheet, View } from 'react-native';
+import { ListRenderItem, StyleSheet, View, ViewStyle } from 'react-native';
 import { RefreshControl } from 'react-native-gesture-handler';
 import { useTranslation } from 'react-i18next';
 import {
@@ -34,6 +34,8 @@ import {
 import useTokenList, {
   getSingleAssetsCacheKey,
   ITokenItem,
+  TokenEntityId,
+  useTokenEntity,
   useTokenListComputedStore,
 } from '@/store/tokens';
 import { formatNetworth } from '@/utils/math';
@@ -42,7 +44,7 @@ import { useAppForeground } from '@/hooks/useAppForeground';
 type TokenListItem =
   | {
       type: 'unfold_token' | 'fold_token';
-      data: ITokenItem;
+      tokenId: TokenEntityId;
     }
   | {
       type: 'toggle_token_fold';
@@ -65,6 +67,37 @@ type TokenListItem =
       type: 'loading-skeleton';
       data: string;
     };
+
+const TokenResourceRow = React.memo(
+  ({
+    tokenId,
+    tokenStyle,
+    loaderStyle,
+    onTokenPress,
+  }: {
+    tokenId: TokenEntityId;
+    tokenStyle?: ViewStyle;
+    loaderStyle?: ViewStyle;
+    onTokenPress(token: ITokenItem): void;
+  }) => {
+    const token = useTokenEntity(tokenId);
+
+    if (!token) {
+      return <ItemLoader style={loaderStyle} />;
+    }
+
+    return (
+      <TokenRowV2
+        data={token}
+        style={tokenStyle}
+        onTokenPress={onTokenPress}
+        logoSize={46}
+        chainLogoSize={18}
+        scene="portfolio"
+      />
+    );
+  },
+);
 
 interface Props {
   noAssetsOnAnyChain: boolean;
@@ -102,9 +135,11 @@ export const TokenList = ({
 
   const emptyResult = useMemo(
     () => ({
-      unFoldTokens: [] as ITokenItem[],
-      foldTokens: [] as ITokenItem[],
-      scamTokens: [] as ITokenItem[],
+      unFoldTokenIds: [] as TokenEntityId[],
+      foldTokenIds: [] as TokenEntityId[],
+      scamTokenIds: [] as TokenEntityId[],
+      scamTokenPreviewLogoUrls: [] as string[],
+      foldCoreUsdValue: 0,
       hasFoldTokens: false,
     }),
     [],
@@ -132,14 +167,20 @@ export const TokenList = ({
     registerSingleAssets(currentAddress, selectedChain, isLpTokenEnabled);
   }, [currentAddress, selectedChain, isLpTokenEnabled, registerSingleAssets]);
 
-  const { unFoldTokens, foldTokens, scamTokens, hasFoldTokens } =
-    useTokenListComputedStore(
-      useShallow(state =>
-        singleAssetsKey
-          ? state.singleAssetsCache[singleAssetsKey] || emptyResult
-          : emptyResult,
-      ),
-    );
+  const {
+    unFoldTokenIds,
+    foldTokenIds,
+    scamTokenIds,
+    scamTokenPreviewLogoUrls,
+    foldCoreUsdValue,
+    hasFoldTokens,
+  } = useTokenListComputedStore(
+    useShallow(state =>
+      singleAssetsKey
+        ? state.singleAssetsIndexCache[singleAssetsKey] || emptyResult
+        : emptyResult,
+    ),
+  );
 
   const isLoading = useTokenList(state => {
     if (!lowerAddress) {
@@ -183,39 +224,37 @@ export const TokenList = ({
   const { selectData } = useSingleHomeSelectData();
   const noAnyAssets = !selectData.rawNetWorth || noAssetsOnAnyChain;
 
-  const foldTokenUsdValue = useMemo(() => {
-    const usdValue = foldTokens
-      .filter(item => item.is_core)
-      .reduce((total, item) => total + item.usd_value, 0);
-    return formatNetworth(usdValue);
-  }, [foldTokens]);
+  const foldTokenUsdValue = useMemo(
+    () => formatNetworth(foldCoreUsdValue),
+    [foldCoreUsdValue],
+  );
 
   const dataList = useMemo(() => {
     const items: TokenListItem[] = [];
 
-    unFoldTokens.forEach(token => {
-      items.push({ type: 'unfold_token', data: token });
+    unFoldTokenIds.forEach(tokenId => {
+      items.push({ type: 'unfold_token', tokenId });
     });
 
     const hasFoldSection = hasFoldTokens || isLpTokenEnabled;
     if (hasFoldSection) {
       items.push({ type: 'toggle_token_fold' });
       if (!foldHideList) {
-        foldTokens.forEach(token => {
-          items.push({ type: 'fold_token', data: token });
+        foldTokenIds.forEach(tokenId => {
+          items.push({ type: 'fold_token', tokenId });
         });
-        if (scamTokens.length > 0) {
+        if (scamTokenIds.length > 0) {
           if (foldScam) {
             items.push({
               type: 'scam_token',
               data: {
-                total: scamTokens.length,
-                logoUrls: scamTokens.slice(0, 3).map(i => i.logo_url),
+                total: scamTokenIds.length,
+                logoUrls: scamTokenPreviewLogoUrls,
               },
             });
           } else {
-            scamTokens.forEach(token => {
-              items.push({ type: 'fold_token', data: token });
+            scamTokenIds.forEach(tokenId => {
+              items.push({ type: 'fold_token', tokenId });
             });
           }
         }
@@ -257,18 +296,25 @@ export const TokenList = ({
   }, [
     foldHideList,
     foldScam,
-    foldTokens,
+    foldTokenIds,
     hasFoldTokens,
     isAllLoading,
     isLoading,
     isLpTokenEnabled,
     noAnyAssets,
-    scamTokens,
+    scamTokenIds,
+    scamTokenPreviewLogoUrls,
     t,
-    unFoldTokens,
+    unFoldTokenIds,
   ]);
 
   const [showScrollIndicator, setShowScrollIndicator] = useState(false);
+
+  const tokenRowStyle = useMemo(
+    () =>
+      StyleSheet.flatten([styles.renderItemWrapper, !isLight && styles.bg2]),
+    [isLight, styles.bg2, styles.renderItemWrapper],
+  );
 
   const handleOpenTokenDetail = useCallback(
     (token: ITokenItem) => {
@@ -298,16 +344,11 @@ export const TokenList = ({
         case 'fold_token':
           return (
             <View style={styles.rowWrap}>
-              <TokenRowV2
-                data={item.data}
-                style={StyleSheet.flatten([
-                  styles.renderItemWrapper,
-                  !isLight && styles.bg2,
-                ])}
+              <TokenResourceRow
+                tokenId={item.tokenId}
+                tokenStyle={tokenRowStyle}
+                loaderStyle={styles.removeLeft}
                 onTokenPress={handleOpenTokenDetail}
-                logoSize={46}
-                chainLogoSize={18}
-                scene="portfolio"
               />
             </View>
           );
@@ -381,12 +422,13 @@ export const TokenList = ({
       isLight,
       isLpTokenEnabled,
       styles,
+      tokenRowStyle,
     ],
   );
 
   const keyExtractor = useCallback((item: TokenListItem) => {
     if (item.type === 'unfold_token' || item.type === 'fold_token') {
-      return `${item.type}-${item.data.owner_addr}-${item.data.chain}-${item.data.id}`;
+      return `${item.type}-${item.tokenId}`;
     }
     if (item.type === 'scam_token') {
       return `scam-token-${item.data.total}`;

--- a/apps/mobile/src/store/nfts.ts
+++ b/apps/mobile/src/store/nfts.ts
@@ -1,16 +1,264 @@
 import { getTop10MyAccounts } from '@/core/apis/account';
-import { zCreate } from '@/core/utils/reexports';
+import { mCreate, zCreate } from '@/core/utils/reexports';
 import { syncNFTs } from '@/databases/hooks/assets';
 import { NFTItemEntity } from '@/databases/entities/nftItem';
 import type { DisplayNftItem } from '@/types/assets';
 import { eventBus, EventBusListeners } from '@/utils/events';
 import { useCallback, useEffect } from 'react';
 import { CollectionList } from '@rabby-wallet/rabby-api/dist/types';
+import { ResourceBaseStore } from './_resourceBase';
+import type { ObservableResourceValueSource } from './_resourceFlow';
 
 const normalizeAddresses = (addresses: string[]) =>
   Array.from(new Set(addresses.map(address => address.toLowerCase())));
 
-type CombinedNFTItem = DisplayNftItem & { address?: string };
+export type CombinedNFTItem = DisplayNftItem & { address?: string };
+
+export type NftEntityId = string & {
+  readonly __nftEntityId: unique symbol;
+};
+
+export type NftCollectionId = string & {
+  readonly __nftCollectionId: unique symbol;
+};
+
+export type NftAssetsIndexRow =
+  | {
+      type: 'nft';
+      nftId: NftEntityId;
+    }
+  | {
+      type: 'collection';
+      collectionId: NftCollectionId;
+    };
+
+export type NftCollectionResourceValue = CollectionList & {
+  address?: string;
+};
+
+export type NftAssetsIndexResult = {
+  unFoldRows: NftAssetsIndexRow[];
+  foldRows: NftAssetsIndexRow[];
+};
+
+type NFTListMap = Record<string, DisplayNftItem[]>;
+
+type NFTListComputedState = {
+  multiNftsIndexCache: Record<string, NftAssetsIndexResult>;
+  singleNftsIndexCache: Record<string, NftAssetsIndexResult>;
+  registerMultiNfts: (addresses: string[], chainServerId?: string) => string;
+  registerSingleNfts: (address: string, chainServerId?: string) => string;
+};
+
+const COMPUTED_CACHE_LIMIT = 10;
+const NFT_ENTITY_RESOURCE_FAMILY = 'nft.entity';
+const NFT_COLLECTION_RESOURCE_FAMILY = 'nft.collection';
+
+const createEmptyNftAssetsIndexResult = (): NftAssetsIndexResult => ({
+  unFoldRows: [],
+  foldRows: [],
+});
+
+const getAddressesKey = (addresses: string[]) =>
+  normalizeAddresses(addresses).slice().sort().join('|');
+
+export const getMultiNftsCacheKey = (
+  addresses: string[],
+  chainServerId?: string,
+) => `${getAddressesKey(addresses)}::${chainServerId ?? ''}`;
+
+export const getSingleNftsCacheKey = (
+  address: string,
+  chainServerId?: string,
+) => `${address.toLowerCase()}::${chainServerId ?? ''}`;
+
+const getNftOwnerAddress = (nft: { owner_addr?: string; address?: string }) =>
+  (nft.owner_addr || nft.address || '').toLowerCase();
+
+export const buildNftEntityId = (
+  nft: Pick<DisplayNftItem, 'chain' | 'id'> & {
+    owner_addr?: string;
+    address?: string;
+    inner_id?: string;
+    collection_id?: string;
+  },
+): NftEntityId =>
+  [
+    getNftOwnerAddress(nft),
+    nft.chain?.toLowerCase() || '',
+    nft.collection_id?.toLowerCase() || '',
+    nft.id?.toLowerCase() || '',
+    nft.inner_id?.toLowerCase() || '',
+  ].join(':') as NftEntityId;
+
+const buildNftCollectionId = (
+  listKey: string,
+  section: 'unfold' | 'fold',
+  collection: NftCollectionResourceValue,
+): NftCollectionId =>
+  [
+    listKey,
+    section,
+    collection.address?.toLowerCase() || '',
+    collection.chain?.toLowerCase() || '',
+    collection.id?.toLowerCase() || '',
+  ].join('::') as NftCollectionId;
+
+export const getNftAssetsIndexRowKey = (row: NftAssetsIndexRow) => {
+  if (row.type === 'collection') {
+    return `collection-${row.collectionId}`;
+  }
+  return `nft-${row.nftId}`;
+};
+
+const getNftListFromNftMap = (nftsMap: NFTListMap) =>
+  Object.values(nftsMap).flat();
+
+class NftEntityResourceStore extends ResourceBaseStore<CombinedNFTItem> {
+  constructor() {
+    super(NFT_ENTITY_RESOURCE_FAMILY);
+  }
+
+  upsertNfts = (
+    nfts: CombinedNFTItem[],
+    source: ObservableResourceValueSource = 'remote',
+  ) => {
+    if (!nfts.length) {
+      return;
+    }
+
+    const entries = new Map<NftEntityId, CombinedNFTItem>();
+    nfts.forEach(nft => {
+      entries.set(buildNftEntityId(nft), nft);
+    });
+
+    const now = Date.now();
+    this.setState(prev => {
+      let changed = false;
+      const valueMap = { ...prev.valueMap };
+      const metaMap = { ...prev.metaMap };
+
+      entries.forEach((nft, nftId) => {
+        const prevNft = prev.valueMap[nftId];
+        const prevMeta = prev.metaMap[nftId];
+        const isNftChanged = prevNft !== nft;
+
+        if (isNftChanged) {
+          valueMap[nftId] = nft;
+          changed = true;
+        }
+
+        if (!prevMeta || isNftChanged) {
+          metaMap[nftId] = {
+            family: NFT_ENTITY_RESOURCE_FAMILY,
+            resourceKey: nftId,
+            hasValue: true,
+            version: Math.max(prevMeta?.version || 0, 0) + 1,
+            sourceOfCurrentValue: source,
+            isHydrating: false,
+            isFetchingRemote: false,
+            persistStatus: prevMeta?.persistStatus || 'idle',
+            localTargets: prevMeta?.localTargets || [],
+            activeRemoteRequestId: undefined,
+            lastHydratedAt:
+              source === 'hydrate' ? now : prevMeta?.lastHydratedAt,
+            lastRemoteAt: source === 'remote' ? now : prevMeta?.lastRemoteAt,
+            lastPersistAt: prevMeta?.lastPersistAt,
+            lastError: prevMeta?.lastError,
+          };
+          changed = true;
+        }
+      });
+
+      return changed
+        ? {
+            valueMap,
+            metaMap,
+          }
+        : prev;
+    });
+  };
+
+  syncFromNftsMap = (
+    nftsMap: NFTListMap,
+    source: ObservableResourceValueSource = 'remote',
+  ) => {
+    this.upsertNfts(getNftListFromNftMap(nftsMap), source);
+  };
+}
+
+class NftCollectionResourceStore extends ResourceBaseStore<NftCollectionResourceValue> {
+  constructor() {
+    super(NFT_COLLECTION_RESOURCE_FAMILY);
+  }
+
+  upsertCollections = (
+    collections: Array<{
+      collectionId: NftCollectionId;
+      value: NftCollectionResourceValue;
+    }>,
+    source: ObservableResourceValueSource = 'remote',
+  ) => {
+    if (!collections.length) {
+      return;
+    }
+
+    const now = Date.now();
+    this.setState(prev => {
+      let changed = false;
+      const valueMap = { ...prev.valueMap };
+      const metaMap = { ...prev.metaMap };
+
+      collections.forEach(({ collectionId, value }) => {
+        const prevValue = prev.valueMap[collectionId];
+        const prevMeta = prev.metaMap[collectionId];
+        const isValueChanged = prevValue !== value;
+
+        if (isValueChanged) {
+          valueMap[collectionId] = value;
+          changed = true;
+        }
+
+        if (!prevMeta || isValueChanged) {
+          metaMap[collectionId] = {
+            family: NFT_COLLECTION_RESOURCE_FAMILY,
+            resourceKey: collectionId,
+            hasValue: true,
+            version: Math.max(prevMeta?.version || 0, 0) + 1,
+            sourceOfCurrentValue: source,
+            isHydrating: false,
+            isFetchingRemote: false,
+            persistStatus: prevMeta?.persistStatus || 'idle',
+            localTargets: prevMeta?.localTargets || [],
+            activeRemoteRequestId: undefined,
+            lastHydratedAt:
+              source === 'hydrate' ? now : prevMeta?.lastHydratedAt,
+            lastRemoteAt: source === 'remote' ? now : prevMeta?.lastRemoteAt,
+            lastPersistAt: prevMeta?.lastPersistAt,
+            lastError: prevMeta?.lastError,
+          };
+          changed = true;
+        }
+      });
+
+      return changed
+        ? {
+            valueMap,
+            metaMap,
+          }
+        : prev;
+    });
+  };
+}
+
+export const nftEntityResourceStore = new NftEntityResourceStore();
+export const nftCollectionResourceStore = new NftCollectionResourceStore();
+
+export const useNftEntity = (nftId?: NftEntityId) =>
+  nftEntityResourceStore.useValue(nftId);
+
+export const useNftCollection = (collectionId?: NftCollectionId) =>
+  nftCollectionResourceStore.useValue(collectionId);
 
 const tagNfts = (nfts: DisplayNftItem[]) => {
   return nfts.map(i => {
@@ -53,6 +301,200 @@ export const combinedNfts = (
   });
 
   return nfts;
+};
+
+const filterNftsByChain = <T extends { chain?: string }>(
+  nfts: T[],
+  chainServerId?: string,
+) => {
+  return chainServerId
+    ? nfts.filter(item => (item.chain ? item.chain === chainServerId : true))
+    : nfts;
+};
+
+const buildNftAssetsIndexRows = (
+  nfts: CombinedNFTItem[],
+  section: 'unfold' | 'fold',
+  listKey: string,
+  options?: {
+    forSingleAddress?: boolean;
+  },
+) => {
+  const rows: NftAssetsIndexRow[] = [];
+  const collections: Array<{
+    collectionId: NftCollectionId;
+    value: NftCollectionResourceValue;
+  }> = [];
+  const collectionMap: Record<string, NftCollectionResourceValue> = {};
+
+  nfts.forEach(item => {
+    if (!item.collection_id || !item.collection) {
+      rows.push({
+        type: 'nft',
+        nftId: buildNftEntityId(item),
+      });
+      return;
+    }
+
+    const key = `${options?.forSingleAddress ? '' : item.address}-${
+      item.chain
+    }-${item.collection.id}`;
+    const existingCollection = collectionMap[key];
+    if (existingCollection) {
+      existingCollection.nft_list.push({ ...item, collection: null });
+      return;
+    }
+
+    const collection = {
+      ...item.collection,
+      address: item.address,
+      nft_list: [{ ...item, collection: null }],
+    } as unknown as NftCollectionResourceValue;
+    const collectionId = buildNftCollectionId(listKey, section, collection);
+    collectionMap[key] = collection;
+    collections.push({
+      collectionId,
+      value: collection,
+    });
+    rows.push({
+      type: 'collection',
+      collectionId,
+    });
+  });
+
+  if (collections.length) {
+    const collectionNfts = collections.flatMap(
+      collection => collection.value.nft_list || [],
+    );
+    nftEntityResourceStore.upsertNfts(collectionNfts as CombinedNFTItem[]);
+    nftCollectionResourceStore.upsertCollections(collections);
+  }
+
+  return rows;
+};
+
+const buildNftAssetsIndexResult = (
+  nfts: CombinedNFTItem[],
+  listKey: string,
+  options?: {
+    forSingleAddress?: boolean;
+  },
+): NftAssetsIndexResult => {
+  const foldNfts: CombinedNFTItem[] = [];
+  const unFoldNfts: CombinedNFTItem[] = [];
+
+  nfts.forEach(item => {
+    if (item._isFold) {
+      foldNfts.push(item);
+    } else {
+      unFoldNfts.push(item);
+    }
+  });
+
+  nftEntityResourceStore.upsertNfts(nfts);
+
+  return {
+    unFoldRows: buildNftAssetsIndexRows(unFoldNfts, 'unfold', listKey, options),
+    foldRows: buildNftAssetsIndexRows(foldNfts, 'fold', listKey, options),
+  };
+};
+
+const computeSingleNftsIndex = (
+  nftsMap: NFTListMap,
+  address: string,
+  chainServerId?: string,
+): NftAssetsIndexResult => {
+  if (!address) {
+    return createEmptyNftAssetsIndexResult();
+  }
+
+  const normalizedAddress = address.toLowerCase();
+  const nfts = nftsMap[normalizedAddress] || [];
+
+  return buildNftAssetsIndexResult(
+    filterNftsByChain(nfts, chainServerId),
+    getSingleNftsCacheKey(normalizedAddress, chainServerId),
+    {
+      forSingleAddress: true,
+    },
+  );
+};
+
+const computeMultiNftsIndex = (
+  nftsMap: NFTListMap,
+  addresses: string[],
+  chainServerId?: string,
+): NftAssetsIndexResult => {
+  if (!addresses.length) {
+    return createEmptyNftAssetsIndexResult();
+  }
+
+  return buildNftAssetsIndexResult(
+    filterNftsByChain(combinedNfts(nftsMap, addresses), chainServerId),
+    getMultiNftsCacheKey(addresses, chainServerId),
+  );
+};
+
+const multiNftsIndexCacheParams = new Map<
+  string,
+  {
+    addresses: string[];
+    chainServerId?: string;
+  }
+>();
+
+const singleNftsIndexCacheParams = new Map<
+  string,
+  {
+    address: string;
+    chainServerId?: string;
+  }
+>();
+
+const multiNftsIndexCacheOrder: string[] = [];
+const singleNftsIndexCacheOrder: string[] = [];
+
+const upsertRecordCache = <T>(
+  cache: Record<string, T>,
+  key: string,
+  value: T,
+  keys: string[],
+) => {
+  return mCreate(cache, draft => {
+    const record = draft as Record<string, T>;
+    record[key] = value;
+    keys.forEach(removedKey => {
+      delete record[removedKey];
+    });
+  });
+};
+
+const touchCacheParams = <T>(
+  map: Map<string, T>,
+  order: string[],
+  key: string,
+  params: T,
+  limit = COMPUTED_CACHE_LIMIT,
+) => {
+  if (map.has(key)) {
+    map.set(key, params);
+    const index = order.indexOf(key);
+    if (index > -1) {
+      order.splice(index, 1);
+    }
+    order.push(key);
+    return [] as string[];
+  }
+  map.set(key, params);
+  order.push(key);
+  if (order.length > limit) {
+    const removed = order.shift();
+    if (removed) {
+      map.delete(removed);
+      return [removed];
+    }
+  }
+  return [] as string[];
 };
 
 export interface NFTListState {
@@ -272,6 +714,90 @@ const nftListStore = zCreate<NFTListState>((set, get) => ({
     }, 0);
   },
 }));
+
+export const useNftListComputedStore = zCreate<NFTListComputedState>(set => ({
+  multiNftsIndexCache: {},
+  singleNftsIndexCache: {},
+  registerMultiNfts(addresses, chainServerId) {
+    const key = getMultiNftsCacheKey(addresses, chainServerId);
+    const removedKeys = touchCacheParams(
+      multiNftsIndexCacheParams,
+      multiNftsIndexCacheOrder,
+      key,
+      {
+        addresses,
+        chainServerId,
+      },
+    );
+    const nftsMap = nftListStore.getState().nftsMap;
+    set(state => ({
+      multiNftsIndexCache: upsertRecordCache(
+        state.multiNftsIndexCache,
+        key,
+        computeMultiNftsIndex(nftsMap, addresses, chainServerId),
+        removedKeys,
+      ),
+    }));
+    return key;
+  },
+  registerSingleNfts(address, chainServerId) {
+    const normalizedAddress = address.toLowerCase();
+    const key = getSingleNftsCacheKey(normalizedAddress, chainServerId);
+    const removedKeys = touchCacheParams(
+      singleNftsIndexCacheParams,
+      singleNftsIndexCacheOrder,
+      key,
+      {
+        address: normalizedAddress,
+        chainServerId,
+      },
+    );
+    const nftsMap = nftListStore.getState().nftsMap;
+    set(state => ({
+      singleNftsIndexCache: upsertRecordCache(
+        state.singleNftsIndexCache,
+        key,
+        computeSingleNftsIndex(nftsMap, normalizedAddress, chainServerId),
+        removedKeys,
+      ),
+    }));
+    return key;
+  },
+}));
+
+const rebuildComputedCaches = (nftsMap: NFTListMap) => {
+  const multiNftsIndexCache: Record<string, NftAssetsIndexResult> = {};
+  multiNftsIndexCacheParams.forEach((params, key) => {
+    multiNftsIndexCache[key] = computeMultiNftsIndex(
+      nftsMap,
+      params.addresses,
+      params.chainServerId,
+    );
+  });
+
+  const singleNftsIndexCache: Record<string, NftAssetsIndexResult> = {};
+  singleNftsIndexCacheParams.forEach((params, key) => {
+    singleNftsIndexCache[key] = computeSingleNftsIndex(
+      nftsMap,
+      params.address,
+      params.chainServerId,
+    );
+  });
+
+  useNftListComputedStore.setState({
+    multiNftsIndexCache,
+    singleNftsIndexCache,
+  });
+};
+
+let latestNftsMap = nftListStore.getState().nftsMap;
+nftListStore.subscribe(state => {
+  if (state.nftsMap === latestNftsMap) {
+    return;
+  }
+  latestNftsMap = state.nftsMap;
+  rebuildComputedCaches(state.nftsMap);
+});
 
 export function getAssetsMapDirectly(type: 'nfts') {
   if (type !== 'nfts') {

--- a/apps/mobile/src/store/protocols.ts
+++ b/apps/mobile/src/store/protocols.ts
@@ -1,4 +1,4 @@
-import { zCreate } from '@/core/utils/reexports';
+import { mCreate, zCreate } from '@/core/utils/reexports';
 import { ProtocolItemEntity } from '@/databases/entities/portocolItem';
 import { AppChainEntity } from '@/databases/entities/appchain';
 import { syncProtocols, syncSpecificProtocol } from '@/databases/hooks/assets';
@@ -7,6 +7,9 @@ import { formatAppChain } from '@/utils/appchain';
 import { reportLendingUserStatusOnce } from '@/utils/lendingUserStatus';
 import { complexProtocol2ProtocolItem } from '@/utils/protocol';
 import type { ICacheProtocolItem, IProtocolItem } from '@/types/assets';
+import { formatNetworth } from '@/utils/math';
+import { ResourceBaseStore } from './_resourceBase';
+import type { ObservableResourceValueSource } from './_resourceFlow';
 
 export type {
   ICacheProtocolItem,
@@ -31,8 +34,8 @@ interface ProtocolListState {
 }
 
 type ProtocolListComputedState = {
-  multiProtocolsCache: Record<string, ICacheProtocolItem>;
-  singleProtocolsCache: Record<string, ICacheProtocolItem>;
+  multiProtocolsIndexCache: Record<string, ProtocolAssetsIndexResult>;
+  singleProtocolsIndexCache: Record<string, ProtocolAssetsIndexResult>;
   registerMultiProtocols: (
     addresses: string[],
     chainServerId?: string,
@@ -41,6 +44,23 @@ type ProtocolListComputedState = {
 };
 
 const COMPUTED_CACHE_LIMIT = 10;
+const PROTOCOL_ENTITY_RESOURCE_FAMILY = 'protocol.entity';
+
+export type ProtocolEntityId = string & {
+  readonly __protocolEntityId: unique symbol;
+};
+
+export type ProtocolAssetsIndexResult = {
+  foldIds: ProtocolEntityId[];
+  unFoldIds: ProtocolEntityId[];
+  foldDeFiValue: string;
+};
+
+const createEmptyProtocolAssetsIndexResult = (): ProtocolAssetsIndexResult => ({
+  foldIds: [],
+  unFoldIds: [],
+  foldDeFiValue: '',
+});
 
 const normalizeAddresses = (addresses: string[]) =>
   addresses.map(address => address.toLowerCase());
@@ -58,8 +78,100 @@ export const getSingleProtocolsCacheKey = (
   chainServerId?: string,
 ) => `${address.toLowerCase()}::${chainServerId ?? ''}`;
 
+export const buildProtocolEntityId = (
+  protocol: Pick<IProtocolItem, 'owner_addr' | 'chain' | 'id'>,
+): ProtocolEntityId =>
+  [
+    protocol.owner_addr.toLowerCase(),
+    (protocol.chain || '').toLowerCase(),
+    protocol.id.toLowerCase(),
+  ].join(':') as ProtocolEntityId;
+
+const getProtocolListFromProtocolMap = (protocolMap: ProtocolListMap) =>
+  Object.values(protocolMap).flat();
+
+class ProtocolEntityResourceStore extends ResourceBaseStore<IProtocolItem> {
+  constructor() {
+    super(PROTOCOL_ENTITY_RESOURCE_FAMILY);
+  }
+
+  upsertProtocols = (
+    protocols: IProtocolItem[],
+    source: ObservableResourceValueSource = 'remote',
+  ) => {
+    if (!protocols.length) {
+      return;
+    }
+
+    const entries = new Map<ProtocolEntityId, IProtocolItem>();
+    protocols.forEach(protocol => {
+      entries.set(buildProtocolEntityId(protocol), protocol);
+    });
+
+    const now = Date.now();
+    this.setState(prev => {
+      let changed = false;
+      const valueMap = { ...prev.valueMap };
+      const metaMap = { ...prev.metaMap };
+
+      entries.forEach((protocol, protocolId) => {
+        const prevProtocol = prev.valueMap[protocolId];
+        const prevMeta = prev.metaMap[protocolId];
+        const isProtocolChanged = prevProtocol !== protocol;
+
+        if (isProtocolChanged) {
+          valueMap[protocolId] = protocol;
+          changed = true;
+        }
+
+        if (!prevMeta || isProtocolChanged) {
+          metaMap[protocolId] = {
+            family: PROTOCOL_ENTITY_RESOURCE_FAMILY,
+            resourceKey: protocolId,
+            hasValue: true,
+            version: Math.max(prevMeta?.version || 0, 0) + 1,
+            sourceOfCurrentValue: source,
+            isHydrating: false,
+            isFetchingRemote: false,
+            persistStatus: prevMeta?.persistStatus || 'idle',
+            localTargets: prevMeta?.localTargets || [],
+            activeRemoteRequestId: undefined,
+            lastHydratedAt:
+              source === 'hydrate' ? now : prevMeta?.lastHydratedAt,
+            lastRemoteAt: source === 'remote' ? now : prevMeta?.lastRemoteAt,
+            lastPersistAt: prevMeta?.lastPersistAt,
+            lastError: prevMeta?.lastError,
+          };
+          changed = true;
+        }
+      });
+
+      return changed
+        ? {
+            valueMap,
+            metaMap,
+          }
+        : prev;
+    });
+  };
+
+  syncFromProtocolMap = (
+    protocolMap: ProtocolListMap,
+    source: ObservableResourceValueSource = 'remote',
+  ) => {
+    this.upsertProtocols(getProtocolListFromProtocolMap(protocolMap), source);
+  };
+}
+
+export const protocolEntityResourceStore = new ProtocolEntityResourceStore();
+
+export const useProtocolEntity = (protocolId?: ProtocolEntityId) =>
+  protocolEntityResourceStore.useValue(protocolId);
+
 const splitFoldAndUnfold = (list: IProtocolItem[]): ICacheProtocolItem => {
-  const sortedList = list.sort((a, b) => (b.netWorth || 0) - (a.netWorth || 0));
+  const sortedList = [...list].sort(
+    (a, b) => (b.netWorth || 0) - (a.netWorth || 0),
+  );
 
   const totalNetWorth = sortedList.reduce(
     (acc, curr) => acc + (Number(curr?.netWorth) || 0),
@@ -132,7 +244,60 @@ const computeMultiProtocols = (
   return splitFoldAndUnfold(filtered);
 };
 
-const multiProtocolsCacheParams = new Map<
+const getAllProtocolCount = (protocols: IProtocolItem[]) => {
+  let total = 0;
+  protocols?.forEach(protocol => {
+    total +=
+      protocol._portfolios?.reduce((sum, item) => {
+        return (
+          sum +
+          (item._sumTokenRealUsdValue < 0 ? 0 : item._sumTokenRealUsdValue || 0)
+        );
+      }, 0) || 0;
+  });
+  return formatNetworth(total, false, '$');
+};
+
+const buildProtocolAssetsIndexResult = (
+  result: ICacheProtocolItem,
+): ProtocolAssetsIndexResult => {
+  const protocols = [...result.unFold, ...result.fold];
+  protocolEntityResourceStore.upsertProtocols(protocols);
+
+  return {
+    unFoldIds: result.unFold.map(buildProtocolEntityId),
+    foldIds: result.fold.map(buildProtocolEntityId),
+    foldDeFiValue: getAllProtocolCount(result.fold),
+  };
+};
+
+const computeSingleProtocolsIndex = (
+  protocolMap: ProtocolListMap,
+  address: string,
+  chainServerId?: string,
+): ProtocolAssetsIndexResult => {
+  if (!address) {
+    return createEmptyProtocolAssetsIndexResult();
+  }
+  return buildProtocolAssetsIndexResult(
+    computeSingleProtocols(protocolMap, address, chainServerId),
+  );
+};
+
+const computeMultiProtocolsIndex = (
+  protocolMap: ProtocolListMap,
+  addresses: string[],
+  chainServerId?: string,
+): ProtocolAssetsIndexResult => {
+  if (!addresses.length) {
+    return createEmptyProtocolAssetsIndexResult();
+  }
+  return buildProtocolAssetsIndexResult(
+    computeMultiProtocols(protocolMap, addresses, chainServerId),
+  );
+};
+
+const multiProtocolsIndexCacheParams = new Map<
   string,
   {
     addresses: string[];
@@ -140,7 +305,7 @@ const multiProtocolsCacheParams = new Map<
   }
 >();
 
-const singleProtocolsCacheParams = new Map<
+const singleProtocolsIndexCacheParams = new Map<
   string,
   {
     address: string;
@@ -148,21 +313,22 @@ const singleProtocolsCacheParams = new Map<
   }
 >();
 
-const multiProtocolsCacheOrder: string[] = [];
-const singleProtocolsCacheOrder: string[] = [];
+const multiProtocolsIndexCacheOrder: string[] = [];
+const singleProtocolsIndexCacheOrder: string[] = [];
 
-const removeKeysFromCache = <T extends Record<string, unknown>>(
-  cache: T,
+const upsertRecordCache = <T>(
+  cache: Record<string, T>,
+  key: string,
+  value: T,
   keys: string[],
 ) => {
-  if (!keys.length) {
-    return cache;
-  }
-  const next = { ...cache };
-  keys.forEach(key => {
-    delete next[key];
+  return mCreate(cache, draft => {
+    const record = draft as Record<string, T>;
+    record[key] = value;
+    keys.forEach(removedKey => {
+      delete record[removedKey];
+    });
   });
-  return next;
 };
 
 const touchCacheParams = <T>(
@@ -409,13 +575,13 @@ export const useProtocolListStore = zCreate<ProtocolListState>(set => ({
 
 export const useProtocolListComputedStore = zCreate<ProtocolListComputedState>(
   set => ({
-    multiProtocolsCache: {},
-    singleProtocolsCache: {},
+    multiProtocolsIndexCache: {},
+    singleProtocolsIndexCache: {},
     registerMultiProtocols(addresses, chainServerId) {
       const key = getMultiProtocolsCacheKey(addresses, chainServerId);
       const removedKeys = touchCacheParams(
-        multiProtocolsCacheParams,
-        multiProtocolsCacheOrder,
+        multiProtocolsIndexCacheParams,
+        multiProtocolsIndexCacheOrder,
         key,
         {
           addresses,
@@ -423,12 +589,12 @@ export const useProtocolListComputedStore = zCreate<ProtocolListComputedState>(
         },
       );
       const protocolMap = useProtocolListStore.getState().protocolMap;
+      protocolEntityResourceStore.syncFromProtocolMap(protocolMap);
       set(state => ({
-        multiProtocolsCache: removeKeysFromCache(
-          {
-            ...state.multiProtocolsCache,
-            [key]: computeMultiProtocols(protocolMap, addresses, chainServerId),
-          },
+        multiProtocolsIndexCache: upsertRecordCache(
+          state.multiProtocolsIndexCache,
+          key,
+          computeMultiProtocolsIndex(protocolMap, addresses, chainServerId),
           removedKeys,
         ),
       }));
@@ -438,8 +604,8 @@ export const useProtocolListComputedStore = zCreate<ProtocolListComputedState>(
       const normalizedAddress = address.toLowerCase();
       const key = getSingleProtocolsCacheKey(normalizedAddress, chainServerId);
       const removedKeys = touchCacheParams(
-        singleProtocolsCacheParams,
-        singleProtocolsCacheOrder,
+        singleProtocolsIndexCacheParams,
+        singleProtocolsIndexCacheOrder,
         key,
         {
           address: normalizedAddress,
@@ -447,12 +613,12 @@ export const useProtocolListComputedStore = zCreate<ProtocolListComputedState>(
         },
       );
       const protocolMap = useProtocolListStore.getState().protocolMap;
+      protocolEntityResourceStore.syncFromProtocolMap(protocolMap);
       set(state => ({
-        singleProtocolsCache: removeKeysFromCache(
-          {
-            ...state.singleProtocolsCache,
-            [key]: computeSingleProtocols(protocolMap, address, chainServerId),
-          },
+        singleProtocolsIndexCache: upsertRecordCache(
+          state.singleProtocolsIndexCache,
+          key,
+          computeSingleProtocolsIndex(protocolMap, address, chainServerId),
           removedKeys,
         ),
       }));
@@ -462,18 +628,22 @@ export const useProtocolListComputedStore = zCreate<ProtocolListComputedState>(
 );
 
 const rebuildComputedCaches = (protocolMap: ProtocolListMap) => {
-  const multiProtocolsCache: Record<string, ICacheProtocolItem> = {};
-  multiProtocolsCacheParams.forEach((params, key) => {
-    multiProtocolsCache[key] = computeMultiProtocols(
+  protocolEntityResourceStore.syncFromProtocolMap(protocolMap);
+
+  const multiProtocolsIndexCache: Record<string, ProtocolAssetsIndexResult> =
+    {};
+  multiProtocolsIndexCacheParams.forEach((params, key) => {
+    multiProtocolsIndexCache[key] = computeMultiProtocolsIndex(
       protocolMap,
       params.addresses,
       params.chainServerId,
     );
   });
 
-  const singleProtocolsCache: Record<string, ICacheProtocolItem> = {};
-  singleProtocolsCacheParams.forEach((params, key) => {
-    singleProtocolsCache[key] = computeSingleProtocols(
+  const singleProtocolsIndexCache: Record<string, ProtocolAssetsIndexResult> =
+    {};
+  singleProtocolsIndexCacheParams.forEach((params, key) => {
+    singleProtocolsIndexCache[key] = computeSingleProtocolsIndex(
       protocolMap,
       params.address.toLowerCase(),
       params.chainServerId,
@@ -481,12 +651,17 @@ const rebuildComputedCaches = (protocolMap: ProtocolListMap) => {
   });
 
   useProtocolListComputedStore.setState({
-    multiProtocolsCache,
-    singleProtocolsCache,
+    multiProtocolsIndexCache,
+    singleProtocolsIndexCache,
   });
 };
 
+let latestProtocolMap = useProtocolListStore.getState().protocolMap;
 useProtocolListStore.subscribe(state => {
+  if (state.protocolMap === latestProtocolMap) {
+    return;
+  }
+  latestProtocolMap = state.protocolMap;
   rebuildComputedCaches(state.protocolMap);
 });
 

--- a/apps/mobile/src/store/tokens.ts
+++ b/apps/mobile/src/store/tokens.ts
@@ -1,7 +1,7 @@
 import { getTop10MyAccounts } from '@/core/apis/account';
 import { queryTokensCache } from '@/core/apis/tokenCache';
 import { openapi } from '@/core/request';
-import { zCreate } from '@/core/utils/reexports';
+import { mCreate, zCreate } from '@/core/utils/reexports';
 import { TokenItemEntity } from '@/databases/entities/tokenitem';
 import { syncRemoteTokens } from '@/databases/sync/assets';
 import { defaultTokenFilter, lpTokenFilter } from '@/utils/lpToken';
@@ -406,14 +406,14 @@ const getTokenRuntimeGroupKey = (token: ITokenItem) =>
   (token as { groupKey?: string }).groupKey;
 
 const stripTokenRuntimeGroupFields = (token: ITokenItem): ITokenItem => {
-  const {
-    groupItems: _groupItems,
-    groupKey: _groupKey,
-    ...rest
-  } = token as ITokenItem & {
-    groupItems?: ITokenItem[];
-    groupKey?: string;
+  const rest = {
+    ...(token as ITokenItem & {
+      groupItems?: ITokenItem[];
+      groupKey?: string;
+    }),
   };
+  delete rest.groupItems;
+  delete rest.groupKey;
 
   return rest;
 };
@@ -1067,9 +1067,7 @@ const tokenListStore = zCreate<TokenListState>(set => ({
 }));
 
 type TokenListComputedState = {
-  multiAssetsCache: Record<string, TokenAssetsResult>;
   multiAssetsIndexCache: Record<string, TokenAssetsIndexResult>;
-  singleAssetsCache: Record<string, TokenAssetsResult>;
   singleAssetsIndexCache: Record<string, TokenAssetsIndexResult>;
   tokenSelectCache: Record<string, ITokenItem[]>;
   perpsTokenSelectCache: Record<string, ITokenItem[]>;
@@ -1095,7 +1093,7 @@ type TokenListComputedState = {
   registerChainSelector: (addresses: string[]) => string;
 };
 
-const multiAssetsCacheParams = new Map<
+const multiAssetsIndexCacheParams = new Map<
   string,
   {
     addresses: string[];
@@ -1104,7 +1102,7 @@ const multiAssetsCacheParams = new Map<
     tokenDisplayMode?: TokenDisplayMode;
   }
 >();
-const singleAssetsCacheParams = new Map<
+const singleAssetsIndexCacheParams = new Map<
   string,
   {
     address: string;
@@ -1123,24 +1121,25 @@ const tokenSelectCacheParams = new Map<
 >();
 const perpsTokenSelectCacheParams = new Map<string, { address: string }>();
 const chainSelectorCacheParams = new Map<string, { addresses: string[] }>();
-const multiAssetsCacheOrder: string[] = [];
-const singleAssetsCacheOrder: string[] = [];
+const multiAssetsIndexCacheOrder: string[] = [];
+const singleAssetsIndexCacheOrder: string[] = [];
 const tokenSelectCacheOrder: string[] = [];
 const perpsTokenSelectCacheOrder: string[] = [];
 const chainSelectorCacheOrder: string[] = [];
 
-const removeKeysFromCache = <T extends Record<string, unknown>>(
-  cache: T,
+const upsertRecordCache = <T>(
+  cache: Record<string, T>,
+  key: string,
+  value: T,
   keys: string[],
 ) => {
-  if (!keys.length) {
-    return cache;
-  }
-  const next = { ...cache };
-  keys.forEach(key => {
-    delete next[key];
+  return mCreate(cache, draft => {
+    const record = draft as Record<string, T>;
+    record[key] = value;
+    keys.forEach(removedKey => {
+      delete record[removedKey];
+    });
   });
-  return next;
 };
 
 const touchCacheParams = <T>(
@@ -1174,9 +1173,7 @@ const touchCacheParams = <T>(
 export const EMPTY_TOKEN_LIST = [];
 export const useTokenListComputedStore = zCreate<TokenListComputedState>(
   set => ({
-    multiAssetsCache: {},
     multiAssetsIndexCache: {},
-    singleAssetsCache: {},
     singleAssetsIndexCache: {},
     tokenSelectCache: {},
     perpsTokenSelectCache: {},
@@ -1194,8 +1191,8 @@ export const useTokenListComputedStore = zCreate<TokenListComputedState>(
         tokenDisplayMode,
       );
       const removedKeys = touchCacheParams(
-        multiAssetsCacheParams,
-        multiAssetsCacheOrder,
+        multiAssetsIndexCacheParams,
+        multiAssetsIndexCacheOrder,
         key,
         {
           addresses,
@@ -1207,31 +1204,17 @@ export const useTokenListComputedStore = zCreate<TokenListComputedState>(
       const tokenListMap = tokenListStore.getState().tokenListMap;
       tokenEntityResourceStore.syncFromTokenListMap(tokenListMap);
       set(state => ({
-        multiAssetsCache: removeKeysFromCache(
-          {
-            ...state.multiAssetsCache,
-            [key]: computeMultiAssets(
-              tokenListMap,
-              addresses,
-              chainServerId,
-              isLpTokenEnabled,
-              tokenDisplayMode,
-            ),
-          },
-          removedKeys,
-        ),
-        multiAssetsIndexCache: removeKeysFromCache(
-          {
-            ...state.multiAssetsIndexCache,
-            [key]: computeMultiAssetsIndex(
-              tokenListMap,
-              addresses,
-              chainServerId,
-              isLpTokenEnabled,
-              tokenDisplayMode,
-              key,
-            ),
-          },
+        multiAssetsIndexCache: upsertRecordCache(
+          state.multiAssetsIndexCache,
+          key,
+          computeMultiAssetsIndex(
+            tokenListMap,
+            addresses,
+            chainServerId,
+            isLpTokenEnabled,
+            tokenDisplayMode,
+            key,
+          ),
           removedKeys,
         ),
       }));
@@ -1244,8 +1227,8 @@ export const useTokenListComputedStore = zCreate<TokenListComputedState>(
         isLpTokenEnabled,
       );
       const removedKeys = touchCacheParams(
-        singleAssetsCacheParams,
-        singleAssetsCacheOrder,
+        singleAssetsIndexCacheParams,
+        singleAssetsIndexCacheOrder,
         key,
         {
           address,
@@ -1256,28 +1239,15 @@ export const useTokenListComputedStore = zCreate<TokenListComputedState>(
       const tokenListMap = tokenListStore.getState().tokenListMap;
       tokenEntityResourceStore.syncFromTokenListMap(tokenListMap);
       set(state => ({
-        singleAssetsCache: removeKeysFromCache(
-          {
-            ...state.singleAssetsCache,
-            [key]: computeSingleAssets(
-              tokenListMap,
-              address,
-              chainServerId,
-              isLpTokenEnabled,
-            ),
-          },
-          removedKeys,
-        ),
-        singleAssetsIndexCache: removeKeysFromCache(
-          {
-            ...state.singleAssetsIndexCache,
-            [key]: computeSingleAssetsIndex(
-              tokenListMap,
-              address,
-              chainServerId,
-              isLpTokenEnabled,
-            ),
-          },
+        singleAssetsIndexCache: upsertRecordCache(
+          state.singleAssetsIndexCache,
+          key,
+          computeSingleAssetsIndex(
+            tokenListMap,
+            address,
+            chainServerId,
+            isLpTokenEnabled,
+          ),
           removedKeys,
         ),
       }));
@@ -1303,17 +1273,16 @@ export const useTokenListComputedStore = zCreate<TokenListComputedState>(
       );
       const tokenListMap = tokenListStore.getState().tokenListMap;
       set(state => ({
-        tokenSelectCache: removeKeysFromCache(
-          {
-            ...state.tokenSelectCache,
-            [key]: computeTokenSelect(
-              tokenListMap,
-              addresses,
-              chainServerId,
-              keyword,
-              isLpTokenEnabled,
-            ),
-          },
+        tokenSelectCache: upsertRecordCache(
+          state.tokenSelectCache,
+          key,
+          computeTokenSelect(
+            tokenListMap,
+            addresses,
+            chainServerId,
+            keyword,
+            isLpTokenEnabled,
+          ),
           removedKeys,
         ),
       }));
@@ -1334,11 +1303,10 @@ export const useTokenListComputedStore = zCreate<TokenListComputedState>(
       );
       const tokenListMap = tokenListStore.getState().tokenListMap;
       set(state => ({
-        perpsTokenSelectCache: removeKeysFromCache(
-          {
-            ...state.perpsTokenSelectCache,
-            [key]: computePerpsTokenSelect(tokenListMap, address),
-          },
+        perpsTokenSelectCache: upsertRecordCache(
+          state.perpsTokenSelectCache,
+          key,
+          computePerpsTokenSelect(tokenListMap, address),
           removedKeys,
         ),
       }));
@@ -1356,11 +1324,10 @@ export const useTokenListComputedStore = zCreate<TokenListComputedState>(
       );
       const tokenListMap = tokenListStore.getState().tokenListMap;
       set(state => ({
-        chainSelectorCache: removeKeysFromCache(
-          {
-            ...state.chainSelectorCache,
-            [key]: computeChainSelector(tokenListMap, addresses),
-          },
+        chainSelectorCache: upsertRecordCache(
+          state.chainSelectorCache,
+          key,
+          computeChainSelector(tokenListMap, addresses),
           removedKeys,
         ),
       }));
@@ -1374,16 +1341,8 @@ const rebuildComputedCaches = (
 ) => {
   tokenEntityResourceStore.syncFromTokenListMap(tokenListMap);
 
-  const multiAssetsCache: Record<string, TokenAssetsResult> = {};
   const multiAssetsIndexCache: Record<string, TokenAssetsIndexResult> = {};
-  multiAssetsCacheParams.forEach((params, key) => {
-    multiAssetsCache[key] = computeMultiAssets(
-      tokenListMap,
-      params.addresses,
-      params.chainServerId,
-      params.isLpTokenEnabled,
-      params.tokenDisplayMode,
-    );
+  multiAssetsIndexCacheParams.forEach((params, key) => {
     multiAssetsIndexCache[key] = computeMultiAssetsIndex(
       tokenListMap,
       params.addresses,
@@ -1394,15 +1353,8 @@ const rebuildComputedCaches = (
     );
   });
 
-  const singleAssetsCache: Record<string, TokenAssetsResult> = {};
   const singleAssetsIndexCache: Record<string, TokenAssetsIndexResult> = {};
-  singleAssetsCacheParams.forEach((params, key) => {
-    singleAssetsCache[key] = computeSingleAssets(
-      tokenListMap,
-      params.address,
-      params.chainServerId,
-      params.isLpTokenEnabled,
-    );
+  singleAssetsIndexCacheParams.forEach((params, key) => {
     singleAssetsIndexCache[key] = computeSingleAssetsIndex(
       tokenListMap,
       params.address,
@@ -1439,9 +1391,7 @@ const rebuildComputedCaches = (
   });
 
   useTokenListComputedStore.setState({
-    multiAssetsCache,
     multiAssetsIndexCache,
-    singleAssetsCache,
     singleAssetsIndexCache,
     tokenSelectCache,
     perpsTokenSelectCache,

--- a/apps/mobile/src/store/tokens.ts
+++ b/apps/mobile/src/store/tokens.ts
@@ -18,6 +18,8 @@ import type {
   TokenDisplayMode,
 } from '@/types/assets';
 import PQueue from 'p-queue';
+import { ResourceBaseStore } from './_resourceBase';
+import type { ObservableResourceValueSource } from './_resourceFlow';
 
 export type { ITokenItem, TokenAssetsResult } from '@/types/assets';
 
@@ -181,6 +183,136 @@ export const getPerpsTokenSelectCacheKey = (address: string) =>
 
 export const getChainSelectorCacheKey = (addresses: string[]) =>
   getAddressesKey(addresses);
+
+export type TokenEntityId = string & {
+  readonly __tokenEntityId: unique symbol;
+};
+
+export type TokenAssetsIndexResult = {
+  unFoldTokenIds: TokenEntityId[];
+  foldTokenIds: TokenEntityId[];
+  scamTokenIds: TokenEntityId[];
+  scamTokenPreviewLogoUrls: string[];
+  foldCoreUsdValue: number;
+  hasFoldTokens: boolean;
+};
+
+const TOKEN_ENTITY_RESOURCE_FAMILY = 'token.entity';
+
+const createEmptyAssetsIndexResult = (): TokenAssetsIndexResult => ({
+  unFoldTokenIds: [],
+  foldTokenIds: [],
+  scamTokenIds: [],
+  scamTokenPreviewLogoUrls: [],
+  foldCoreUsdValue: 0,
+  hasFoldTokens: false,
+});
+
+export const buildTokenEntityId = (
+  token: Pick<ITokenItem, 'owner_addr' | 'chain' | 'id'>,
+): TokenEntityId =>
+  [
+    token.owner_addr.toLowerCase(),
+    token.chain.toLowerCase(),
+    token.id.toLowerCase(),
+  ].join(':') as TokenEntityId;
+
+const getTokenListFromTokenMap = (
+  tokenListMap: TokenListState['tokenListMap'],
+) => Object.values(tokenListMap).flat();
+
+class TokenEntityResourceStore extends ResourceBaseStore<ITokenItem> {
+  constructor() {
+    super(TOKEN_ENTITY_RESOURCE_FAMILY);
+  }
+
+  upsertTokens = (
+    tokens: ITokenItem[],
+    source: ObservableResourceValueSource = 'remote',
+  ) => {
+    if (!tokens.length) {
+      return;
+    }
+
+    const entries = new Map<TokenEntityId, ITokenItem>();
+    tokens.forEach(token => {
+      entries.set(buildTokenEntityId(token), token);
+    });
+
+    const now = Date.now();
+    this.setState(prev => {
+      let changed = false;
+      const valueMap = { ...prev.valueMap };
+      const metaMap = { ...prev.metaMap };
+
+      entries.forEach((token, tokenId) => {
+        const prevToken = prev.valueMap[tokenId];
+        const prevMeta = prev.metaMap[tokenId];
+        const isTokenChanged = prevToken !== token;
+
+        if (isTokenChanged) {
+          valueMap[tokenId] = token;
+          changed = true;
+        }
+
+        if (!prevMeta || isTokenChanged) {
+          metaMap[tokenId] = {
+            family: TOKEN_ENTITY_RESOURCE_FAMILY,
+            resourceKey: tokenId,
+            hasValue: true,
+            version: Math.max(prevMeta?.version || 0, 0) + 1,
+            sourceOfCurrentValue: source,
+            isHydrating: false,
+            isFetchingRemote: false,
+            persistStatus: prevMeta?.persistStatus || 'idle',
+            localTargets: prevMeta?.localTargets || [],
+            activeRemoteRequestId: undefined,
+            lastHydratedAt:
+              source === 'hydrate' ? now : prevMeta?.lastHydratedAt,
+            lastRemoteAt: source === 'remote' ? now : prevMeta?.lastRemoteAt,
+            lastPersistAt: prevMeta?.lastPersistAt,
+            lastError: prevMeta?.lastError,
+          };
+          changed = true;
+        }
+      });
+
+      return changed
+        ? {
+            valueMap,
+            metaMap,
+          }
+        : prev;
+    });
+  };
+
+  syncFromTokenListMap = (
+    tokenListMap: TokenListState['tokenListMap'],
+    source: ObservableResourceValueSource = 'remote',
+  ) => {
+    this.upsertTokens(getTokenListFromTokenMap(tokenListMap), source);
+  };
+}
+
+export const tokenEntityResourceStore = new TokenEntityResourceStore();
+
+export const useTokenEntity = (tokenId?: TokenEntityId) =>
+  tokenEntityResourceStore.useValue(tokenId);
+
+const buildTokenAssetsIndexResult = (
+  result: TokenAssetsResult,
+): TokenAssetsIndexResult => ({
+  unFoldTokenIds: result.unFoldTokens.map(buildTokenEntityId),
+  foldTokenIds: result.foldTokens.map(buildTokenEntityId),
+  scamTokenIds: result.scamTokens.map(buildTokenEntityId),
+  scamTokenPreviewLogoUrls: result.scamTokens
+    .slice(0, 3)
+    .map(token => token.logo_url),
+  foldCoreUsdValue: result.foldTokens
+    .filter(token => token.is_core)
+    .reduce((total, token) => total + (token.usd_value || 0), 0),
+  hasFoldTokens: result.hasFoldTokens,
+});
 
 type AggregatedTokenItem = ITokenItem & {
   groupKey: string;
@@ -358,6 +490,21 @@ const computeSingleAssets = (
         ),
         scamTokens: scamTokens.filter(i => lpTokenFilter(i, isLpTokenEnabled)),
       };
+};
+
+const computeSingleAssetsIndex = (
+  tokenListMap: TokenListState['tokenListMap'],
+  address: string,
+  chainServerId?: string,
+  isLpTokenEnabled?: boolean,
+): TokenAssetsIndexResult => {
+  if (!address) {
+    return createEmptyAssetsIndexResult();
+  }
+
+  return buildTokenAssetsIndexResult(
+    computeSingleAssets(tokenListMap, address, chainServerId, isLpTokenEnabled),
+  );
 };
 
 const computeTokenSelect = (
@@ -701,6 +848,7 @@ const tokenListStore = zCreate<TokenListState>(set => ({
 type TokenListComputedState = {
   multiAssetsCache: Record<string, TokenAssetsResult>;
   singleAssetsCache: Record<string, TokenAssetsResult>;
+  singleAssetsIndexCache: Record<string, TokenAssetsIndexResult>;
   tokenSelectCache: Record<string, ITokenItem[]>;
   perpsTokenSelectCache: Record<string, ITokenItem[]>;
   chainSelectorCache: Record<string, ITokenItem[]>;
@@ -806,6 +954,7 @@ export const useTokenListComputedStore = zCreate<TokenListComputedState>(
   set => ({
     multiAssetsCache: {},
     singleAssetsCache: {},
+    singleAssetsIndexCache: {},
     tokenSelectCache: {},
     perpsTokenSelectCache: {},
     chainSelectorCache: {},
@@ -867,11 +1016,24 @@ export const useTokenListComputedStore = zCreate<TokenListComputedState>(
         },
       );
       const tokenListMap = tokenListStore.getState().tokenListMap;
+      tokenEntityResourceStore.syncFromTokenListMap(tokenListMap);
       set(state => ({
         singleAssetsCache: removeKeysFromCache(
           {
             ...state.singleAssetsCache,
             [key]: computeSingleAssets(
+              tokenListMap,
+              address,
+              chainServerId,
+              isLpTokenEnabled,
+            ),
+          },
+          removedKeys,
+        ),
+        singleAssetsIndexCache: removeKeysFromCache(
+          {
+            ...state.singleAssetsIndexCache,
+            [key]: computeSingleAssetsIndex(
               tokenListMap,
               address,
               chainServerId,
@@ -972,6 +1134,8 @@ export const useTokenListComputedStore = zCreate<TokenListComputedState>(
 const rebuildComputedCaches = (
   tokenListMap: TokenListState['tokenListMap'],
 ) => {
+  tokenEntityResourceStore.syncFromTokenListMap(tokenListMap);
+
   const multiAssetsCache: Record<string, TokenAssetsResult> = {};
   multiAssetsCacheParams.forEach((params, key) => {
     multiAssetsCache[key] = computeMultiAssets(
@@ -984,8 +1148,15 @@ const rebuildComputedCaches = (
   });
 
   const singleAssetsCache: Record<string, TokenAssetsResult> = {};
+  const singleAssetsIndexCache: Record<string, TokenAssetsIndexResult> = {};
   singleAssetsCacheParams.forEach((params, key) => {
     singleAssetsCache[key] = computeSingleAssets(
+      tokenListMap,
+      params.address,
+      params.chainServerId,
+      params.isLpTokenEnabled,
+    );
+    singleAssetsIndexCache[key] = computeSingleAssetsIndex(
       tokenListMap,
       params.address,
       params.chainServerId,
@@ -1023,6 +1194,7 @@ const rebuildComputedCaches = (
   useTokenListComputedStore.setState({
     multiAssetsCache,
     singleAssetsCache,
+    singleAssetsIndexCache,
     tokenSelectCache,
     perpsTokenSelectCache,
     chainSelectorCache,

--- a/apps/mobile/src/store/tokens.ts
+++ b/apps/mobile/src/store/tokens.ts
@@ -188,7 +188,24 @@ export type TokenEntityId = string & {
   readonly __tokenEntityId: unique symbol;
 };
 
+export type TokenGroupId = string & {
+  readonly __tokenGroupId: unique symbol;
+};
+
+export type TokenAssetsIndexRow =
+  | {
+      type: 'token';
+      tokenId: TokenEntityId;
+    }
+  | {
+      type: 'group';
+      groupId: TokenGroupId;
+    };
+
 export type TokenAssetsIndexResult = {
+  unFoldRows: TokenAssetsIndexRow[];
+  foldRows: TokenAssetsIndexRow[];
+  scamRows: TokenAssetsIndexRow[];
   unFoldTokenIds: TokenEntityId[];
   foldTokenIds: TokenEntityId[];
   scamTokenIds: TokenEntityId[];
@@ -197,9 +214,20 @@ export type TokenAssetsIndexResult = {
   hasFoldTokens: boolean;
 };
 
+export type TokenGroupResourceValue = {
+  groupKey: string;
+  primaryTokenId: TokenEntityId;
+  memberTokenIds: TokenEntityId[];
+  summary: ITokenItem;
+};
+
 const TOKEN_ENTITY_RESOURCE_FAMILY = 'token.entity';
+const TOKEN_GROUP_RESOURCE_FAMILY = 'token.group';
 
 const createEmptyAssetsIndexResult = (): TokenAssetsIndexResult => ({
+  unFoldRows: [],
+  foldRows: [],
+  scamRows: [],
   unFoldTokenIds: [],
   foldTokenIds: [],
   scamTokenIds: [],
@@ -294,25 +322,194 @@ class TokenEntityResourceStore extends ResourceBaseStore<ITokenItem> {
   };
 }
 
+class TokenGroupResourceStore extends ResourceBaseStore<TokenGroupResourceValue> {
+  constructor() {
+    super(TOKEN_GROUP_RESOURCE_FAMILY);
+  }
+
+  upsertGroups = (
+    groups: Array<{ groupId: TokenGroupId; value: TokenGroupResourceValue }>,
+    source: ObservableResourceValueSource = 'remote',
+  ) => {
+    if (!groups.length) {
+      return;
+    }
+
+    const now = Date.now();
+    this.setState(prev => {
+      let changed = false;
+      const valueMap = { ...prev.valueMap };
+      const metaMap = { ...prev.metaMap };
+
+      groups.forEach(({ groupId, value }) => {
+        const prevValue = prev.valueMap[groupId];
+        const prevMeta = prev.metaMap[groupId];
+        const isValueChanged = prevValue !== value;
+
+        if (isValueChanged) {
+          valueMap[groupId] = value;
+          changed = true;
+        }
+
+        if (!prevMeta || isValueChanged) {
+          metaMap[groupId] = {
+            family: TOKEN_GROUP_RESOURCE_FAMILY,
+            resourceKey: groupId,
+            hasValue: true,
+            version: Math.max(prevMeta?.version || 0, 0) + 1,
+            sourceOfCurrentValue: source,
+            isHydrating: false,
+            isFetchingRemote: false,
+            persistStatus: prevMeta?.persistStatus || 'idle',
+            localTargets: prevMeta?.localTargets || [],
+            activeRemoteRequestId: undefined,
+            lastHydratedAt:
+              source === 'hydrate' ? now : prevMeta?.lastHydratedAt,
+            lastRemoteAt: source === 'remote' ? now : prevMeta?.lastRemoteAt,
+            lastPersistAt: prevMeta?.lastPersistAt,
+            lastError: prevMeta?.lastError,
+          };
+          changed = true;
+        }
+      });
+
+      return changed
+        ? {
+            valueMap,
+            metaMap,
+          }
+        : prev;
+    });
+  };
+}
+
 export const tokenEntityResourceStore = new TokenEntityResourceStore();
+export const tokenGroupResourceStore = new TokenGroupResourceStore();
 
 export const useTokenEntity = (tokenId?: TokenEntityId) =>
   tokenEntityResourceStore.useValue(tokenId);
 
+export const useTokenGroup = (groupId?: TokenGroupId) =>
+  tokenGroupResourceStore.useValue(groupId);
+
+export const getTokenAssetsIndexRowKey = (row: TokenAssetsIndexRow) => {
+  if (row.type === 'group') {
+    return `group-${row.groupId}`;
+  }
+  return `token-${row.tokenId}`;
+};
+
+const getTokenRuntimeGroupItems = (token: ITokenItem) =>
+  (token as { groupItems?: ITokenItem[] }).groupItems;
+
+const getTokenRuntimeGroupKey = (token: ITokenItem) =>
+  (token as { groupKey?: string }).groupKey;
+
+const stripTokenRuntimeGroupFields = (token: ITokenItem): ITokenItem => {
+  const {
+    groupItems: _groupItems,
+    groupKey: _groupKey,
+    ...rest
+  } = token as ITokenItem & {
+    groupItems?: ITokenItem[];
+    groupKey?: string;
+  };
+
+  return rest;
+};
+
+const buildTokenGroupId = (
+  listKey: string,
+  section: 'unfold' | 'fold' | 'scam',
+  token: ITokenItem,
+): TokenGroupId => {
+  const groupKey = getTokenRuntimeGroupKey(token) || buildTokenEntityId(token);
+  return `${listKey}::${section}::${groupKey}` as TokenGroupId;
+};
+
+const buildTokenAssetsIndexRows = (
+  tokens: ITokenItem[],
+  section: 'unfold' | 'fold' | 'scam',
+  listKey?: string,
+) => {
+  const groups: Array<{
+    groupId: TokenGroupId;
+    value: TokenGroupResourceValue;
+  }> = [];
+  const rows = tokens.map(token => {
+    const groupItems = getTokenRuntimeGroupItems(token);
+
+    if (listKey && groupItems?.length) {
+      const groupId = buildTokenGroupId(listKey, section, token);
+      const memberTokenIds = groupItems.map(buildTokenEntityId);
+      groups.push({
+        groupId,
+        value: {
+          groupKey: getTokenRuntimeGroupKey(token) || groupId,
+          primaryTokenId: buildTokenEntityId(token),
+          memberTokenIds,
+          summary: stripTokenRuntimeGroupFields(token),
+        },
+      });
+      return {
+        type: 'group',
+        groupId,
+      } satisfies TokenAssetsIndexRow;
+    }
+
+    return {
+      type: 'token',
+      tokenId: buildTokenEntityId(token),
+    } satisfies TokenAssetsIndexRow;
+  });
+
+  if (groups.length) {
+    const groupTokens = tokens.flatMap(token => {
+      return getTokenRuntimeGroupItems(token) || [];
+    });
+    tokenEntityResourceStore.upsertTokens(groupTokens);
+    tokenGroupResourceStore.upsertGroups(groups);
+  }
+
+  return rows;
+};
+
 const buildTokenAssetsIndexResult = (
   result: TokenAssetsResult,
-): TokenAssetsIndexResult => ({
-  unFoldTokenIds: result.unFoldTokens.map(buildTokenEntityId),
-  foldTokenIds: result.foldTokens.map(buildTokenEntityId),
-  scamTokenIds: result.scamTokens.map(buildTokenEntityId),
-  scamTokenPreviewLogoUrls: result.scamTokens
-    .slice(0, 3)
-    .map(token => token.logo_url),
-  foldCoreUsdValue: result.foldTokens
-    .filter(token => token.is_core)
-    .reduce((total, token) => total + (token.usd_value || 0), 0),
-  hasFoldTokens: result.hasFoldTokens,
-});
+  listKey?: string,
+): TokenAssetsIndexResult => {
+  const unFoldRows = buildTokenAssetsIndexRows(
+    result.unFoldTokens,
+    'unfold',
+    listKey,
+  );
+  const foldRows = buildTokenAssetsIndexRows(
+    result.foldTokens,
+    'fold',
+    listKey,
+  );
+  const scamRows = buildTokenAssetsIndexRows(
+    result.scamTokens,
+    'scam',
+    listKey,
+  );
+
+  return {
+    unFoldRows,
+    foldRows,
+    scamRows,
+    unFoldTokenIds: result.unFoldTokens.map(buildTokenEntityId),
+    foldTokenIds: result.foldTokens.map(buildTokenEntityId),
+    scamTokenIds: result.scamTokens.map(buildTokenEntityId),
+    scamTokenPreviewLogoUrls: result.scamTokens
+      .slice(0, 3)
+      .map(token => token.logo_url),
+    foldCoreUsdValue: result.foldTokens
+      .filter(token => token.is_core)
+      .reduce((total, token) => total + (token.usd_value || 0), 0),
+    hasFoldTokens: result.hasFoldTokens,
+  };
+};
 
 type AggregatedTokenItem = ITokenItem & {
   groupKey: string;
@@ -427,6 +624,30 @@ const computeMultiAssets = (
       lpTokenFilter(i, isLpTokenEnabled),
     ),
   };
+};
+
+const computeMultiAssetsIndex = (
+  tokenListMap: TokenListState['tokenListMap'],
+  addresses: string[],
+  chainServerId?: string,
+  isLpTokenEnabled?: boolean,
+  tokenDisplayMode?: TokenDisplayMode,
+  listKey?: string,
+): TokenAssetsIndexResult => {
+  if (!addresses.length) {
+    return createEmptyAssetsIndexResult();
+  }
+
+  return buildTokenAssetsIndexResult(
+    computeMultiAssets(
+      tokenListMap,
+      addresses,
+      chainServerId,
+      isLpTokenEnabled,
+      tokenDisplayMode,
+    ),
+    listKey,
+  );
 };
 
 const computeSingleAssets = (
@@ -847,6 +1068,7 @@ const tokenListStore = zCreate<TokenListState>(set => ({
 
 type TokenListComputedState = {
   multiAssetsCache: Record<string, TokenAssetsResult>;
+  multiAssetsIndexCache: Record<string, TokenAssetsIndexResult>;
   singleAssetsCache: Record<string, TokenAssetsResult>;
   singleAssetsIndexCache: Record<string, TokenAssetsIndexResult>;
   tokenSelectCache: Record<string, ITokenItem[]>;
@@ -953,6 +1175,7 @@ export const EMPTY_TOKEN_LIST = [];
 export const useTokenListComputedStore = zCreate<TokenListComputedState>(
   set => ({
     multiAssetsCache: {},
+    multiAssetsIndexCache: {},
     singleAssetsCache: {},
     singleAssetsIndexCache: {},
     tokenSelectCache: {},
@@ -982,6 +1205,7 @@ export const useTokenListComputedStore = zCreate<TokenListComputedState>(
         },
       );
       const tokenListMap = tokenListStore.getState().tokenListMap;
+      tokenEntityResourceStore.syncFromTokenListMap(tokenListMap);
       set(state => ({
         multiAssetsCache: removeKeysFromCache(
           {
@@ -992,6 +1216,20 @@ export const useTokenListComputedStore = zCreate<TokenListComputedState>(
               chainServerId,
               isLpTokenEnabled,
               tokenDisplayMode,
+            ),
+          },
+          removedKeys,
+        ),
+        multiAssetsIndexCache: removeKeysFromCache(
+          {
+            ...state.multiAssetsIndexCache,
+            [key]: computeMultiAssetsIndex(
+              tokenListMap,
+              addresses,
+              chainServerId,
+              isLpTokenEnabled,
+              tokenDisplayMode,
+              key,
             ),
           },
           removedKeys,
@@ -1137,6 +1375,7 @@ const rebuildComputedCaches = (
   tokenEntityResourceStore.syncFromTokenListMap(tokenListMap);
 
   const multiAssetsCache: Record<string, TokenAssetsResult> = {};
+  const multiAssetsIndexCache: Record<string, TokenAssetsIndexResult> = {};
   multiAssetsCacheParams.forEach((params, key) => {
     multiAssetsCache[key] = computeMultiAssets(
       tokenListMap,
@@ -1144,6 +1383,14 @@ const rebuildComputedCaches = (
       params.chainServerId,
       params.isLpTokenEnabled,
       params.tokenDisplayMode,
+    );
+    multiAssetsIndexCache[key] = computeMultiAssetsIndex(
+      tokenListMap,
+      params.addresses,
+      params.chainServerId,
+      params.isLpTokenEnabled,
+      params.tokenDisplayMode,
+      key,
     );
   });
 
@@ -1193,6 +1440,7 @@ const rebuildComputedCaches = (
 
   useTokenListComputedStore.setState({
     multiAssetsCache,
+    multiAssetsIndexCache,
     singleAssetsCache,
     singleAssetsIndexCache,
     tokenSelectCache,


### PR DESCRIPTION
## Summary
- move DeFi list rendering to lightweight protocol ids with row-level resource lookup
- add NFT entity/collection resource stores and index caches for single/multi address lists
- keep single-address NFT refresh side effects while removing parent-level full object list derivation

## Checks
- yarn workspace rabby-mobile eslint src/store/protocols.ts src/store/nfts.ts src/screens/Home/PortfolioList.tsx src/screens/Address/components/MultiAssets/ProtocolList.tsx src/screens/Home/NFTList.tsx src/screens/Address/components/MultiAssets/NFTList.tsx --ext .ts,.tsx
- git diff --check
- yarn workspace rabby-mobile typecheck (blocked by existing src/core/apis/keychainDebug.ts react-native-keychain type errors)
