### PR TITLE
test: add Android device Maestro runners

### DIFF
--- a/apps/automation-maestro/README.md
+++ b/apps/automation-maestro/README.md
@@ -19,6 +19,7 @@ Currently verified shared utilities:
 Current first flow:
 
 - `flows/android-onboarding-import-private-key.yaml`
+
   - start from the welcome page
   - import via private key
   - set app password
@@ -26,10 +27,12 @@ Current first flow:
   - wait for single-address balance to render after success, then return to unlocked Home
 
 - `flows/android-onboarding-import-private-key-to-single-home.yaml`
+
   - same onboarding path, but it intentionally stops on single-address Home
   - this is the base flow for single-address balance smoke validation
 
 - `flows/ios-onboarding-import-private-key-to-single-home.yaml`
+
   - start from the welcome page on a booted iOS simulator
   - paste the first configured private key through the simulator system clipboard
   - use an iOS-specific submit point on the private-key page
@@ -38,12 +41,14 @@ Current first flow:
   - stop on single-address Home after success
 
 - `src/run-ios-onboarding-import-private-key.mjs`
+
   - require a booted iOS simulator
   - terminate the debug app, clear simulator app data, and reset the simulator keychain
   - write the first configured private key into the simulator pasteboard before launch
   - launch the app, then run the iOS onboarding flow end-to-end
 
 - `flows/android-home-balance-smoke.yaml`
+
   - preserve app data and relaunch
   - bootstrap from Welcome, Unlock, or Home
   - wait until Home portfolio balance exits the loading state
@@ -51,6 +56,7 @@ Current first flow:
   - toggle the Home curve once and then restore it
 
 - `src/run-android-single-home-balance-smoke.mjs`
+
   - clear app state and import the first configured private key
   - stop on single-address Home
   - on debug builds, validate balance / change / curve state through the DevTools bridge
@@ -58,12 +64,14 @@ Current first flow:
   - return to unlocked Home at the end of the debug validation chain
 
 - `src/run-android-balance-suite.mjs`
+
   - runs the current balance-focused debug regression chain in order
   - onboarding into single-address Home
   - relaunch and verify Home portfolio balance
   - add watch address and verify Home recovers afterward
 
 - `src/run-android-components2024-showcase-smoke.mjs`
+
   - preserve app data and relaunch
   - bootstrap from Welcome, Unlock, or Home
   - navigate from Home into Settings -> UI Playground -> 2024 Components
@@ -127,6 +135,26 @@ Send smoke:
 yarn workspace automation-maestro run:android-send-smoke
 ```
 
+Android device doctor:
+
+```bash
+yarn workspace automation-maestro doctor:android-device
+RABBY_MAESTRO_APP_ID=com.debank.rabbymobile.regression yarn workspace automation-maestro doctor:android-device --launch
+```
+
+Run one Android flow on the connected device while preserving app data:
+
+```bash
+RABBY_MAESTRO_APP_ID=com.debank.rabbymobile.regression yarn workspace automation-maestro run:android-device-flow --flow flows/android-home-ready-existing-user.yaml
+RABBY_MAESTRO_APP_ID=com.debank.rabbymobile.regression yarn workspace automation-maestro run:android-device-flow --flow flows/android-home-balance-smoke.yaml -- --include-tags smoke
+```
+
+Existing-user Android smoke:
+
+```bash
+RABBY_MAESTRO_APP_ID=com.debank.rabbymobile.regression yarn workspace automation-maestro run:android-existing-user-smoke
+```
+
 Multi-key run:
 
 - first key uses the onboarding flow above
@@ -151,6 +179,8 @@ yarn workspace automation-maestro run:android-onboarding-import-private-keys
   clears app data, and writes the first configured private key into the
   simulator pasteboard before launching the app
 - debug-package runners additionally connect to Metro DevTools and write bridge snapshots as JSON artifacts next to the Maestro HTML reports
+- `run:android-device-flow` is the generic connected-device runner for
+  preserving current app data while exercising one selected Android flow
 - local-only files such as `.env.local`, `.env.regression`, and `.artifacts/`
   are expected to stay untracked inside this package
 
@@ -257,31 +287,31 @@ Example:
 ```js
 export default {
   maestro: {
-    binary: "/Users/you/.maestro/bin/maestro"
+    binary: '/Users/you/.maestro/bin/maestro',
   },
   android: {
-    sharedFixtureFile: "flows.fixture.local.json",
+    sharedFixtureFile: 'flows.fixture.local.json',
     onboardingImportPrivateKey: {
-      packageName: "com.debank.rabbymobile.debug",
-      appPassword: "11111111",
+      packageName: 'com.debank.rabbymobile.debug',
+      appPassword: '11111111',
       launchActivity:
-        "com.debank.rabbymobile.debug/com.debank.rabbymobile.MainActivity"
+        'com.debank.rabbymobile.debug/com.debank.rabbymobile.MainActivity',
     },
     sendSmoke: {
-      fixtureFile: "flows.fixture.local.json"
+      fixtureFile: 'flows.fixture.local.json',
     },
     homeImportPrivateKey: {
-      flowFile: "flows/android-home-import-private-key.yaml"
-    }
+      flowFile: 'flows/android-home-import-private-key.yaml',
+    },
   },
   ios: {
     onboardingImportPrivateKey: {
-      bundleId: "com.debank.rabby-mobile-debug",
-      appPassword: "11111111",
-      flowFile: "flows/ios-onboarding-import-private-key.yaml",
+      bundleId: 'com.debank.rabby-mobile-debug',
+      appPassword: '11111111',
+      flowFile: 'flows/ios-onboarding-import-private-key.yaml',
       resetKeychain: true,
-      clearAppData: true
-    }
-  }
+      clearAppData: true,
+    },
+  },
 };
 ```

--- a/apps/automation-maestro/package.json
+++ b/apps/automation-maestro/package.json
@@ -6,6 +6,9 @@
     "node": ">=22"
   },
   "scripts": {
+    "doctor:android-device": "node src/doctor-android-device.mjs",
+    "run:android-device-flow": "node src/run-android-device-flow.mjs",
+    "run:android-existing-user-smoke": "node src/run-android-existing-user-smoke.mjs",
     "run:android-home-add-watch-address": "node src/run-android-home-add-watch-address.mjs",
     "run:android-home-balance-smoke": "node src/run-android-home-balance-smoke.mjs",
     "run:android-components2024-showcase-smoke": "node src/run-android-components2024-showcase-smoke.mjs",

--- a/apps/automation-maestro/src/doctor-android-device.mjs
+++ b/apps/automation-maestro/src/doctor-android-device.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { loadMaestroConfig, resolveMaestroFile } from './shared/config.mjs';
+import { loadLocalEnv } from './shared/env.mjs';
+import {
+  assertNodeVersion,
+  captureAdb,
+  ensureAndroidReady,
+  resolveAdbBinary,
+  resolveLaunchActivity,
+  resolveMaestroAppId,
+  resolveMaestroBinary,
+  runAdb,
+} from './shared/android.mjs';
+import { maestroRoot } from './shared/paths.mjs';
+import { capture, log, run } from './shared/process.mjs';
+
+function readFlagValue(name) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) {
+    return null;
+  }
+
+  const value = process.argv[index + 1]?.trim();
+  if (!value || value.startsWith('--')) {
+    throw new Error(`[maestro:doctor] ${name} requires a value`);
+  }
+
+  return value;
+}
+
+function hasFlag(name) {
+  return process.argv.includes(name);
+}
+
+function resolveAndroidFlowFiles(explicitFlowFile) {
+  if (explicitFlowFile) {
+    return [resolveMaestroFile(explicitFlowFile)];
+  }
+
+  const flowsDir = path.join(maestroRoot, 'flows');
+  return fs
+    .readdirSync(flowsDir)
+    .filter(fileName => fileName.startsWith('android-'))
+    .filter(fileName => fileName.endsWith('.yaml'))
+    .sort()
+    .map(fileName => path.join(flowsDir, fileName));
+}
+
+function assertInstalledPackage(adbBinary, packageName) {
+  const packagePath = captureAdb(adbBinary, [
+    'shell',
+    'pm',
+    'path',
+    packageName,
+  ]);
+
+  if (!packagePath) {
+    throw new Error(
+      `[maestro:doctor] package is not installed: ${packageName}`,
+    );
+  }
+
+  return packagePath.split('\n')[0];
+}
+
+async function main() {
+  assertNodeVersion();
+  loadLocalEnv();
+
+  const explicitPackageName = readFlagValue('--package');
+  if (explicitPackageName) {
+    process.env.RABBY_MAESTRO_APP_ID = explicitPackageName;
+  }
+
+  const shouldLaunch = hasFlag('--launch');
+  const shouldSkipSyntax = hasFlag('--skip-syntax');
+  const explicitFlowFile = readFlagValue('--flow');
+
+  const config = await loadMaestroConfig();
+  const packageName = resolveMaestroAppId({
+    fallback: config.android.onboardingImportPrivateKey.packageName,
+    platformEnvNames: [
+      'RABBY_ANDROID_E2E_PACKAGE',
+      'RABBY_ANDROID_DEBUG_PACKAGE',
+    ],
+  });
+
+  const adbBinary = resolveAdbBinary();
+  const maestroBin = resolveMaestroBinary(config);
+
+  log('maestro:doctor', `adb: ${adbBinary}`);
+  log('maestro:doctor', `maestro: ${maestroBin}`);
+  log('maestro:doctor', `package: ${packageName}`);
+
+  ensureAndroidReady(adbBinary);
+  log('maestro:doctor', captureAdb(adbBinary, ['devices', '-l']));
+
+  const packagePath = assertInstalledPackage(adbBinary, packageName);
+  log('maestro:doctor', `installed package path: ${packagePath}`);
+
+  const launchActivity = resolveLaunchActivity(adbBinary, packageName);
+  if (!launchActivity || launchActivity === 'No activity found') {
+    throw new Error(
+      `[maestro:doctor] unable to resolve launch activity for ${packageName}`,
+    );
+  }
+  log('maestro:doctor', `launch activity: ${launchActivity}`);
+
+  const maestroVersion = capture(maestroBin, ['--version']);
+  log('maestro:doctor', `maestro version: ${maestroVersion}`);
+
+  if (!shouldSkipSyntax) {
+    const flowFiles = resolveAndroidFlowFiles(explicitFlowFile);
+    log('maestro:doctor', `checking ${flowFiles.length} android flow(s)`);
+    for (const flowFile of flowFiles) {
+      if (!fs.existsSync(flowFile)) {
+        throw new Error(`[maestro:doctor] flow file not found: ${flowFile}`);
+      }
+      run(maestroBin, ['check-syntax', flowFile]);
+    }
+  }
+
+  if (shouldLaunch) {
+    log(
+      'maestro:doctor',
+      `Force-stopping ${packageName} while preserving data`,
+    );
+    runAdb(adbBinary, ['shell', 'am', 'force-stop', packageName], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+
+    log('maestro:doctor', `Launching ${launchActivity}`);
+    runAdb(adbBinary, ['shell', 'am', 'start', '-W', '-n', launchActivity], {
+      stdio: 'inherit',
+    });
+  }
+
+  log('maestro:doctor', 'Android device doctor passed');
+}
+
+main().catch(error => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/apps/automation-maestro/src/run-android-device-flow.mjs
+++ b/apps/automation-maestro/src/run-android-device-flow.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { loadMaestroConfig, resolveMaestroFile } from './shared/config.mjs';
+import { loadLocalEnv } from './shared/env.mjs';
+import {
+  assertNodeVersion,
+  ensureAndroidReady,
+  ensureOutputDir,
+  formatRunId,
+  launchActivity as launchAndroidActivity,
+  resolveAdbBinary,
+  resolveArtifactRootDir,
+  resolveLaunchActivity,
+  resolveMaestroAppId,
+  resolveMaestroAppPassword,
+  resolveMaestroBinary,
+  runAdb,
+  runMaestroFlow,
+} from './shared/android.mjs';
+import { log } from './shared/process.mjs';
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+function parseArgs(argv) {
+  const passthroughIndex = argv.indexOf('--');
+  const ownArgs =
+    passthroughIndex === -1 ? argv : argv.slice(0, passthroughIndex);
+  const forwardedArgs =
+    passthroughIndex === -1 ? [] : argv.slice(passthroughIndex + 1);
+
+  const result = {
+    flow: null,
+    packageName: null,
+    skipLaunch: false,
+    waitMs: 5000,
+    forwardedArgs,
+  };
+
+  for (let index = 0; index < ownArgs.length; index += 1) {
+    const arg = ownArgs[index];
+
+    if (arg === '--flow') {
+      result.flow = ownArgs[index + 1]?.trim();
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--package') {
+      result.packageName = ownArgs[index + 1]?.trim();
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--wait-ms') {
+      result.waitMs = Number(ownArgs[index + 1]);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--no-launch') {
+      result.skipLaunch = true;
+      continue;
+    }
+
+    result.forwardedArgs.push(arg);
+  }
+
+  if (!result.flow) {
+    throw new Error('[maestro:android-device-flow] --flow <file> is required');
+  }
+
+  if (!Number.isFinite(result.waitMs) || result.waitMs < 0) {
+    throw new Error('[maestro:android-device-flow] --wait-ms must be >= 0');
+  }
+
+  return result;
+}
+
+function flowArtifactName(flowFile) {
+  return path.basename(flowFile).replace(/\.ya?ml$/i, '');
+}
+
+async function main() {
+  assertNodeVersion();
+  loadLocalEnv();
+
+  const args = parseArgs(process.argv.slice(2));
+  if (args.packageName) {
+    process.env.RABBY_MAESTRO_APP_ID = args.packageName;
+  }
+
+  const config = await loadMaestroConfig();
+  const onboardingConfig = config.android.onboardingImportPrivateKey;
+  const maestroBin = resolveMaestroBinary(config);
+  const adbBinary = resolveAdbBinary();
+
+  const packageName = resolveMaestroAppId({
+    fallback: onboardingConfig.packageName,
+    platformEnvNames: [
+      'RABBY_ANDROID_E2E_PACKAGE',
+      'RABBY_ANDROID_DEBUG_PACKAGE',
+    ],
+  });
+  const appPassword = resolveMaestroAppPassword({
+    fallback: onboardingConfig.appPassword,
+    platformEnvNames: [
+      'RABBY_ANDROID_APP_PASSWORD',
+      'RABBY_ANDROID_DEBUG_PASSWORD',
+    ],
+  });
+
+  const flowFile = resolveMaestroFile(args.flow);
+  if (!fs.existsSync(flowFile)) {
+    throw new Error(
+      `[maestro:android-device-flow] flow file not found: ${flowFile}`,
+    );
+  }
+
+  ensureAndroidReady(adbBinary);
+
+  const launchActivity = resolveLaunchActivity(
+    adbBinary,
+    packageName,
+    onboardingConfig.launchActivity,
+  );
+  if (
+    !args.skipLaunch &&
+    (!launchActivity || launchActivity === 'No activity found')
+  ) {
+    throw new Error(
+      `[maestro:android-device-flow] unable to resolve launch activity for ${packageName}`,
+    );
+  }
+
+  const outputDir = path.join(
+    resolveArtifactRootDir(),
+    'maestro',
+    'android-device-flow',
+    flowArtifactName(flowFile),
+    formatRunId(),
+  );
+  ensureOutputDir(outputDir);
+
+  if (!args.skipLaunch) {
+    log(
+      'maestro:android-device-flow',
+      `Force-stopping ${packageName} while preserving app data`,
+    );
+    runAdb(adbBinary, ['shell', 'am', 'force-stop', packageName], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+
+    log('maestro:android-device-flow', `Launching ${launchActivity}`);
+    launchAndroidActivity(adbBinary, launchActivity);
+    log(
+      'maestro:android-device-flow',
+      `Waiting ${args.waitMs}ms before starting Maestro`,
+    );
+    await sleep(args.waitMs);
+  } else {
+    log(
+      'maestro:android-device-flow',
+      'Skipping launch. Current device app state will be used as-is.',
+    );
+  }
+
+  log('maestro:android-device-flow', `Flow: ${flowFile}`);
+  log('maestro:android-device-flow', `Artifacts: ${outputDir}`);
+  log(
+    'maestro:android-device-flow',
+    'App data is preserved. Use onboarding flows only when the current app state matches them.',
+  );
+
+  runMaestroFlow({
+    maestroBin,
+    flowFile,
+    outputDir,
+    reportBasename: 'report',
+    packageName,
+    appPassword,
+    maestroEnv: config.maestro.env,
+    forwardedArgs: args.forwardedArgs,
+  });
+
+  log(
+    'maestro:android-device-flow',
+    `Completed. Report: ${path.join(outputDir, 'report.html')}`,
+  );
+}
+
+main().catch(error => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/apps/automation-maestro/src/run-android-existing-user-smoke.mjs
+++ b/apps/automation-maestro/src/run-android-existing-user-smoke.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { loadMaestroConfig, resolveMaestroFile } from './shared/config.mjs';
+import { loadLocalEnv } from './shared/env.mjs';
+import {
+  assertNodeVersion,
+  ensureAndroidReady,
+  ensureOutputDir,
+  formatRunId,
+  launchActivity as launchAndroidActivity,
+  resolveAdbBinary,
+  resolveArtifactRootDir,
+  resolveLaunchActivity,
+  resolveMaestroAppId,
+  resolveMaestroAppPassword,
+  resolveMaestroBinary,
+  runAdb,
+  runMaestroFlow,
+} from './shared/android.mjs';
+import { log } from './shared/process.mjs';
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+async function main() {
+  assertNodeVersion();
+  loadLocalEnv();
+
+  const config = await loadMaestroConfig();
+  const onboardingConfig = config.android.onboardingImportPrivateKey;
+  const maestroBin = resolveMaestroBinary(config);
+  const adbBinary = resolveAdbBinary();
+
+  const packageName = resolveMaestroAppId({
+    fallback: onboardingConfig.packageName,
+    platformEnvNames: [
+      'RABBY_ANDROID_E2E_PACKAGE',
+      'RABBY_ANDROID_DEBUG_PACKAGE',
+    ],
+  });
+  const appPassword = resolveMaestroAppPassword({
+    fallback: onboardingConfig.appPassword,
+    platformEnvNames: [
+      'RABBY_ANDROID_APP_PASSWORD',
+      'RABBY_ANDROID_DEBUG_PASSWORD',
+    ],
+  });
+
+  const flowFile = resolveMaestroFile(
+    'flows/android-home-ready-existing-user.yaml',
+  );
+  if (!fs.existsSync(flowFile)) {
+    throw new Error(`[maestro:existing-user] flow file not found: ${flowFile}`);
+  }
+
+  ensureAndroidReady(adbBinary);
+  const launchActivity = resolveLaunchActivity(
+    adbBinary,
+    packageName,
+    onboardingConfig.launchActivity,
+  );
+
+  if (!launchActivity || launchActivity === 'No activity found') {
+    throw new Error(
+      `[maestro:existing-user] unable to resolve launch activity for ${packageName}`,
+    );
+  }
+
+  const outputDir = path.join(
+    resolveArtifactRootDir(),
+    'maestro',
+    'android-existing-user-smoke',
+    formatRunId(),
+  );
+  ensureOutputDir(outputDir);
+
+  log(
+    'maestro:existing-user',
+    `Force-stopping ${packageName} while preserving app data`,
+  );
+  runAdb(adbBinary, ['shell', 'am', 'force-stop', packageName], {
+    stdio: ['ignore', 'ignore', 'pipe'],
+  });
+
+  log('maestro:existing-user', `Launching ${launchActivity}`);
+  launchAndroidActivity(adbBinary, launchActivity);
+  log('maestro:existing-user', 'Waiting 5s before starting Maestro');
+  await sleep(5000);
+
+  log('maestro:existing-user', `Flow: ${flowFile}`);
+  log('maestro:existing-user', `Artifacts: ${outputDir}`);
+  log(
+    'maestro:existing-user',
+    'App data is preserved. This smoke expects an existing wallet state and fails on onboarding.',
+  );
+
+  runMaestroFlow({
+    maestroBin,
+    flowFile,
+    outputDir,
+    reportBasename: 'report',
+    packageName,
+    appPassword,
+    maestroEnv: config.maestro.env,
+    forwardedArgs: process.argv.slice(2),
+  });
+
+  log(
+    'maestro:existing-user',
+    `Completed. Report: ${path.join(outputDir, 'report.html')}`,
+  );
+}
+
+main().catch(error => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/apps/automation-maestro/src/shared/android.mjs
+++ b/apps/automation-maestro/src/shared/android.mjs
@@ -26,7 +26,8 @@ export function formatRunId(date = new Date()) {
   return (
     [date.getFullYear(), pad(date.getMonth() + 1), pad(date.getDate())].join(
       '',
-    ) + `-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`
+    ) +
+    `-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`
   );
 }
 
@@ -56,8 +57,7 @@ export function resolveMaestroBinary(config) {
       envVarName: 'MAESTRO_BIN',
       commandName: 'maestro',
       fallbackPath: defaultMaestroBinary(),
-      errorMessage:
-        '[maestro] maestro CLI is required but not found in PATH',
+      errorMessage: '[maestro] maestro CLI is required but not found in PATH',
     })
   );
 }
@@ -83,7 +83,7 @@ export function runAdb(adbBinary, args, options) {
   return run(adbBinary, adbArgs(args), options);
 }
 
-function captureAdb(adbBinary, args, options) {
+export function captureAdb(adbBinary, args, options) {
   return capture(adbBinary, adbArgs(args), options);
 }
 
@@ -128,10 +128,7 @@ export function launchActivity(adbBinary, launchActivity) {
   });
 }
 
-export function resolveMaestroAppId({
-  fallback,
-  platformEnvNames = [],
-} = {}) {
+export function resolveMaestroAppId({ fallback, platformEnvNames = [] } = {}) {
   for (const envName of ['RABBY_MAESTRO_APP_ID', ...platformEnvNames]) {
     const value = process.env[envName]?.trim();
     if (value) {


### PR DESCRIPTION
Summary
- Add an Android connected-device doctor for adb, Maestro, installed package, launch activity, and flow syntax checks.
- Add a generic Android device flow runner that preserves app data and writes Maestro artifacts per run.
- Add an existing-user home-ready smoke wrapper and document the connected-device workflow.

Tested
- node --check apps/automation-maestro/src/doctor-android-device.mjs
- node --check apps/automation-maestro/src/run-android-device-flow.mjs
- node --check apps/automation-maestro/src/run-android-existing-user-smoke.mjs
- RABBY_MAESTRO_APP_ID=com.debank.rabbymobile.regression corepack yarn workspace automation-maestro doctor:android-device --flow flows/android-home-ready-existing-user.yaml
- RABBY_MAESTRO_APP_ID=com.debank.rabbymobile.regression corepack yarn workspace automation-maestro run:android-device-flow --flow flows/android-home-ready-existing-user.yaml (Passed; report under .artifacts)