### PR TITLE
fix: stabilize Android keychain diagnostics

### DIFF
--- a/apps/mobile/src/core/apis/keychain.ts
+++ b/apps/mobile/src/core/apis/keychain.ts
@@ -104,6 +104,7 @@ type KeychainBiometricsFailureDiagnostic = {
     androidAuthPromptPolicy?: unknown;
     androidAllowKeyStoreRecovery?: unknown;
     shouldAttachTrustedVaultKeyString?: unknown;
+    skipPostDecryptKeychainRewrite?: unknown;
   };
   debugStates: {
     current: SafeKeychainDebugState | null;
@@ -281,6 +282,8 @@ export async function requestGenericPassword(
           requestOptions.androidAllowKeyStoreRecovery,
         shouldAttachTrustedVaultKeyString:
           requestOptions.shouldAttachTrustedVaultKeyString,
+        skipPostDecryptKeychainRewrite:
+          requestOptions.skipPostDecryptKeychainRewrite,
       },
     });
     return await currentApi.requestGenericPassword(...args);
@@ -295,6 +298,8 @@ export async function requestGenericPassword(
           requestOptions.androidAllowKeyStoreRecovery,
         shouldAttachTrustedVaultKeyString:
           requestOptions.shouldAttachTrustedVaultKeyString,
+        skipPostDecryptKeychainRewrite:
+          requestOptions.skipPostDecryptKeychainRewrite,
       },
     });
 

--- a/apps/mobile/src/core/apis/keychainCommon.ts
+++ b/apps/mobile/src/core/apis/keychainCommon.ts
@@ -990,6 +990,7 @@ export function createBusinessKeychainApi({
     androidAllowKeyStoreRecovery = false,
     shouldAttachTrustedVaultKeyString = true,
     skipLegacyAndroidBiometricsStorageUpgrade = false,
+    skipPostDecryptKeychainRewrite = false,
   }: {
     purpose?: T;
     onPlainPassword?: (
@@ -1000,6 +1001,7 @@ export function createBusinessKeychainApi({
     androidAllowKeyStoreRecovery?: boolean;
     shouldAttachTrustedVaultKeyString?: boolean;
     skipLegacyAndroidBiometricsStorageUpgrade?: boolean;
+    skipPostDecryptKeychainRewrite?: boolean;
     skipCurrentVersionRewriteAfterLegacyFallback?: boolean;
   }): Promise<null | DefaultRet> {
     const instance = await waitInstance();
@@ -1012,6 +1014,7 @@ export function createBusinessKeychainApi({
         androidAuthPromptPolicy,
         androidAllowKeyStoreRecovery,
         shouldAttachTrustedVaultKeyString,
+        skipPostDecryptKeychainRewrite,
       });
       const keychainObject = (await keychainModule.getGenericPassword({
         ...DEFAULT_GET_OPTIONS,
@@ -1052,6 +1055,37 @@ export function createBusinessKeychainApi({
           hasEmbeddedVaultKeyString: !!decrypted.vaultKeyString,
         });
 
+        const maybeRewriteStoredCredentialsAfterDecrypt = async () => {
+          if (skipPostDecryptKeychainRewrite) {
+            traceAndroidKeychainPerf('post_decrypt_keychain_rewrite_skipped', {
+              elapsedMs: Date.now() - startedAt,
+              usedFallbackRabbitCode,
+              hasEmbeddedVaultKeyString: !!decrypted.vaultKeyString,
+            });
+            return;
+          }
+
+          if (usedFallbackRabbitCode) {
+            await silentlyUpgradeStoredPasswordPayload(
+              decrypted.password,
+              decrypted,
+            );
+          } else if (decrypted.vaultKeyString) {
+            await normalizeEmbeddedTrustedVaultKeyString(
+              decrypted.password,
+              decrypted,
+            );
+          } else if (!skipLegacyAndroidBiometricsStorageUpgrade) {
+            await upgradeLegacyAndroidBiometricsStorage(
+              decrypted.password,
+              typeof keychainObject.storage === 'string'
+                ? keychainObject.storage
+                : undefined,
+              decrypted,
+            );
+          }
+        };
+
         switch (purpose) {
           case RequestGenericPurpose.VERIFY: {
             const verifyResult =
@@ -1059,25 +1093,7 @@ export function createBusinessKeychainApi({
                 decrypted.password,
               );
             if (verifyResult.success) {
-              if (usedFallbackRabbitCode) {
-                await silentlyUpgradeStoredPasswordPayload(
-                  decrypted.password,
-                  decrypted,
-                );
-              } else if (decrypted.vaultKeyString) {
-                await normalizeEmbeddedTrustedVaultKeyString(
-                  decrypted.password,
-                  decrypted,
-                );
-              } else if (!skipLegacyAndroidBiometricsStorageUpgrade) {
-                await upgradeLegacyAndroidBiometricsStorage(
-                  decrypted.password,
-                  typeof keychainObject.storage === 'string'
-                    ? keychainObject.storage
-                    : undefined,
-                  decrypted,
-                );
-              }
+              await maybeRewriteStoredCredentialsAfterDecrypt();
             }
 
             onRequestReturn(instance);
@@ -1111,25 +1127,7 @@ export function createBusinessKeychainApi({
                 !!credentialsWithVaultKey.vaultKeyString,
             });
             apisLock.updateUnlockTime();
-            if (usedFallbackRabbitCode) {
-              await silentlyUpgradeStoredPasswordPayload(
-                decrypted.password,
-                decrypted,
-              );
-            } else if (decrypted.vaultKeyString) {
-              await normalizeEmbeddedTrustedVaultKeyString(
-                decrypted.password,
-                decrypted,
-              );
-            } else if (!skipLegacyAndroidBiometricsStorageUpgrade) {
-              await upgradeLegacyAndroidBiometricsStorage(
-                decrypted.password,
-                typeof keychainObject.storage === 'string'
-                  ? keychainObject.storage
-                  : undefined,
-                decrypted,
-              );
-            }
+            await maybeRewriteStoredCredentialsAfterDecrypt();
             onRequestReturn(instance);
             traceAndroidKeychainPerf('request_generic_password_end', {
               elapsedMs: Date.now() - startedAt,

--- a/apps/mobile/src/hooks/biometrics.ts
+++ b/apps/mobile/src/hooks/biometrics.ts
@@ -7,6 +7,7 @@ import {
   RequestGenericPurpose,
   isAuthenticatedByBiometrics,
   parseKeychainError,
+  type KeychainDebugState,
   type KeychainSupportedBiometryType,
 } from '@/core/apis/keychain';
 import { useTranslation } from 'react-i18next';
@@ -16,7 +17,7 @@ import {
 } from '@/core/apis/lock';
 import { Vibration } from 'react-native';
 import { IExtractFromPromise } from '@/utils/type';
-import { IS_IOS } from '@/core/native/utils';
+import { IS_ANDROID, IS_IOS } from '@/core/native/utils';
 import { zCreate } from '@/core/utils/reexports';
 import {
   resolveValFromUpdater,
@@ -24,6 +25,7 @@ import {
   UpdaterOrPartials,
 } from '@/core/utils/store';
 import { useShallow } from 'zustand/react/shallow';
+import { logger } from '@/utils/logger';
 
 type BiometricsInfoState = {
   authEnabled: boolean;
@@ -46,6 +48,78 @@ runIIFEFunc(() => {
     setBiometrics(prev => ({ ...prev, supportedBiometryType: supportedType }));
   });
 });
+
+function isPrimaryAndroidBiometricsEntryReady(state: KeychainDebugState) {
+  if (state.platform !== 'android' || !state.debugSupported) {
+    return true;
+  }
+
+  return state.hasEntry && state.hasUsername && state.hasPassword;
+}
+
+async function checkAndroidBiometricsEntryReady() {
+  if (!IS_ANDROID || !isAuthenticatedByBiometrics()) {
+    return true;
+  }
+
+  try {
+    const debugState = await apisKeychain.getKeychainDebugState();
+    const ready = isPrimaryAndroidBiometricsEntryReady(debugState);
+
+    if (!ready) {
+      logger.warn('[biometrics] Android keychain entry is unavailable', {
+        sourceLabel: debugState.sourceLabel,
+        hasEntry: debugState.hasEntry,
+        hasUsername: debugState.hasUsername,
+        hasPassword: debugState.hasPassword,
+        resolvedCipherStorageName:
+          debugState.platform === 'android'
+            ? debugState.resolvedCipherStorageName
+            : undefined,
+        hasKeystoreAlias:
+          debugState.platform === 'android'
+            ? debugState.hasKeystoreAlias
+            : undefined,
+      });
+    }
+
+    return ready;
+  } catch (error) {
+    logger.warn('[biometrics] failed to inspect Android keychain entry', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return true;
+  }
+}
+
+export function disableBiometricsForCurrentSession(reason: string) {
+  logger.warn('[biometrics] disabled for current session', { reason });
+  setBiometrics(prev => ({ ...prev, authEnabled: false }));
+}
+
+async function ensureBiometricsReadyForUnlock() {
+  let supportedType = null as KeychainSupportedBiometryType;
+  try {
+    supportedType = await apisKeychain.getSupportedBiometryType();
+  } catch (error) {
+    logger.warn('[biometrics] failed to fetch supported biometry type', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const enabledBySetting = isAuthenticatedByBiometrics();
+  const entryReady = await checkAndroidBiometricsEntryReady();
+  const nextAuthEnabled = enabledBySetting && !!supportedType && entryReady;
+
+  setBiometrics(prev => ({
+    ...prev,
+    supportedBiometryType:
+      supportedType || (nextAuthEnabled ? prev.supportedBiometryType : null),
+    authEnabled: nextAuthEnabled,
+  }));
+
+  return nextAuthEnabled;
+}
 
 export function useBiometricsComputed() {
   const authEnabled = biometricsInfoStore(s => s.authEnabled);
@@ -87,11 +161,14 @@ const fetchBiometrics = async () => {
     } catch (error) {
       console.error(error);
     }
+    const enabledBySetting = isAuthenticatedByBiometrics();
+    const entryReady = await checkAndroidBiometricsEntryReady();
+    const nextAuthEnabledByEntry = enabledBySetting && entryReady;
+
     setBiometrics(prev => {
       if (!didFetchSupportedType) {
         return prev;
       }
-      const nextAuthEnabled = isAuthenticatedByBiometrics();
       // if (prev.authEnabled && !supportedType) {
       //   toast.info(
       //     'Biometrics authentication disabled because no valid biometric data found.',
@@ -101,8 +178,12 @@ const fetchBiometrics = async () => {
         ...prev,
         supportedBiometryType:
           supportedType ||
-          (nextAuthEnabled ? prev.supportedBiometryType : null),
-        authEnabled: nextAuthEnabled,
+          (!IS_ANDROID && nextAuthEnabledByEntry
+            ? prev.supportedBiometryType
+            : null),
+        authEnabled:
+          nextAuthEnabledByEntry &&
+          !!(supportedType || (!IS_ANDROID && prev.supportedBiometryType)),
       };
     });
   } catch (error) {
@@ -173,6 +254,8 @@ const toggleBiometrics = async <T extends boolean>(
 export const storeApisBiometrics = {
   fetchBiometrics,
   toggleBiometrics,
+  disableBiometricsForCurrentSession,
+  ensureBiometricsReadyForUnlock,
 };
 
 export function useBiometrics(options?: { autoFetch?: boolean }) {

--- a/apps/mobile/src/screens/Testkits/DevDataKeychain.tsx
+++ b/apps/mobile/src/screens/Testkits/DevDataKeychain.tsx
@@ -1455,6 +1455,8 @@ export default function DevDataKeychain(): JSX.Element {
   const refreshState = useCallback(async () => {
     setIsLoading(true);
     try {
+      const canReadOfficialV10State =
+        !IS_ANDROID || currentKeychainVersion === '10.0.0';
       const [
         v8State,
         v9State,
@@ -1467,17 +1469,30 @@ export default function DevDataKeychain(): JSX.Element {
       ] = await Promise.all([
         apisKeychainV8_2_0.getKeychainDebugState(),
         apisKeychainV9_0_0.getKeychainDebugState(),
-        apisKeychainV10_0_0.getKeychainDebugState(),
-        apisKeychainDebug.getKeychainDebugState(
-          apisKeychainDebug.KEYCHAIN_DEFAULT_SERVICE,
-        ),
-        apisKeychainDebug.getKeychainDebugState(
-          apisKeychainDebug.KEYCHAIN_PROBE_SERVICE,
-        ),
+        canReadOfficialV10State
+          ? apisKeychainV10_0_0.getKeychainDebugState()
+          : Promise.resolve(null),
+        canReadOfficialV10State
+          ? apisKeychainDebug.getKeychainDebugState(
+              apisKeychainDebug.KEYCHAIN_DEFAULT_SERVICE,
+            )
+          : Promise.resolve(null),
+        canReadOfficialV10State
+          ? apisKeychainDebug.getKeychainDebugState(
+              apisKeychainDebug.KEYCHAIN_PROBE_SERVICE,
+            )
+          : Promise.resolve(null),
         apisKeychainV8_2_0.getSupportedStorageTypes(),
         apisKeychainV9_0_0.getSupportedStorageTypes(),
         apisKeychainV10_0_0.getSupportedStorageTypes(),
       ]);
+
+      if (!canReadOfficialV10State) {
+        logger.info(
+          '[keychain-debug] skipped official v10 state refresh to avoid Android DataStore migration',
+          { currentKeychainVersion },
+        );
+      }
 
       setBusinessStates(prev => ({
         ...prev,
@@ -1504,7 +1519,7 @@ export default function DevDataKeychain(): JSX.Element {
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [currentKeychainVersion]);
 
   useEffect(() => {
     refreshState();
@@ -1625,6 +1640,7 @@ export default function DevDataKeychain(): JSX.Element {
           purpose: apisKeychain.RequestGenericPurpose.DECRYPT_PWD,
           androidAuthPromptPolicy: policy,
           shouldAttachTrustedVaultKeyString: !IS_ANDROID,
+          skipPostDecryptKeychainRewrite: IS_ANDROID,
           onPlainPassword: (password, credentials) => {
             callbackCalled = true;
             decryptedPassword = password;
@@ -1749,6 +1765,7 @@ export default function DevDataKeychain(): JSX.Element {
       const requestResult = await apisKeychain.requestGenericPassword({
         purpose: apisKeychain.RequestGenericPurpose.DECRYPT_PWD,
         shouldAttachTrustedVaultKeyString: !IS_ANDROID,
+        skipPostDecryptKeychainRewrite: IS_ANDROID,
         onPlainPassword: password => {
           callbackCalled = true;
           decryptedPassword = password;

--- a/apps/mobile/src/screens/Unlock/Unlock.tsx
+++ b/apps/mobile/src/screens/Unlock/Unlock.tsx
@@ -35,6 +35,7 @@ import {
   APPLICATION_ID,
 } from '@/constant';
 import {
+  KEYCHAIN_ERROR_CODES,
   RequestGenericPurpose,
   isBrokenBiometricsEntryError,
   parseKeychainError,
@@ -210,6 +211,27 @@ function traceAndroidUnlockPerf(
 
   logger.info(`[RabbyUnlockPerf:unlock] ${event}`, data);
   console.info('[RabbyUnlockPerf:unlock]', event, data);
+}
+
+function shouldSwitchToPasswordAfterBiometricsError(error: unknown) {
+  if (isBrokenBiometricsEntryError(error)) {
+    return true;
+  }
+
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const code = 'code' in error ? error.code : undefined;
+  const message =
+    'message' in error && typeof error.message === 'string'
+      ? error.message
+      : '';
+
+  return (
+    code === KEYCHAIN_ERROR_CODES.NIL_KEYCHAIN_OBJECT ||
+    message.includes('Failed to retrieve keychain object')
+  );
 }
 
 export function BiometricsIcon(props: { isFaceID?: boolean; size?: number }) {
@@ -446,6 +468,7 @@ export default function UnlockScreen() {
         await apisKeychain.requestGenericPassword({
           purpose: RequestGenericPurpose.DECRYPT_PWD,
           shouldAttachTrustedVaultKeyString: !isAndroid,
+          skipPostDecryptKeychainRewrite: isAndroid,
           onPlainPassword: async (password, credentials) => {
             if (!isBiometricActionActive(actionId)) {
               hideAuthToastRef.current?.();
@@ -543,14 +566,15 @@ export default function UnlockScreen() {
 
         storeApisUnlock.resetUnlocking();
 
-        if (__DEV__ && incToReset() === 0) {
+        if (shouldSwitchToPasswordAfterBiometricsError(error)) {
+          storeApisBiometrics.disableBiometricsForCurrentSession(
+            'unlock-biometrics-keychain-unavailable',
+          );
           toastBiometricsFailed(t('page.unlock.biometrics.usePassword'));
           setUsingBiometrics(false);
-        } else if (error.code === 'NIL_KEYCHAIN_OBJECT') {
+        } else if (__DEV__ && incToReset() === 0) {
           toastBiometricsFailed(t('page.unlock.biometrics.usePassword'));
           setUsingBiometrics(false);
-        } else if (isBrokenBiometricsEntryError(error)) {
-          toastBiometricsFailed(error.message);
         } else {
           toastBiometricsFailed(t('page.unlock.biometrics.failedAndTipTitle'));
         }
@@ -591,9 +615,10 @@ export default function UnlockScreen() {
     ) {
       return;
     }
+
+    lockBiometricRef.current = true;
     const actionId = biometricActionIdRef.current + 1;
     biometricActionIdRef.current = actionId;
-    lockBiometricRef.current = true;
     const unlockBiometricsIfActive = () => {
       if (!isBiometricActionActive(actionId)) {
         return Promise.resolve();
@@ -605,6 +630,22 @@ export default function UnlockScreen() {
       lockBiometricRef.current = false;
     };
 
+    const biometricsReady = await storeApisBiometrics
+      .ensureBiometricsReadyForUnlock()
+      .catch(error => {
+        logger.warn('[unlock] biometrics readiness check failed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return false;
+      });
+    if (!biometricsReady) {
+      traceAndroidUnlockPerf('biometrics_not_ready_switch_to_password');
+      toastBiometricsFailed(t('page.unlock.biometrics.usePassword'));
+      setUsingBiometrics(false);
+      releaseBiometricLock();
+      return;
+    }
+
     if (!isFaceID && !isAndroid) {
       const hideToast = toastUnlocking();
       await unlockBiometricsIfActive().finally(() => {
@@ -614,7 +655,13 @@ export default function UnlockScreen() {
     } else {
       await unlockBiometricsIfActive().finally(releaseBiometricLock);
     }
-  }, [isFaceID, isBiometricActionActive, unlockWithBiometrics, checkUnlocked]);
+  }, [
+    isFaceID,
+    isBiometricActionActive,
+    unlockWithBiometrics,
+    checkUnlocked,
+    t,
+  ]);
 
   useLayoutEffect(() => {
     incToReset(true);


### PR DESCRIPTION
## Summary
- Skip official v10/DataStore keychain state reads on Android unless the active keychain version is v10, preventing debug-page refresh from migrating v9 `RN_KEYCHAIN` data.
- Keep Android unlock/debug verification paths from rewriting the primary keychain entry after decrypt.
- Make Android biometrics state fall back to password only when the primary entry is genuinely unavailable, while keeping transient failures non-destructive.

## Tests
- `corepack yarn workspace rabby-mobile typecheck`
- `DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged`
- `corepack yarn workspace rabby-mobile lint:cycles`
- `corepack yarn workspace rabby-mobile lint:cycles:eslint`
- `corepack yarn workspace rabby-mobile test --runInBand` failed in existing React Native renderHook tests with `actImplementation is not a function`; keychain test suites passed in the run.

## Manual validation
- Android regression package was validated on device: opening Keychain Data no longer breaks biometrics; both unlock-path debug buttons succeed.
