### PR TITLE
test: cover RN hooks and components

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -48,7 +48,7 @@
     "start:thrifty": "WITH_ROZENITE=true yarn start:dev:thrifty",
     "sync:data": "node ./scripts/sync.js",
     "syncrnversion": "./node_modules/.bin/react-native-version --never-amend --never-increment-build",
-    "test": "jest",
+    "test": "cross-env NODE_ENV=test BABEL_ENV=test jest",
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
     "vbundle:android": "react-native-bundle-visualizer --platform=android --entry-file=./index.js",
     "vbundle:ios": "react-native-bundle-visualizer --platform=ios --entry-file=./index.js",

--- a/apps/mobile/src/components/AddressViewer/CopyAddress.test.tsx
+++ b/apps/mobile/src/components/AddressViewer/CopyAddress.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import Clipboard from '@react-native-clipboard/clipboard';
+
+import { CopyAddressIcon, toastCopyAddressSuccess } from './CopyAddress';
+import { toast } from '@/components2024/Toast';
+
+jest.mock('@react-native-clipboard/clipboard', () => ({
+  setString: jest.fn(),
+}));
+
+jest.mock('@/components2024/Toast', () => ({
+  toast: {
+    success: jest.fn(),
+  },
+}));
+
+jest.mock('@/components/Typography', () => ({
+  Text: require('react-native').Text,
+}));
+
+jest.mock('@/hooks/theme', () => ({
+  useThemeStyles: () => ({
+    colors: {
+      'neutral-foot': '#999999',
+    },
+  }),
+}));
+
+jest.mock('i18next', () => ({
+  t: (key: string) => key,
+}));
+
+describe('CopyAddressIcon', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('copies the address and lets callers replace the success toast', () => {
+    const onToastSuccess = jest.fn();
+    const stopPropagation = jest.fn();
+
+    render(
+      <CopyAddressIcon
+        address="0xAbC"
+        onToastSuccess={onToastSuccess}
+        icon={() => <>{null}</>}
+        title="Copy"
+      />,
+    );
+
+    fireEvent.press(screen.getByText('Copy'), { stopPropagation });
+
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+    expect(Clipboard.setString).toHaveBeenCalledWith('0xAbC');
+    expect(onToastSuccess).toHaveBeenCalledWith({ address: '0xAbC' });
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it('does not stop propagation or toast when address is missing', () => {
+    const onToastSuccess = jest.fn();
+    const stopPropagation = jest.fn();
+
+    render(
+      <CopyAddressIcon
+        address={null}
+        onToastSuccess={onToastSuccess}
+        icon={() => <>{null}</>}
+        title="Copy"
+      />,
+    );
+
+    fireEvent.press(screen.getByText('Copy'), { stopPropagation });
+
+    expect(stopPropagation).not.toHaveBeenCalled();
+    expect(Clipboard.setString).not.toHaveBeenCalled();
+    expect(onToastSuccess).not.toHaveBeenCalled();
+  });
+});
+
+describe('toastCopyAddressSuccess', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses a simple copied toast when no hash-like string is provided', () => {
+    toastCopyAddressSuccess({ title: 'Copied account' });
+
+    expect(toast.success).toHaveBeenCalledWith('Copied account');
+  });
+
+  it('uses custom toast content when an address is provided', () => {
+    toastCopyAddressSuccess({
+      hashLikeString: '0xabc',
+      title: 'Copied address',
+    });
+
+    expect(toast.success).toHaveBeenCalledWith(expect.any(Function));
+  });
+});

--- a/apps/mobile/src/components/AddressViewer/index.test.tsx
+++ b/apps/mobile/src/components/AddressViewer/index.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { TouchableOpacity } from 'react-native';
+
+import { ellipsisAddress } from '@/utils/address';
+import { AddressViewer } from './index';
+
+jest.mock('@/components/Typography', () => ({
+  Text: require('react-native').Text,
+}));
+
+jest.mock('@/hooks/theme', () => ({
+  useThemeColors: () => ({
+    'neutral-foot': '#999999',
+  }),
+}));
+
+jest.mock('@/assets/icons/common/arrow-down-gray.svg', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+
+  return function MockArrow() {
+    return <Text testID="address-viewer-arrow">arrow</Text>;
+  };
+});
+
+describe('AddressViewer', () => {
+  const address = '0x1234567890ABCDEF1234567890ABCDEF12345678';
+
+  it('lowercases and ellipsizes the address by default', () => {
+    render(<AddressViewer address={address} />);
+
+    expect(
+      screen.getByText(ellipsisAddress(address.toLowerCase())),
+    ).toBeTruthy();
+    expect(screen.getByTestId('address-viewer-arrow')).toBeTruthy();
+  });
+
+  it('can render full address with index and no arrow', () => {
+    render(
+      <AddressViewer
+        address={address}
+        ellipsis={false}
+        showArrow={false}
+        showIndex
+        index={3}
+      />,
+    );
+
+    expect(screen.getByText(address.toLowerCase())).toBeTruthy();
+    expect(screen.getByText('3')).toBeTruthy();
+    expect(screen.queryByTestId('address-viewer-arrow')).toBeNull();
+  });
+
+  it('honors disabledPress', () => {
+    const onClick = jest.fn();
+    const { UNSAFE_getByType, rerender } = render(
+      <AddressViewer address={address} onClick={onClick} disabledPress />,
+    );
+
+    expect(UNSAFE_getByType(TouchableOpacity).props.disabled).toBe(true);
+
+    rerender(
+      <AddressViewer
+        address={address}
+        onClick={onClick}
+        disabledPress={false}
+      />,
+    );
+    expect(UNSAFE_getByType(TouchableOpacity).props.disabled).toBe(false);
+    expect(onClick).not.toHaveBeenCalled();
+
+    rerender(<AddressViewer address={address} onClick={onClick} />);
+    fireEvent.press(UNSAFE_getByType(TouchableOpacity));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/components/AutoShrinkAmountTextInput.test.tsx
+++ b/apps/mobile/src/components/AutoShrinkAmountTextInput.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+
+import {
+  AutoShrinkAmountText,
+  AutoShrinkAmountTextInput,
+} from './AutoShrinkAmountTextInput';
+
+jest.mock('@/components/Typography', () => {
+  const ReactNative = jest.requireActual('react-native');
+
+  return {
+    Text: ReactNative.Text,
+    TextInput: ReactNative.TextInput,
+  };
+});
+
+describe('AutoShrinkAmountTextInput', () => {
+  it('shrinks the input font size to the largest fitting step', () => {
+    render(
+      <AutoShrinkAmountTextInput
+        testID="amount-input"
+        value="123456"
+        style={{ fontSize: 28, height: 40 }}
+      />,
+    );
+    const input = screen.getByTestId('amount-input');
+    const measureText = screen.getByText('123456');
+
+    expect(StyleSheet.flatten(input.props.style).fontSize).toBe(28);
+
+    fireEvent(input, 'layout', {
+      nativeEvent: { layout: { width: 120 } },
+    });
+    fireEvent(measureText, 'textLayout', {
+      nativeEvent: { lines: [{ width: 150 }] },
+    });
+
+    expect(StyleSheet.flatten(input.props.style).fontSize).toBe(22);
+    expect(input.props.scrollEnabled).toBe(false);
+  });
+
+  it('keeps multiline input scroll behavior caller-controlled', () => {
+    render(
+      <AutoShrinkAmountTextInput
+        testID="amount-input"
+        multiline
+        scrollEnabled
+        value="123456"
+      />,
+    );
+
+    expect(screen.getByTestId('amount-input').props.scrollEnabled).toBe(true);
+  });
+
+  it('shrinks display text using the same measuring path', () => {
+    render(
+      <AutoShrinkAmountText
+        testID="amount-text"
+        style={{ fontSize: 28 }}
+        maxFontSize={28}
+        minFontSize={18}
+        fontSizeStep={2}>
+        123456
+      </AutoShrinkAmountText>,
+    );
+    const visibleText = screen.getByTestId('amount-text');
+    const [, measureText] = screen.getAllByText('123456');
+
+    fireEvent(visibleText, 'layout', {
+      nativeEvent: { layout: { width: 120 } },
+    });
+    fireEvent(measureText, 'textLayout', {
+      nativeEvent: { lines: [{ width: 150 }] },
+    });
+
+    expect(StyleSheet.flatten(visibleText.props.style).fontSize).toBe(22);
+  });
+});

--- a/apps/mobile/src/components/Button.test.tsx
+++ b/apps/mobile/src/components/Button.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import { Button, MiniButton, PrimaryButton } from './Button';
+
+jest.mock('@/hooks/theme', () => ({
+  useGetBinaryMode: () => 'light',
+  useThemeColors: () => ({
+    'blue-default': '#1677ff',
+    'blue-disable': '#9ec5ff',
+    'green-default': '#00aa66',
+    'neutral-bg1': '#ffffff',
+    'neutral-line': '#eeeeee',
+    'neutral-title2': '#111111',
+    'red-default': '#ff4444',
+  }),
+  useTheme2024: () => ({
+    styles: {
+      miniBtnTextView: {},
+      miniBtnView: {},
+    },
+  }),
+}));
+
+jest.mock('@/components/Text', () => ({
+  Text: require('react-native').Text,
+}));
+
+describe('Button', () => {
+  it('calls onPress when enabled', () => {
+    const onPress = jest.fn();
+
+    render(<Button title="Continue" onPress={onPress} testID="button" />);
+
+    fireEvent.press(screen.getByTestId('button'));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button')).toBeTruthy();
+  });
+
+  it('blocks onPress while loading and marks the button busy', () => {
+    const onPress = jest.fn();
+
+    render(
+      <Button
+        title="Continue"
+        loading
+        showTitleOnLoading
+        onPress={onPress}
+        testID="button"
+      />,
+    );
+
+    fireEvent.press(screen.getByTestId('button'));
+
+    expect(onPress).not.toHaveBeenCalled();
+    expect(screen.getByRole('button').props.accessibilityState).toEqual(
+      expect.objectContaining({ busy: true }),
+    );
+    expect(screen.getByText('Continue')).toBeTruthy();
+  });
+
+  it('blocks onPress when disabled and marks the button disabled', () => {
+    const onPress = jest.fn();
+
+    render(
+      <Button title="Continue" disabled onPress={onPress} testID="button" />,
+    );
+
+    fireEvent.press(screen.getByTestId('button'));
+
+    expect(onPress).not.toHaveBeenCalled();
+    expect(screen.getByRole('button').props.accessibilityState).toEqual(
+      expect.objectContaining({ disabled: true }),
+    );
+  });
+
+  it('keeps PrimaryButton and MiniButton press behavior wired', () => {
+    const primaryPress = jest.fn();
+    const miniPress = jest.fn();
+
+    render(
+      <>
+        <PrimaryButton
+          title="Primary"
+          onPress={primaryPress}
+          testID="primary"
+        />
+        <MiniButton onPress={miniPress} testID="mini">
+          Mini
+        </MiniButton>
+      </>,
+    );
+
+    fireEvent.press(screen.getByTestId('primary'));
+    fireEvent.press(screen.getByTestId('mini'));
+
+    expect(primaryPress).toHaveBeenCalledTimes(1);
+    expect(miniPress).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Primary')).toBeTruthy();
+    expect(screen.getByText('Mini')).toBeTruthy();
+  });
+});

--- a/apps/mobile/src/components/CustomTouchableOpacity.test.tsx
+++ b/apps/mobile/src/components/CustomTouchableOpacity.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+
+import {
+  CustomTouchableOpacity,
+  getViewComponentByAs,
+} from './CustomTouchableOpacity';
+
+jest.mock('react-native-gesture-handler', () => {
+  const ReactNative = jest.requireActual('react-native');
+
+  return {
+    Pressable: ReactNative.Pressable,
+    TouchableOpacity: ReactNative.TouchableOpacity,
+  };
+});
+
+function makeTouchEvent(x: number, y: number) {
+  return {
+    nativeEvent: {
+      pageX: x,
+      pageY: y,
+    },
+    preventDefault: jest.fn(),
+    isDefaultPrevented: jest.fn(() => false),
+  };
+}
+
+describe('CustomTouchableOpacity', () => {
+  it('uses the requested touchable implementation', () => {
+    const ReactNative = jest.requireActual('react-native');
+
+    expect(getViewComponentByAs()).toBe(ReactNative.TouchableOpacity);
+    expect(getViewComponentByAs('TouchableOpacity')).toBe(
+      ReactNative.TouchableOpacity,
+    );
+    expect(getViewComponentByAs('RNGHTouchableOpacity')).toBe(
+      ReactNative.TouchableOpacity,
+    );
+  });
+
+  it('calls press handlers for a stable tap', () => {
+    const onPress = jest.fn();
+    const onPressIn = jest.fn();
+    const onPressOut = jest.fn();
+    const { getByTestId } = render(
+      <CustomTouchableOpacity
+        testID="touchable"
+        onPress={onPress}
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
+      />,
+    );
+    const touchable = getByTestId('touchable');
+    const pressInEvent = makeTouchEvent(10, 10);
+    const pressOutEvent = makeTouchEvent(15, 19);
+
+    fireEvent(touchable, 'pressIn', pressInEvent);
+    fireEvent(touchable, 'pressOut', pressOutEvent);
+    fireEvent(touchable, 'press', pressOutEvent);
+
+    expect(onPressIn).toHaveBeenCalledWith(pressInEvent);
+    expect(onPressOut).toHaveBeenCalledWith(pressOutEvent);
+    expect(pressOutEvent.preventDefault).not.toHaveBeenCalled();
+    expect(onPress).toHaveBeenCalledWith(pressOutEvent);
+  });
+
+  it('prevents press after the finger moves outside the tap threshold', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <CustomTouchableOpacity testID="touchable" onPress={onPress} />,
+    );
+    const touchable = getByTestId('touchable');
+    const pressOutEvent = makeTouchEvent(25, 10);
+
+    fireEvent(touchable, 'pressIn', makeTouchEvent(10, 10));
+    fireEvent(touchable, 'pressOut', pressOutEvent);
+    pressOutEvent.isDefaultPrevented.mockReturnValue(true);
+    fireEvent(touchable, 'press', pressOutEvent);
+
+    expect(pressOutEvent.preventDefault).toHaveBeenCalled();
+    expect(onPress).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/components/Form/hooks.test.ts
+++ b/apps/mobile/src/components/Form/hooks.test.ts
@@ -1,0 +1,55 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-native';
+
+import { useInputBlurOnTouchaway } from './hooks';
+
+jest.mock('@/components/Typography', () => ({}));
+
+describe('useInputBlurOnTouchaway', () => {
+  it('blurs a single input ref when touchaway is emitted', () => {
+    const blur = jest.fn();
+    const inputRef = { current: { blur } };
+
+    const { result } = renderHook(() =>
+      useInputBlurOnTouchaway(inputRef as React.RefObject<any>),
+    );
+
+    result.current.onTouchInputAway();
+
+    expect(blur).toHaveBeenCalledTimes(1);
+  });
+
+  it('blurs every input in an input ref list', () => {
+    const firstBlur = jest.fn();
+    const secondBlur = jest.fn();
+    const refs = [
+      { current: { blur: firstBlur } },
+      { current: null },
+      { current: { blur: secondBlur } },
+    ];
+
+    const { result } = renderHook(() =>
+      useInputBlurOnTouchaway(refs as React.RefObject<any>[]),
+    );
+
+    result.current.onTouchInputAway();
+
+    expect(firstBlur).toHaveBeenCalledTimes(1);
+    expect(secondBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes listeners on unmount', () => {
+    const blur = jest.fn();
+    const inputRef = { current: { blur } };
+    const { result, unmount } = renderHook(() =>
+      useInputBlurOnTouchaway(inputRef as React.RefObject<any>),
+    );
+
+    const { onTouchInputAway } = result.current;
+
+    unmount();
+    onTouchInputAway();
+
+    expect(blur).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/components/PillsSwitch/PillsSwitch.test.tsx
+++ b/apps/mobile/src/components/PillsSwitch/PillsSwitch.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import { PillsSwitch } from './index';
+
+jest.mock('@/hooks/theme', () => ({
+  useThemeColors: () => ({
+    'blue-default': '#1677ff',
+    'neutral-bg-1': '#ffffff',
+    'neutral-body': '#333333',
+    'neutral-line': '#eeeeee',
+  }),
+}));
+
+jest.mock('@/components/Typography', () => ({
+  Text: require('react-native').Text,
+}));
+
+jest.mock('react-native-gesture-handler', () => ({
+  TouchableOpacity: require('react-native').TouchableOpacity,
+}));
+
+describe('PillsSwitch', () => {
+  const options = [
+    { key: 'tokens', label: 'Tokens' },
+    { key: 'nfts', label: 'NFTs' },
+  ] as const;
+
+  it('renders every option label', () => {
+    render(<PillsSwitch options={options} value="tokens" />);
+
+    expect(screen.getByText('Tokens')).toBeTruthy();
+    expect(screen.getByText('NFTs')).toBeTruthy();
+  });
+
+  it('calls onTabChange with the selected option key', () => {
+    const onTabChange = jest.fn();
+    render(
+      <PillsSwitch
+        options={options}
+        value="tokens"
+        onTabChange={onTabChange}
+      />,
+    );
+
+    fireEvent.press(screen.getByText('NFTs'));
+
+    expect(onTabChange).toHaveBeenCalledWith('nfts');
+  });
+
+  it('supports an empty option list without rendering labels', () => {
+    const { toJSON } = render(<PillsSwitch options={[]} />);
+
+    expect(toJSON()).toBeTruthy();
+    expect(screen.queryByText('Tokens')).toBeNull();
+  });
+});

--- a/apps/mobile/src/components/Switch/Switch.test.tsx
+++ b/apps/mobile/src/components/Switch/Switch.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { Animated } from 'react-native';
+
+import { RabbySwitch } from './Switch';
+
+jest.mock('@/components/Typography', () => ({
+  Text: require('react-native').Text,
+}));
+
+jest.mock('react-use/lib/usePrevious', () => () => undefined);
+
+describe('RabbySwitch', () => {
+  beforeEach(() => {
+    jest.spyOn(Animated, 'parallel').mockReturnValue({
+      start: (callback?: () => void) => callback?.(),
+      stop: jest.fn(),
+      reset: jest.fn(),
+    } as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders switch accessibility state from the controlled value', () => {
+    render(<RabbySwitch value testID="switch" />);
+
+    expect(screen.getByRole('switch').props.accessibilityState).toEqual(
+      expect.objectContaining({ checked: true }),
+    );
+  });
+
+  it('requests the opposite value when pressed', () => {
+    const onValueChange = jest.fn();
+    const onPress = jest.fn();
+
+    render(
+      <RabbySwitch
+        value={false}
+        onPress={onPress}
+        onValueChange={onValueChange}
+        testID="switch"
+      />,
+    );
+
+    fireEvent.press(screen.getByTestId('switch'));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenCalledWith(true);
+  });
+
+  it('does not request value changes while disabled', () => {
+    const onValueChange = jest.fn();
+
+    render(
+      <RabbySwitch
+        disabled
+        value={false}
+        onValueChange={onValueChange}
+        testID="switch"
+      />,
+    );
+
+    fireEvent.press(screen.getByTestId('switch'));
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('switch').props.accessibilityState).toEqual(
+      expect.objectContaining({
+        disabled: true,
+        checked: false,
+      }),
+    );
+  });
+
+  it('renders the active or inactive label from the controlled value', () => {
+    const { rerender } = render(
+      <RabbySwitch value activeText="Enabled" inActiveText="Disabled" />,
+    );
+
+    expect(screen.getByText('Enabled')).toBeTruthy();
+    expect(screen.queryByText('Disabled')).toBeNull();
+
+    rerender(
+      <RabbySwitch
+        value={false}
+        activeText="Enabled"
+        inActiveText="Disabled"
+      />,
+    );
+
+    expect(screen.getByText('Disabled')).toBeTruthy();
+    expect(screen.queryByText('Enabled')).toBeNull();
+  });
+});

--- a/apps/mobile/src/components/TruncatedText.test.tsx
+++ b/apps/mobile/src/components/TruncatedText.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react-native';
+
+import { TruncatedText } from './TruncatedText';
+
+jest.mock('@/components/Typography', () => {
+  const ReactNative = jest.requireActual('react-native');
+
+  return {
+    Text: ReactNative.Text,
+  };
+});
+
+describe('TruncatedText', () => {
+  let consoleLog: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    consoleLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    consoleLog.mockRestore();
+  });
+
+  it('reports non-truncated first layout and truncated repeated layout width', () => {
+    const onTextLayout = jest.fn();
+    const onTruncate = jest.fn();
+    const { getByText } = render(
+      <TruncatedText
+        numberOfLines={1}
+        text="Rabby Wallet"
+        onTextLayout={onTextLayout}
+        onTruncate={onTruncate}
+      />,
+    );
+    const text = getByText('Rabby Wallet');
+    const layoutEvent = {
+      nativeEvent: {
+        lines: [{ width: 120 }],
+      },
+    };
+
+    fireEvent(text, 'textLayout', layoutEvent);
+    fireEvent(text, 'textLayout', layoutEvent);
+
+    expect(onTextLayout).toHaveBeenCalledTimes(2);
+    expect(onTruncate).toHaveBeenNthCalledWith(1, false);
+    expect(onTruncate).toHaveBeenNthCalledWith(2, true);
+  });
+
+  it('re-runs the probe when text changes', () => {
+    const { getByText, rerender } = render(
+      <TruncatedText numberOfLines={1} text="First" />,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(10);
+    });
+    expect(getByText('First ')).toBeTruthy();
+
+    rerender(<TruncatedText numberOfLines={1} text="Second" />);
+    act(() => {
+      jest.advanceTimersByTime(10);
+    });
+
+    expect(getByText('Second ')).toBeTruthy();
+  });
+});

--- a/apps/mobile/src/hooks/tap.test.ts
+++ b/apps/mobile/src/hooks/tap.test.ts
@@ -1,0 +1,71 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useMultiPress } from './tap';
+
+describe('useMultiPress', () => {
+  let now = 0;
+  let dateNowSpy: jest.SpyInstance<number, []>;
+
+  beforeEach(() => {
+    now = 1000;
+    dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+  });
+
+  afterEach(() => {
+    dateNowSpy.mockRestore();
+  });
+
+  it('fires only after the required number of quick presses and then resets', () => {
+    const onMultiPress = jest.fn();
+    const { result } = renderHook(() =>
+      useMultiPress({
+        requiredPresses: 3,
+        timeout: 300,
+        onMultiPress,
+      }),
+    );
+
+    act(() => {
+      result.current.handlePress();
+      now += 100;
+      result.current.handlePress();
+    });
+    expect(onMultiPress).not.toHaveBeenCalled();
+
+    act(() => {
+      now += 100;
+      result.current.handlePress();
+    });
+    expect(onMultiPress).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      now += 100;
+      result.current.handlePress();
+    });
+    expect(onMultiPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('restarts the press count after the timeout window', () => {
+    const onMultiPress = jest.fn();
+    const { result } = renderHook(() =>
+      useMultiPress({
+        requiredPresses: 2,
+        timeout: 250,
+        onMultiPress,
+      }),
+    );
+
+    act(() => {
+      result.current.handlePress();
+      now += 251;
+      result.current.handlePress();
+    });
+    expect(onMultiPress).not.toHaveBeenCalled();
+
+    act(() => {
+      now += 100;
+      result.current.handlePress();
+    });
+    expect(onMultiPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/hooks/useAddressSource.test.ts
+++ b/apps/mobile/src/hooks/useAddressSource.test.ts
@@ -1,0 +1,157 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { KEYRING_CLASS, KEYRING_TYPE } from '@rabby-wallet/keyring-utils';
+
+import { apiMnemonic } from '@/core/apis';
+import { useAddressSource } from './useAddressSource';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => `t:${key}`,
+  }),
+}));
+
+jest.mock('@rabby-wallet/keyring-utils', () => ({
+  KEYRING_CLASS: {
+    GNOSIS: 'Gnosis Keyring',
+    HARDWARE: {
+      KEYSTONE: 'Keystone Hardware',
+      LEDGER: 'Ledger Hardware',
+      ONEKEY: 'OneKey Hardware',
+      TREZOR: 'Trezor Hardware',
+    },
+  },
+  KEYRING_TYPE: {
+    HdKeyring: 'HD Key Tree',
+    SimpleKeyring: 'Simple Key Pair',
+    WatchAddressKeyring: 'Watch Address',
+  },
+}));
+
+jest.mock('@/core/apis', () => ({
+  apiMnemonic: {
+    getMnemonicKeyringIfNeedPassphrase: jest.fn(),
+  },
+}));
+
+jest.mock('@/utils/walletInfo', () => ({
+  WALLET_INFO: {
+    Rabby: {
+      name: 'Rabby Wallet',
+    },
+  },
+}));
+
+const getMnemonicKeyringIfNeedPassphrase =
+  apiMnemonic.getMnemonicKeyringIfNeedPassphrase as jest.Mock;
+
+describe('useAddressSource', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses the imported HD source when needPassphrase is already known', () => {
+    const { result: imported } = renderHook(() =>
+      useAddressSource({
+        type: KEYRING_TYPE.HdKeyring,
+        brandName: '',
+        byImport: true,
+        needPassphrase: false,
+      }),
+    );
+    const { result: importedWithPassphrase } = renderHook(() =>
+      useAddressSource({
+        type: KEYRING_TYPE.HdKeyring,
+        brandName: '',
+        byImport: true,
+        needPassphrase: true,
+      }),
+    );
+
+    expect(imported.current).toBe('t:constant.IMPORTED_HD_KEYRING');
+    expect(importedWithPassphrase.current).toBe(
+      't:constant.IMPORTED_HD_KEYRING_NEED_PASSPHRASE',
+    );
+    expect(getMnemonicKeyringIfNeedPassphrase).not.toHaveBeenCalled();
+  });
+
+  it('updates imported HD source after async passphrase detection', async () => {
+    getMnemonicKeyringIfNeedPassphrase.mockResolvedValue(true);
+
+    const { result } = renderHook(() =>
+      useAddressSource({
+        type: KEYRING_TYPE.HdKeyring,
+        brandName: '',
+        byImport: true,
+        address: '0xabc',
+      }),
+    );
+
+    expect(result.current).toBe('t:constant.IMPORTED_HD_KEYRING');
+
+    await waitFor(() => {
+      expect(result.current).toBe(
+        't:constant.IMPORTED_HD_KEYRING_NEED_PASSPHRASE',
+      );
+    });
+    expect(getMnemonicKeyringIfNeedPassphrase).toHaveBeenCalledWith(
+      'address',
+      '0xabc',
+    );
+  });
+
+  it('keeps the imported HD fallback when async passphrase detection fails', async () => {
+    getMnemonicKeyringIfNeedPassphrase.mockRejectedValue(new Error('locked'));
+
+    const { result } = renderHook(() =>
+      useAddressSource({
+        type: KEYRING_TYPE.HdKeyring,
+        brandName: '',
+        byImport: true,
+        address: '0xabc',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(getMnemonicKeyringIfNeedPassphrase).toHaveBeenCalled();
+    });
+    expect(result.current).toBe('t:constant.IMPORTED_HD_KEYRING');
+  });
+
+  it('uses translated labels for built-in software keyrings', () => {
+    const { result: simple } = renderHook(() =>
+      useAddressSource({
+        type: KEYRING_TYPE.SimpleKeyring,
+        brandName: '',
+      }),
+    );
+    const { result: watch } = renderHook(() =>
+      useAddressSource({
+        type: KEYRING_TYPE.WatchAddressKeyring,
+        brandName: '',
+      }),
+    );
+
+    expect(simple.current).toBe('t:constant.KEYRING_TYPE_TEXT.SimpleKeyring');
+    expect(watch.current).toBe(
+      't:constant.KEYRING_TYPE_TEXT.WatchAddressKeyring',
+    );
+  });
+
+  it('falls back to static labels for hardware and safe keyrings', () => {
+    const { result: ledger } = renderHook(() =>
+      useAddressSource({
+        type: KEYRING_CLASS.HARDWARE.LEDGER,
+        brandName: '',
+      }),
+    );
+    const { result: safe } = renderHook(() =>
+      useAddressSource({
+        type: KEYRING_CLASS.GNOSIS,
+        brandName: '',
+      }),
+    );
+
+    expect(ledger.current).toBe('Imported by Ledger');
+    expect(safe.current).toBe('Imported by Safe');
+  });
+});

--- a/apps/mobile/src/hooks/useAppForeground.test.ts
+++ b/apps/mobile/src/hooks/useAppForeground.test.ts
@@ -1,0 +1,105 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useAppForeground } from './useAppForeground';
+
+const mockAddEventListener = jest.fn();
+let mockCurrentState = 'active';
+
+jest.mock('react-native', () => ({
+  AppState: {
+    get currentState() {
+      return mockCurrentState;
+    },
+    addEventListener: (...args: unknown[]) => mockAddEventListener(...args),
+  },
+}));
+
+describe('useAppForeground', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCurrentState = 'active';
+  });
+
+  it('calls the latest foreground callback after the app returns from background', () => {
+    const remove = jest.fn();
+    let listener: ((state: string) => void) | undefined;
+
+    mockAddEventListener.mockImplementation(
+      (event: string, nextListener: (state: string) => void) => {
+        listener = nextListener;
+        return { remove };
+      },
+    );
+
+    const firstCallback = jest.fn();
+    const secondCallback = jest.fn();
+    const { rerender, unmount } = renderHook(
+      ({ onForeground }) => useAppForeground({ onForeground }),
+      {
+        initialProps: { onForeground: firstCallback },
+      },
+    );
+
+    rerender({ onForeground: secondCallback });
+
+    act(() => {
+      listener?.('background');
+      listener?.('active');
+    });
+
+    expect(firstCallback).not.toHaveBeenCalled();
+    expect(secondCallback).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(mockAddEventListener).toHaveBeenCalledWith(
+      'change',
+      expect.any(Function),
+    );
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires once on mount-time active state when the app was already backgrounded', () => {
+    const onForeground = jest.fn();
+    let listener: ((state: string) => void) | undefined;
+    mockCurrentState = 'background';
+    mockAddEventListener.mockImplementation(
+      (_event: string, nextListener: (state: string) => void) => {
+        listener = nextListener;
+        return { remove: jest.fn() };
+      },
+    );
+
+    renderHook(() => useAppForeground({ onForeground }));
+
+    act(() => {
+      listener?.('active');
+      listener?.('active');
+    });
+
+    expect(onForeground).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not subscribe while disabled and resubscribes when enabled', () => {
+    const remove = jest.fn();
+    const onForeground = jest.fn();
+    mockAddEventListener.mockReturnValue({ remove });
+
+    const { rerender } = renderHook(
+      ({ enabled }) => useAppForeground({ enabled, onForeground }),
+      {
+        initialProps: { enabled: false },
+      },
+    );
+
+    expect(mockAddEventListener).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+
+    expect(mockAddEventListener).toHaveBeenCalledTimes(1);
+
+    rerender({ enabled: false });
+
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/hooks/useAppGesture.test.ts
+++ b/apps/mobile/src/hooks/useAppGesture.test.ts
@@ -1,0 +1,93 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-native';
+
+import { useHandleBackPressClosable } from './useAppGesture';
+
+const mockAddEventListener = jest.fn();
+
+jest.mock('react-native', () => ({
+  BackHandler: {
+    addEventListener: (...args: unknown[]) => mockAddEventListener(...args),
+  },
+}));
+
+describe('useHandleBackPressClosable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns true from the hardware handler when requestBack rejects closing', () => {
+    const remove = jest.fn();
+    let handler: (() => boolean) | undefined;
+    const requestBack = jest.fn(() => false);
+    mockAddEventListener.mockImplementation(
+      (event: string, nextHandler: () => boolean) => {
+        handler = nextHandler;
+        return { remove };
+      },
+    );
+
+    const { result } = renderHook(() =>
+      useHandleBackPressClosable(requestBack),
+    );
+    const dispose = result.current.onHardwareBackHandler();
+
+    expect(mockAddEventListener).toHaveBeenCalledWith(
+      'hardwareBackPress',
+      expect.any(Function),
+    );
+    expect(handler?.()).toBe(true);
+    expect(requestBack).toHaveBeenCalledTimes(1);
+
+    dispose();
+
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the ref value when deciding whether the hardware event can bubble', () => {
+    let handler: (() => boolean) | undefined;
+    const closableRef = React.createRef<boolean>();
+    closableRef.current = true;
+    mockAddEventListener.mockImplementation(
+      (_event: string, nextHandler: () => boolean) => {
+        handler = nextHandler;
+        return { remove: jest.fn() };
+      },
+    );
+
+    const { result } = renderHook(() =>
+      useHandleBackPressClosable(closableRef),
+    );
+
+    result.current.onHardwareBackHandler();
+
+    expect(handler?.()).toBe(false);
+
+    closableRef.current = false;
+
+    expect(handler?.()).toBe(true);
+  });
+
+  it('subscribes automatically when enabled and removes the listener when disabled', () => {
+    const remove = jest.fn();
+    mockAddEventListener.mockReturnValue({ remove });
+
+    const { rerender, unmount } = renderHook(
+      ({ autoEffectEnabled }) =>
+        useHandleBackPressClosable(() => true, { autoEffectEnabled }),
+      {
+        initialProps: { autoEffectEnabled: true },
+      },
+    );
+
+    expect(mockAddEventListener).toHaveBeenCalledTimes(1);
+
+    rerender({ autoEffectEnabled: false });
+
+    expect(remove).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/hooks/useCexSupportList.test.ts
+++ b/apps/mobile/src/hooks/useCexSupportList.test.ts
@@ -1,0 +1,88 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { openapi } from '@/core/request';
+import { getCexId } from '@/utils/addressCexId';
+import {
+  getCexInfo,
+  globalSupportCexList,
+  useCexSupportList,
+} from './useCexSupportList';
+
+jest.mock('react-native-haptic-feedback', () => ({
+  trigger: jest.fn(),
+}));
+
+const expectedSupportList = [
+  {
+    id: 'binance',
+    name: 'Binance',
+    logo_url: 'https://example.com/binance.png',
+  },
+  {
+    id: 'coinbase',
+    name: 'Coinbase',
+    logo_url: 'https://example.com/coinbase.png',
+  },
+];
+
+jest.mock('@/core/request', () => ({
+  openapi: {
+    getCexSupportList: jest.fn(() =>
+      Promise.resolve([
+        {
+          id: 'binance',
+          name: 'Binance',
+          logo_url: 'https://example.com/binance.png',
+        },
+        {
+          id: 'coinbase',
+          name: 'Coinbase',
+          logo_url: 'https://example.com/coinbase.png',
+        },
+      ]),
+    ),
+  },
+}));
+
+jest.mock('@/utils/addressCexId', () => ({
+  getCexId: jest.fn(),
+}));
+
+const getCexSupportList = openapi.getCexSupportList as jest.Mock;
+const getCexIdMock = getCexId as jest.Mock;
+
+describe('useCexSupportList', () => {
+  beforeEach(() => {
+    getCexIdMock.mockReset();
+  });
+
+  it('hydrates the hook store from openapi once the module side effect resolves', async () => {
+    const { result } = renderHook(() => useCexSupportList());
+
+    await waitFor(() => {
+      expect(result.current.list).toEqual(expectedSupportList);
+    });
+    expect(getCexSupportList).toHaveBeenCalledTimes(1);
+    expect(globalSupportCexList).toEqual(expectedSupportList);
+  });
+
+  it('resolves cex display info from cached support list and stored address mapping', async () => {
+    renderHook(() => useCexSupportList());
+
+    await waitFor(() => {
+      expect(globalSupportCexList.length).toBeGreaterThan(0);
+    });
+
+    getCexIdMock.mockReturnValue('coinbase');
+    expect(getCexInfo('0xABC')).toEqual({
+      id: 'coinbase',
+      name: 'Coinbase',
+      logo: 'https://example.com/coinbase.png',
+    });
+    expect(getCexIdMock).toHaveBeenCalledWith('0xABC');
+
+    getCexIdMock.mockReturnValue('missing');
+    expect(getCexInfo('0xABC')).toBeUndefined();
+    expect(getCexInfo('')).toBeUndefined();
+  });
+});

--- a/apps/mobile/src/hooks/useParseAddress.test.ts
+++ b/apps/mobile/src/hooks/useParseAddress.test.ts
@@ -1,0 +1,235 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { apiProvider } from '@/core/apis';
+import { openapi, testOpenapi } from '@/core/request';
+import { AddressType } from '@/utils/address';
+import {
+  useCheckAddressType,
+  useParseContractAddress,
+} from './useParseAddress';
+import { formatTxExplainAbiData } from '../utils/transaction';
+
+jest.mock('@/core/apis', () => ({
+  apiProvider: {
+    requestETHRpc: jest.fn(),
+    getRecommendNonce: jest.fn(),
+  },
+}));
+
+jest.mock('@/core/request', () => ({
+  openapi: {
+    preExecTx: jest.fn(),
+  },
+  testOpenapi: {
+    preExecTx: jest.fn(),
+  },
+}));
+
+jest.mock('@/constant', () => ({
+  INTERNAL_REQUEST_ORIGIN: 'rabby-internal',
+}));
+
+jest.mock('../utils/transaction', () => ({
+  formatTxExplainAbiData: jest.fn(() => 'transfer(address,uint256)'),
+}));
+
+const requestETHRpc = apiProvider.requestETHRpc as jest.Mock;
+const getRecommendNonce = apiProvider.getRecommendNonce as jest.Mock;
+const preExecTx = openapi.preExecTx as jest.Mock;
+const testnetPreExecTx = testOpenapi.preExecTx as jest.Mock;
+const formatAbi = formatTxExplainAbiData as jest.Mock;
+
+const account = {
+  address: '0x1111111111111111111111111111111111111111',
+  type: 'HD Key Tree',
+};
+const chain = {
+  id: 1,
+  enum: 'ETH',
+  serverId: 'eth',
+  network: '1',
+};
+
+describe('useParseAddress', () => {
+  const consoleError = console.error;
+  let consoleErrorMock: jest.SpyInstance;
+
+  beforeAll(() => {
+    consoleErrorMock = jest
+      .spyOn(console, 'error')
+      .mockImplementation((message, ...rest) => {
+        const text = [message, ...rest].map(item => String(item)).join(' ');
+        if (text.includes('not wrapped in act')) {
+          return;
+        }
+
+        consoleError(message, ...rest);
+      });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    consoleErrorMock.mockRestore();
+  });
+
+  describe('useCheckAddressType', () => {
+    it('classifies valid addresses as EOA or contract from eth_getCode', async () => {
+      requestETHRpc.mockResolvedValueOnce('0x');
+      const { result, rerender } = renderHook(
+        ({ addr }) => useCheckAddressType(addr, chain, account as never),
+        {
+          initialProps: {
+            addr: '0x2222222222222222222222222222222222222222',
+          },
+        },
+      );
+
+      await waitFor(() => {
+        expect(result.current.addressType).toBe(AddressType.EOA);
+      });
+      expect(requestETHRpc).toHaveBeenCalledWith(
+        {
+          method: 'eth_getCode',
+          params: ['0x2222222222222222222222222222222222222222', 'latest'],
+        },
+        'eth',
+        account,
+      );
+
+      requestETHRpc.mockResolvedValueOnce('0x60016001');
+      rerender({
+        addr: '0x3333333333333333333333333333333333333333',
+      });
+
+      await waitFor(() => {
+        expect(result.current.addressType).toBe(AddressType.CONTRACT);
+      });
+    });
+
+    it('returns UNKNOWN without RPC for missing chain or invalid address', async () => {
+      const { result } = renderHook(() =>
+        useCheckAddressType('not-an-address', chain, account as never),
+      );
+
+      await waitFor(() => {
+        expect(result.current.addressType).toBe(AddressType.UNKNOWN);
+      });
+      expect(requestETHRpc).not.toHaveBeenCalled();
+    });
+
+    it('falls back to UNKNOWN when eth_getCode fails', async () => {
+      requestETHRpc.mockRejectedValue(new Error('rpc down'));
+
+      const { result } = renderHook(() =>
+        useCheckAddressType(
+          '0x2222222222222222222222222222222222222222',
+          chain,
+          account as never,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(result.current.addressType).toBe(AddressType.UNKNOWN);
+      });
+    });
+  });
+
+  describe('useParseContractAddress', () => {
+    it('skips preExec when required inputs are missing', async () => {
+      const { result } = renderHook(() =>
+        useParseContractAddress({
+          contractAddress: '',
+          userAddress: account.address,
+          chain: chain as never,
+          inputDataHex: '0x1234',
+          account,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoadingExplain).toBe(false);
+      });
+      expect(result.current.explain).toBeNull();
+      expect(getRecommendNonce).not.toHaveBeenCalled();
+      expect(preExecTx).not.toHaveBeenCalled();
+    });
+
+    it('pre-executes mainnet contract calls and formats ABI plain text', async () => {
+      getRecommendNonce.mockResolvedValue('0x7');
+      preExecTx.mockResolvedValue({
+        abi: {
+          func: 'transfer',
+        },
+      });
+
+      const { result } = renderHook(() =>
+        useParseContractAddress({
+          contractAddress: '0x3333333333333333333333333333333333333333',
+          userAddress: account.address,
+          chain: chain as never,
+          inputDataHex: '0xa9059cbb',
+          account,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.contractCallPlainText).toBe(
+          'transfer(address,uint256)',
+        );
+      });
+      expect(getRecommendNonce).toHaveBeenCalledWith({
+        from: account.address,
+        chainId: 1,
+        account,
+      });
+      expect(preExecTx).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tx: expect.objectContaining({
+            chainId: 1,
+            from: account.address,
+            to: '0x3333333333333333333333333333333333333333',
+            data: '0xa9059cbb',
+            value: '0xa9059cbb',
+            nonce: '0x7',
+          }),
+          address: account.address,
+          updateNonce: false,
+        }),
+      );
+      expect(formatAbi).toHaveBeenCalledWith({ func: 'transfer' });
+    });
+
+    it('uses testOpenapi when parsing testnet contract calls', async () => {
+      getRecommendNonce.mockResolvedValue('0x8');
+      testnetPreExecTx.mockResolvedValue({
+        abi: {
+          func: 'approve',
+        },
+      });
+
+      const { result } = renderHook(() =>
+        useParseContractAddress(
+          {
+            contractAddress: '0x4444444444444444444444444444444444444444',
+            userAddress: account.address,
+            chain: { ...chain, id: 5, network: '5' } as never,
+            inputDataHex: '0x095ea7b3',
+            account,
+          },
+          { isTestnet: true },
+        ),
+      );
+
+      await waitFor(() => {
+        expect(result.current.contractCallPlainText).toBe(
+          'transfer(address,uint256)',
+        );
+      });
+      expect(testnetPreExecTx).toHaveBeenCalled();
+      expect(preExecTx).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/mobile/src/hooks/useTokenSettings.test.ts
+++ b/apps/mobile/src/hooks/useTokenSettings.test.ts
@@ -1,0 +1,138 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import { preferenceService } from '@/core/services';
+import {
+  getUserTokenSettingsInMemory,
+  useUserTokenSettings,
+} from './useTokenSettings';
+
+jest.mock('react-native-haptic-feedback', () => ({
+  trigger: jest.fn(),
+}));
+
+const mockMakeSettings = (
+  overrides: Partial<ReturnType<typeof getUserTokenSettingsInMemory>> = {},
+) => ({
+  foldTokens: [],
+  unfoldTokens: [],
+  includeDefiAndTokens: [],
+  excludeDefiAndTokens: [],
+  pinedQueue: [],
+  foldNfts: [],
+  unfoldNfts: [],
+  foldDefis: [],
+  unFoldDefis: [],
+  ...overrides,
+});
+
+let mockCurrentSettings = mockMakeSettings();
+
+jest.mock('@/core/services', () => ({
+  preferenceService: {
+    getUserTokenSettings: jest.fn(() => mockCurrentSettings),
+    pinToken: jest.fn(({ tokenId, chainId }) => {
+      mockCurrentSettings = mockMakeSettings({
+        ...mockCurrentSettings,
+        pinedQueue: [{ tokenId, chainId }],
+      });
+    }),
+    removePinedToken: jest.fn(({ tokenId, chainId }) => {
+      mockCurrentSettings = mockMakeSettings({
+        ...mockCurrentSettings,
+        pinedQueue: mockCurrentSettings.pinedQueue.filter(
+          item => item.tokenId !== tokenId || item.chainId !== chainId,
+        ),
+      });
+    }),
+  },
+}));
+
+const getUserTokenSettings =
+  preferenceService.getUserTokenSettings as jest.Mock;
+const pinToken = preferenceService.pinToken as jest.Mock;
+const removePinedToken = preferenceService.removePinedToken as jest.Mock;
+
+describe('useUserTokenSettings', () => {
+  beforeEach(() => {
+    mockCurrentSettings = mockMakeSettings();
+    jest.clearAllMocks();
+
+    const { result, unmount } = renderHook(() => useUserTokenSettings());
+    act(() => {
+      result.current.setUserTokenSettings(mockMakeSettings());
+    });
+    unmount();
+  });
+
+  it('preserves default buckets while applying partial store updates', () => {
+    mockCurrentSettings = mockMakeSettings({
+      pinedQueue: [{ tokenId: 'eth', chainId: 'eth' }],
+    });
+
+    const { result } = renderHook(() => useUserTokenSettings());
+
+    expect(result.current.userTokenSettings.pinedQueue).toEqual([]);
+
+    act(() => {
+      result.current.setUserTokenSettings({
+        pinedQueue: [{ tokenId: 'usdc', chainId: 'arb' }],
+      } as never);
+    });
+
+    expect(result.current.userTokenSettings.pinedQueue).toEqual([
+      { tokenId: 'usdc', chainId: 'arb' },
+    ]);
+    expect(result.current.userTokenSettings.foldTokens).toEqual([]);
+  });
+
+  it('fetches the latest persisted settings into the hook store', async () => {
+    const { result } = renderHook(() => useUserTokenSettings());
+
+    mockCurrentSettings = mockMakeSettings({
+      pinedQueue: [{ tokenId: 'dai', chainId: 'eth' }],
+      includeDefiAndTokens: ['dai'],
+    });
+
+    await act(async () => {
+      await result.current.fetchUserTokenSettings();
+    });
+
+    expect(getUserTokenSettings).toHaveBeenCalled();
+    expect(result.current.userTokenSettings.pinedQueue).toEqual([
+      { tokenId: 'dai', chainId: 'eth' },
+    ]);
+    expect(result.current.userTokenSettings.includeDefiAndTokens).toEqual([
+      'dai',
+    ]);
+  });
+
+  it('pins and unpins tokens through preferenceService and refreshes memory', async () => {
+    const { result } = renderHook(() => useUserTokenSettings());
+
+    act(() => {
+      result.current.pinToken({ id: 'usdt', chain: 'bsc' });
+    });
+
+    expect(pinToken).toHaveBeenCalledWith({
+      tokenId: 'usdt',
+      chainId: 'bsc',
+    });
+    await waitFor(() => {
+      expect(result.current.userTokenSettings.pinedQueue).toEqual([
+        { tokenId: 'usdt', chainId: 'bsc' },
+      ]);
+    });
+
+    act(() => {
+      result.current.removePinedToken({ id: 'usdt', chain: 'bsc' });
+    });
+
+    expect(removePinedToken).toHaveBeenCalledWith({
+      tokenId: 'usdt',
+      chainId: 'bsc',
+    });
+    await waitFor(() => {
+      expect(result.current.userTokenSettings.pinedQueue).toEqual([]);
+    });
+  });
+});

--- a/apps/mobile/src/hooks/useUsdInput.test.ts
+++ b/apps/mobile/src/hooks/useUsdInput.test.ts
@@ -1,0 +1,73 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useSlTpUsdInput, useUsdInput } from './useUsdInput';
+
+describe('useUsdInput', () => {
+  it('normalizes currency and comma decimal input', () => {
+    const { result } = renderHook(() => useUsdInput());
+
+    act(() => {
+      result.current.onChangeText('$12,34');
+    });
+
+    expect(result.current.value).toBe('12.34');
+    expect(result.current.displayedValue).toBe('$12.34');
+  });
+
+  it('keeps the last accepted value when input is invalid or too precise', () => {
+    const { result } = renderHook(() => useUsdInput({ maxDecimals: 2 }));
+
+    act(() => {
+      result.current.onChangeText('1.23');
+    });
+
+    expect(result.current.value).toBe('1.23');
+
+    act(() => {
+      result.current.onChangeText('1.234');
+    });
+
+    expect(result.current.value).toBe('1.23');
+
+    act(() => {
+      result.current.onChangeText('abc');
+    });
+
+    expect(result.current.value).toBe('1.23');
+  });
+});
+
+describe('useSlTpUsdInput', () => {
+  it('allows integer and trailing-dot values without significant-figure limits', () => {
+    const { result } = renderHook(() => useSlTpUsdInput({ szDecimals: 4 }));
+
+    act(() => {
+      result.current.onChangeText('$123456.');
+    });
+
+    expect(result.current.value).toBe('123456.');
+    expect(result.current.displayedValue).toBe('$123456.');
+  });
+
+  it('rejects prices that exceed stop-loss/take-profit precision rules', () => {
+    const { result } = renderHook(() => useSlTpUsdInput({ szDecimals: 4 }));
+
+    act(() => {
+      result.current.onChangeText('12.34');
+    });
+
+    expect(result.current.value).toBe('12.34');
+
+    act(() => {
+      result.current.onChangeText('12.345');
+    });
+
+    expect(result.current.value).toBe('12.34');
+
+    act(() => {
+      result.current.onChangeText('12345.6');
+    });
+
+    expect(result.current.value).toBe('12.34');
+  });
+});

--- a/apps/mobile/src/hooks/whitelist.test.ts
+++ b/apps/mobile/src/hooks/whitelist.test.ts
@@ -1,0 +1,217 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  contactService,
+  keyringService,
+  whitelistService,
+} from '@/core/services';
+import { AuthenticationModal } from '@/components/AuthenticationModal/AuthenticationModal';
+import { AuthenticationModal2024 } from '@/components/AuthenticationModal/AuthenticationModal2024';
+import { removeCexId } from '@/utils/addressCexId';
+import { isAddrInWhitelist, setWhitelist, useWhitelist } from './whitelist';
+
+type MockRecord = { address: string; addedAt?: number };
+
+let mockRecords: MockRecord[] = [];
+let mockWhitelistEnabled = false;
+
+jest.mock('react-native-haptic-feedback', () => ({
+  trigger: jest.fn(),
+}));
+
+jest.mock('@/components/AuthenticationModal/AuthenticationModal', () => ({
+  AuthenticationModal: {
+    show: jest.fn(({ onFinished }) => onFinished?.()),
+  },
+}));
+
+jest.mock('@/components/AuthenticationModal/AuthenticationModal2024', () => ({
+  AuthenticationModal2024: {
+    show: jest.fn(({ onFinished }) => onFinished?.()),
+  },
+}));
+
+jest.mock('@/core/apis', () => ({
+  apisLock: {
+    verifyPasswordOrUnlock: jest.fn(() => Promise.resolve(true)),
+  },
+}));
+
+jest.mock('@/core/services', () => ({
+  contactService: {
+    removeAlias: jest.fn(),
+  },
+  keyringService: {
+    hasAddress: jest.fn(() => Promise.resolve(false)),
+  },
+  whitelistService: {
+    addWhitelist: jest.fn((address: string) => {
+      mockRecords = [{ address: address.toLowerCase(), addedAt: 1 }];
+    }),
+    removeWhitelist: jest.fn((address: string) => {
+      mockRecords = mockRecords.filter(
+        item => item.address.toLowerCase() !== address.toLowerCase(),
+      );
+    }),
+    setWhitelist: jest.fn((addresses: string[]) => {
+      mockRecords = addresses.map((address, index) => ({
+        address,
+        addedAt: index + 1,
+      }));
+    }),
+    getWhitelistRecords: jest.fn(() => [...mockRecords]),
+    isWhitelistEnabled: jest.fn(() => Promise.resolve(mockWhitelistEnabled)),
+    enableWhitelist: jest.fn(() => {
+      mockWhitelistEnabled = true;
+      return Promise.resolve();
+    }),
+    disableWhiteList: jest.fn(() => {
+      mockWhitelistEnabled = false;
+      return Promise.resolve();
+    }),
+  },
+}));
+
+jest.mock('@rabby-wallet/base-utils', () => ({
+  addressUtils: {
+    isSameAddress: (a?: string, b?: string) => {
+      return !!a && !!b && a.toLowerCase() === b.toLowerCase();
+    },
+  },
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('i18next', () => ({
+  t: (key: string) => key,
+}));
+
+jest.mock('@/utils/addressCexId', () => ({
+  removeCexId: jest.fn(),
+}));
+
+const addWhitelist = whitelistService.addWhitelist as jest.Mock;
+const removeWhitelistService = whitelistService.removeWhitelist as jest.Mock;
+const setWhitelistService = whitelistService.setWhitelist as jest.Mock;
+const enableWhitelist = whitelistService.enableWhitelist as jest.Mock;
+const disableWhiteList = whitelistService.disableWhiteList as jest.Mock;
+const hasAddress = keyringService.hasAddress as jest.Mock;
+const removeAlias = contactService.removeAlias as jest.Mock;
+const removeCexIdMock = removeCexId as jest.Mock;
+const authenticationShow = AuthenticationModal.show as jest.Mock;
+const authentication2024Show = AuthenticationModal2024.show as jest.Mock;
+
+describe('whitelist hook', () => {
+  beforeEach(async () => {
+    mockRecords = [];
+    mockWhitelistEnabled = false;
+    jest.clearAllMocks();
+
+    await act(async () => {
+      await setWhitelist([]);
+    });
+  });
+
+  it('checks string and record whitelist entries case-insensitively', () => {
+    expect(
+      isAddrInWhitelist('0xABC', ['0xdef', { address: '0xabc', addedAt: 1 }]),
+    ).toBe(true);
+    expect(isAddrInWhitelist('', [{ address: '0xabc' }])).toBe(false);
+    expect(isAddrInWhitelist('0x123', [{ address: '0xabc' }])).toBe(false);
+  });
+
+  it('normalizes setWhitelist input and reflects it in hook state', async () => {
+    const { result } = renderHook(() =>
+      useWhitelist({ disableAutoFetch: true }),
+    );
+
+    await act(async () => {
+      await result.current.setWhitelist([
+        '0x1111111111111111111111111111111111111111',
+        '0x1111111111111111111111111111111111111111',
+        '0x2222222222222222222222222222222222222222'.toUpperCase(),
+      ]);
+    });
+
+    expect(setWhitelistService).toHaveBeenLastCalledWith([
+      '0x1111111111111111111111111111111111111111',
+      '0x2222222222222222222222222222222222222222',
+    ]);
+    expect(result.current.whitelist).toEqual([
+      '0x1111111111111111111111111111111111111111',
+      '0x2222222222222222222222222222222222222222',
+    ]);
+  });
+
+  it('adds an already validated address without showing the authentication modal', async () => {
+    const onAdded = jest.fn();
+    const { result } = renderHook(() =>
+      useWhitelist({ disableAutoFetch: true }),
+    );
+
+    await act(async () => {
+      await result.current.addWhitelist('0xABC', {
+        hasValidated: true,
+        onAdded,
+      });
+    });
+
+    expect(addWhitelist).toHaveBeenCalledWith('0xABC');
+    expect(authentication2024Show).not.toHaveBeenCalled();
+    expect(onAdded).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(result.current.isAddrOnWhitelist('0xabc')).toBe(true);
+    });
+  });
+
+  it('removes cex and contact metadata when no same address remains', async () => {
+    mockRecords = [{ address: '0xabc', addedAt: 1 }];
+    hasAddress.mockResolvedValue(false);
+    const { result } = renderHook(() =>
+      useWhitelist({ disableAutoFetch: true }),
+    );
+
+    await act(async () => {
+      await result.current.fetchWhitelist();
+    });
+    expect(result.current.whitelist).toEqual(['0xabc']);
+
+    await act(async () => {
+      await result.current.removeWhitelist('0xABC');
+    });
+
+    expect(removeWhitelistService).toHaveBeenCalledWith('0xABC');
+    expect(removeCexIdMock).toHaveBeenCalledWith('0xABC');
+    expect(removeAlias).toHaveBeenCalledWith('0xABC');
+    expect(result.current.whitelist).toEqual([]);
+  });
+
+  it('toggles whitelist enablement through the authentication modal', async () => {
+    const { result } = renderHook(() =>
+      useWhitelist({ disableAutoFetch: true }),
+    );
+
+    await act(async () => {
+      await result.current.toggleWhitelist(true);
+    });
+
+    expect(authenticationShow).toHaveBeenCalled();
+    expect(enableWhitelist).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(result.current.whitelistEnabled).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.toggleWhitelist(false);
+    });
+
+    expect(disableWhiteList).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(result.current.whitelistEnabled).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Summary
- Add focused Jest coverage for reusable mobile hooks and lightweight RN components.
- Cover address parsing/source, CEX/token settings, whitelist handling, app foreground/gesture hooks, multi-press detection, form helpers, switches, buttons, touchable wrapper, address viewer/copy, auto-shrinking amount text, and truncated text.
- Force NODE_ENV/BABEL_ENV=test for the mobile Jest script so React test utilities are stable under inherited shell envs.

Tested
- corepack yarn workspace rabby-mobile test --runInBand (101 suites, 549 tests)
- corepack yarn workspace rabby-mobile typecheck
- corepack yarn workspace rabby-mobile lint:cycles
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged