### PR TITLE
test: cover approval gas display decisions

### DIFF
--- a/apps/mobile/src/components/Approval/components/TxComponents/GasSelector/approvalGasDisplay.test.ts
+++ b/apps/mobile/src/components/Approval/components/TxComponents/GasSelector/approvalGasDisplay.test.ts
@@ -1,0 +1,182 @@
+import {
+  getApprovalGasMethodLabel,
+  isApprovalGasMethodNotEnough,
+  isApprovalSmartGasDisplayEnabled,
+  resolveApprovalDisplayedGasLevelNotEnough,
+  resolveApprovalGasLevelMethod,
+  resolveApprovalGasMethod,
+  shouldAutoSwitchToApprovalGasAccount,
+  shouldHideApprovalGasMethodTabs,
+  shouldUseLegacyApprovalFooterAutoSwitch,
+} from './approvalGasDisplay';
+
+describe('approvalGasDisplay', () => {
+  it('keeps legacy mode behavior explicit', () => {
+    expect(isApprovalSmartGasDisplayEnabled('legacy')).toBe(false);
+    expect(shouldHideApprovalGasMethodTabs('legacy')).toBe(false);
+    expect(shouldUseLegacyApprovalFooterAutoSwitch('legacy')).toBe(true);
+
+    expect(
+      resolveApprovalGasMethod({
+        mode: 'legacy',
+        nativeTokenInsufficient: true,
+        gasAccountChainSupported: true,
+        legacyGasMethod: 'gasAccount',
+      }),
+    ).toBe('gasAccount');
+  });
+
+  it('uses smart display mode to hide manual method tabs', () => {
+    const mode = 'native_insufficient_prefers_gasAccount';
+
+    expect(isApprovalSmartGasDisplayEnabled(mode)).toBe(true);
+    expect(shouldHideApprovalGasMethodTabs(mode)).toBe(true);
+    expect(shouldUseLegacyApprovalFooterAutoSwitch(mode)).toBe(false);
+  });
+
+  it('auto switches to GasAccount only when native gas is insufficient and supported', () => {
+    expect(
+      shouldAutoSwitchToApprovalGasAccount({
+        nativeTokenInsufficient: true,
+        gasAccountChainSupported: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldAutoSwitchToApprovalGasAccount({
+        nativeTokenInsufficient: false,
+        gasAccountChainSupported: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldAutoSwitchToApprovalGasAccount({
+        nativeTokenInsufficient: true,
+        gasAccountChainSupported: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldAutoSwitchToApprovalGasAccount({
+        nativeTokenInsufficient: true,
+        gasAccountChainSupported: true,
+        freeGasAvailable: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldAutoSwitchToApprovalGasAccount({
+        nativeTokenInsufficient: true,
+        gasAccountChainSupported: true,
+        noCustomRPC: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('resolves smart display method from native gas and GasAccount availability', () => {
+    const mode = 'native_insufficient_prefers_gasAccount';
+
+    expect(
+      resolveApprovalGasMethod({
+        mode,
+        nativeTokenInsufficient: true,
+        gasAccountChainSupported: true,
+      }),
+    ).toBe('gasAccount');
+    expect(
+      resolveApprovalGasMethod({
+        mode,
+        nativeTokenInsufficient: true,
+        gasAccountChainSupported: true,
+        freeGasAvailable: true,
+      }),
+    ).toBe('native');
+    expect(
+      resolveApprovalGasMethod({
+        mode,
+        nativeTokenInsufficient: false,
+        gasAccountChainSupported: true,
+      }),
+    ).toBe('native');
+  });
+
+  it('does not rewrite custom gas levels while editing a custom level', () => {
+    expect(
+      resolveApprovalGasLevelMethod({
+        mode: 'native_insufficient_prefers_gasAccount',
+        isCustom: true,
+        nativeTokenInsufficient: true,
+        gasAccountChainSupported: true,
+        currentGasMethod: 'native',
+      }),
+    ).toBe('native');
+
+    expect(
+      resolveApprovalGasLevelMethod({
+        mode: 'native_insufficient_prefers_gasAccount',
+        isCustom: false,
+        nativeTokenInsufficient: true,
+        gasAccountChainSupported: true,
+        currentGasMethod: 'native',
+      }),
+    ).toBe('gasAccount');
+  });
+
+  it('calculates not-enough state for the displayed gas method', () => {
+    expect(
+      isApprovalGasMethodNotEnough({
+        displayMethod: 'native',
+        nativeTokenInsufficient: true,
+      }),
+    ).toBe(true);
+    expect(
+      isApprovalGasMethodNotEnough({
+        displayMethod: 'gasAccount',
+        nativeTokenInsufficient: true,
+        gasAccountBalanceEnough: true,
+      }),
+    ).toBe(false);
+    expect(
+      isApprovalGasMethodNotEnough({
+        displayMethod: 'gasAccount',
+        nativeTokenInsufficient: false,
+        gasAccountBalanceEnough: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('uses active method state for the selected level and cached level flags otherwise', () => {
+    expect(
+      resolveApprovalDisplayedGasLevelNotEnough({
+        isActive: true,
+        displayMethod: 'gasAccount',
+        nativeTokenInsufficient: true,
+        gasAccountBalanceEnough: false,
+        levelNativeInsufficient: false,
+        levelGasAccountNotEnough: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      resolveApprovalDisplayedGasLevelNotEnough({
+        isActive: false,
+        displayMethod: 'gasAccount',
+        nativeTokenInsufficient: false,
+        gasAccountBalanceEnough: true,
+        levelGasAccountNotEnough: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      resolveApprovalDisplayedGasLevelNotEnough({
+        isActive: false,
+        displayMethod: 'native',
+        nativeTokenInsufficient: false,
+        gasAccountBalanceEnough: false,
+        levelNativeInsufficient: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('labels gas methods consistently for headers', () => {
+    expect(getApprovalGasMethodLabel('native')).toBe('Native');
+    expect(getApprovalGasMethodLabel('gasAccount')).toBe('GasAccount');
+  });
+});

--- a/apps/mobile/src/components/Approval/components/TxComponents/GasSelector/directSignSummary.test.ts
+++ b/apps/mobile/src/components/Approval/components/TxComponents/GasSelector/directSignSummary.test.ts
@@ -1,0 +1,71 @@
+const mockFormatGasHeaderUsdValue = jest.fn((value: number | string) => {
+  return `$fmt:${String(value)}`;
+});
+
+jest.mock('@/utils/number', () => ({
+  formatGasHeaderUsdValue: (value: number | string) =>
+    mockFormatGasHeaderUsdValue(value),
+}));
+
+import { buildDirectSignSummary, calcGasAccountUsd } from './directSignSummary';
+
+describe('directSignSummary', () => {
+  beforeEach(() => {
+    mockFormatGasHeaderUsdValue.mockClear();
+  });
+
+  it('keeps native gas summary strings from the caller', () => {
+    expect(
+      buildDirectSignSummary({
+        displayGasMethod: 'native',
+        gasCostUsdStr: '$0.08',
+        gasCostAmountStr: '0.00002 ETH',
+      }),
+    ).toEqual({
+      primaryText: '$0.08',
+      secondaryText: '~0.00002 ETH',
+      useGasAccountCost: false,
+    });
+    expect(mockFormatGasHeaderUsdValue).not.toHaveBeenCalled();
+  });
+
+  it('sums GasAccount tx cost and service gas cost for both summary lines', () => {
+    expect(
+      buildDirectSignSummary({
+        displayGasMethod: 'gasAccount',
+        gasCostUsdStr: '$0.08',
+        gasCostAmountStr: '0.00002 ETH',
+        gasAccountCost: {
+          estimate_tx_cost: 0.01,
+          gas_cost: 0.0025,
+        },
+      }),
+    ).toEqual({
+      primaryText: '$fmt:0.0125',
+      secondaryText: '~fmt:0.0125 USD',
+      useGasAccountCost: true,
+    });
+    expect(mockFormatGasHeaderUsdValue).toHaveBeenCalledTimes(2);
+    expect(mockFormatGasHeaderUsdValue).toHaveBeenNthCalledWith(1, 0.0125);
+    expect(mockFormatGasHeaderUsdValue).toHaveBeenNthCalledWith(2, 0.0125);
+  });
+
+  it('falls back to zero when GasAccount cost fields are missing', () => {
+    expect(
+      buildDirectSignSummary({
+        displayGasMethod: 'gasAccount',
+        gasCostUsdStr: '$0.08',
+        gasCostAmountStr: '0.00002 ETH',
+      }),
+    ).toEqual({
+      primaryText: '$fmt:0',
+      secondaryText: '~fmt:0 USD',
+      useGasAccountCost: true,
+    });
+  });
+
+  it('normalizes empty GasAccount USD values before formatting', () => {
+    expect(calcGasAccountUsd('')).toBe('$fmt:0');
+    expect(mockFormatGasHeaderUsdValue).toHaveBeenCalledWith('0');
+  });
+});

--- a/apps/mobile/src/components/Approval/components/TxComponents/GasSelector/signMainnetCustomGas.test.ts
+++ b/apps/mobile/src/components/Approval/components/TxComponents/GasSelector/signMainnetCustomGas.test.ts
@@ -1,0 +1,89 @@
+import { buildSignMainnetGasChange } from './signMainnetCustomGas';
+
+describe('buildSignMainnetGasChange', () => {
+  it('builds custom gas changes in wei and preserves fixed mode', () => {
+    expect(
+      buildSignMainnetGasChange({
+        gas: {
+          level: 'custom',
+          front_tx_count: 0,
+          price: 0,
+          estimated_seconds: 0,
+          base_fee: 30,
+          priority_price: 0,
+        },
+        gasLimit: 21000,
+        nonce: 7,
+        maxPriorityFeeGwei: 1.5,
+        customGasGwei: 25.25,
+        fixedMode: true,
+      }),
+    ).toEqual({
+      level: 'custom',
+      front_tx_count: 0,
+      price: 25250000000,
+      estimated_seconds: 0,
+      base_fee: 30,
+      priority_price: 1500000000,
+      gasLimit: 21000,
+      nonce: 7,
+      maxPriorityFee: 1500000000,
+      fixedMode: true,
+    });
+  });
+
+  it('adds gas limit, nonce, and priority fee to preset gas levels', () => {
+    expect(
+      buildSignMainnetGasChange({
+        gas: {
+          level: 'fast',
+          front_tx_count: 2,
+          price: 42000000000,
+          estimated_seconds: 15,
+          base_fee: 28,
+          priority_price: 1000000000,
+        },
+        gasLimit: 65000,
+        nonce: 12,
+        maxPriorityFeeGwei: 2,
+        customGasGwei: 99,
+        fixedMode: true,
+      }),
+    ).toEqual({
+      level: 'fast',
+      front_tx_count: 2,
+      price: 42000000000,
+      estimated_seconds: 15,
+      base_fee: 28,
+      priority_price: 2000000000,
+      gasLimit: 65000,
+      nonce: 12,
+      maxPriorityFee: 2000000000,
+    });
+  });
+
+  it('defaults missing custom gas and priority fee values to zero', () => {
+    expect(
+      buildSignMainnetGasChange({
+        gas: {
+          level: 'custom',
+          front_tx_count: 0,
+          price: 123,
+          estimated_seconds: 0,
+          base_fee: 0,
+          priority_price: 456,
+        },
+        gasLimit: 50000,
+        nonce: 1,
+        maxPriorityFeeGwei: 0,
+      }),
+    ).toMatchObject({
+      level: 'custom',
+      price: 0,
+      priority_price: 0,
+      maxPriorityFee: 0,
+      gasLimit: 50000,
+      nonce: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add pure Jest coverage for approval gas display mode and GasAccount auto-switch decisions
- cover direct-sign summary text construction for native gas and GasAccount costs
- cover mainnet custom gas change construction, including Gwei-to-wei conversion and preset gas levels

## Verification
- corepack yarn workspace rabby-mobile test --runInBand src/components/Approval/components/TxComponents/GasSelector/approvalGasDisplay.test.ts src/components/Approval/components/TxComponents/GasSelector/directSignSummary.test.ts src/components/Approval/components/TxComponents/GasSelector/signMainnetCustomGas.test.ts

## Local note
- Full Jest/typecheck were attempted in the symlinked worktree and are blocked by pre-existing local dependency resolution gaps: missing react-native-keychain package alias and packages/biz-utils/dist. The new targeted suites pass locally; fresh CI should validate the full install.