### PR TITLE
test: cover typed data normalization

### DIFF
--- a/apps/mobile/src/components/Approval/components/SignTypedDataExplain/parseSignTypedDataMessage.test.ts
+++ b/apps/mobile/src/components/Approval/components/SignTypedDataExplain/parseSignTypedDataMessage.test.ts
@@ -1,0 +1,65 @@
+import {
+  filterPrimaryType,
+  parseSignTypedDataMessage,
+} from './parseSignTypedDataMessage';
+
+describe('parseSignTypedDataMessage', () => {
+  it('returns message directly when the payload has no primary type', () => {
+    expect(
+      parseSignTypedDataMessage({
+        message: {
+          raw: 'hello',
+        },
+      }),
+    ).toEqual({ raw: 'hello' });
+  });
+
+  it('parses string payloads and keeps only primary type fields', () => {
+    expect(
+      parseSignTypedDataMessage(
+        JSON.stringify({
+          primaryType: 'Permit',
+          types: {
+            Permit: [
+              { name: 'owner', type: 'address' },
+              { name: 'spender', type: 'address' },
+            ],
+          },
+          message: {
+            owner: '0x00000000000000000000000000000000000000aa',
+            spender: '0x00000000000000000000000000000000000000bb',
+            value: '100',
+          },
+        }),
+      ),
+    ).toEqual({
+      owner: '0x00000000000000000000000000000000000000aa',
+      spender: '0x00000000000000000000000000000000000000bb',
+    });
+  });
+});
+
+describe('filterPrimaryType', () => {
+  it('preserves the declared field order and drops undeclared fields', () => {
+    expect(
+      Object.keys(
+        filterPrimaryType({
+          primaryType: 'Order',
+          types: {
+            Order: [
+              { name: 'maker', type: 'address' },
+              { name: 'amount', type: 'uint256' },
+              { name: 'deadline', type: 'uint256' },
+            ],
+          },
+          message: {
+            amount: '10',
+            ignored: 'drop',
+            deadline: '99',
+            maker: '0x00000000000000000000000000000000000000aa',
+          },
+        }),
+      ),
+    ).toEqual(['maker', 'amount', 'deadline']);
+  });
+});

--- a/apps/mobile/src/components/Approval/components/SignTypedDataExplain/parseSignTypedDataMessage.ts
+++ b/apps/mobile/src/components/Approval/components/SignTypedDataExplain/parseSignTypedDataMessage.ts
@@ -19,7 +19,7 @@ export const filterPrimaryType = ({
   message: Record<string, any>;
 }) => {
   const keys = types[primaryType];
-  const filteredMessage: Record<string, string> = {};
+  const filteredMessage: Record<string, any> = {};
 
   keys.forEach((key: { name: string; type: string }) => {
     filteredMessage[key.name] = message[key.name];

--- a/apps/mobile/src/components/Approval/components/TypedDataActions/utils.test.ts
+++ b/apps/mobile/src/components/Approval/components/TypedDataActions/utils.test.ts
@@ -1,0 +1,125 @@
+import { normalizeTypeData } from './utils';
+
+const addr = (suffix: string) =>
+  `0x00000000000000000000000000000000000000${suffix}`;
+
+describe('normalizeTypeData', () => {
+  it('normalizes EIP-712 domain and primary message values for display', () => {
+    const typedData = {
+      primaryType: 'Mail',
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+          { name: 'salt', type: 'bytes32' },
+        ],
+        Mail: [
+          { name: 'from', type: 'Person' },
+          { name: 'to', type: 'Person[]' },
+          { name: 'contents', type: 'string' },
+          { name: 'count', type: 'uint256' },
+          { name: 'enabled', type: 'bool' },
+          { name: 'payload', type: 'bytes32' },
+        ],
+        Person: [
+          { name: 'wallet', type: 'address' },
+          { name: 'name', type: 'string' },
+          { name: 'age', type: 'uint8' },
+          { name: 'verified', type: 'bool' },
+        ],
+      },
+      domain: {
+        name: 'Rabby',
+        version: '1',
+        chainId: 1,
+        verifyingContract: addr('dd'),
+        salt: `0x${'11'.repeat(32)}`,
+        ignoredDomain: 'drop',
+      },
+      message: {
+        from: {
+          wallet: addr('aa'),
+          name: 'Alice',
+          age: 5,
+          verified: true,
+          ignoredNested: 'drop',
+        },
+        to: [
+          {
+            wallet: addr('bb'),
+            name: 'Bob',
+            age: '6',
+            verified: false,
+          },
+          {
+            wallet: addr('cc'),
+            name: 'Carol',
+            age: 7,
+            verified: true,
+          },
+        ],
+        contents: 'Hello from Hermes',
+        count: '42',
+        enabled: true,
+        payload: `0x${'22'.repeat(32)}`,
+        ignoredMessage: 'drop',
+      },
+    };
+
+    expect(normalizeTypeData(typedData)).toEqual({
+      primaryType: 'Mail',
+      types: typedData.types,
+      domain: {
+        name: 'Rabby',
+        version: '1',
+        chainId: '1',
+        verifyingContract: addr('dd'),
+        salt: `0x${'11'.repeat(32)}`,
+      },
+      message: {
+        from: {
+          wallet: addr('aa'),
+          name: 'Alice',
+          age: '5',
+          verified: true,
+        },
+        to: [
+          {
+            wallet: addr('bb'),
+            name: 'Bob',
+            age: '6',
+            verified: false,
+          },
+          {
+            wallet: addr('cc'),
+            name: 'Carol',
+            age: '7',
+            verified: true,
+          },
+        ],
+        contents: 'Hello from Hermes',
+        count: '42',
+        enabled: true,
+        payload: `0x${'22'.repeat(32)}`,
+      },
+    });
+  });
+
+  it('returns the original payload when normalization cannot decode a field', () => {
+    const invalidTypedData = {
+      primaryType: 'Mail',
+      types: {
+        EIP712Domain: [],
+        Mail: [{ name: 'count', type: 'uint256' }],
+      },
+      domain: {},
+      message: {
+        count: 'not-a-number',
+      },
+    };
+
+    expect(normalizeTypeData(invalidTypedData)).toBe(invalidTypedData);
+  });
+});

--- a/apps/mobile/src/components/Approval/components/TypedDataActions/utils.ts
+++ b/apps/mobile/src/components/Approval/components/TypedDataActions/utils.ts
@@ -96,11 +96,12 @@ function parseSignTypedData(typedData: {
       }
       return decodedArray;
     } else if (types[dataType]) {
+      const decodedStruct: Record<string, any> = {};
       for (const field of types[dataType]) {
         const { name, type } = field;
-        data[name] = parseAndDecode(data[name], type);
+        decodedStruct[name] = parseAndDecode(data?.[name], type);
       }
-      return data;
+      return decodedStruct;
     } else {
       if (dataType.startsWith('bytes')) {
         // bytes type is complex and no need to normalize
@@ -139,10 +140,6 @@ function parseSignTypedData(typedData: {
     }
   }
 
-  for (const { name, type } of types.EIP712Domain) {
-    domain[name] = parseAndDecode(domain[name], type);
-  }
-
   typedData.message = parseAndDecode(message, primaryType);
 
   // Filter out the fields that are not part of the primary type
@@ -152,10 +149,11 @@ function parseSignTypedData(typedData: {
     message: typedData.message,
   });
 
+  typedData.domain = parseAndDecode(domain, 'EIP712Domain');
   typedData.domain = filterPrimaryType({
     primaryType: 'EIP712Domain',
     types,
-    message: domain,
+    message: typedData.domain,
   });
 
   return typedData;


### PR DESCRIPTION
## Summary
- add tests for sign typed-data message parsing and primaryType field filtering
- add EIP-712 normalization coverage for domain/message address, bool, integer, string, bytes, array, and nested struct fields
- tighten nested struct normalization so undeclared fields are not displayed as if they were part of the signed typed data

## Verification
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/components/Approval/components/SignTypedDataExplain/parseSignTypedDataMessage.test.ts src/components/Approval/components/TypedDataActions/utils.test.ts