### PR TITLE
test: cover swap and perps utilities

### DIFF
--- a/apps/mobile/src/screens/Perps/components/PerpsPositionSection/__tests__/utils.test.ts
+++ b/apps/mobile/src/screens/Perps/components/PerpsPositionSection/__tests__/utils.test.ts
@@ -1,0 +1,38 @@
+import { PERPS_POSITION_RISK_LEVEL } from '@/constant/perps';
+
+import { calculateDistanceToLiquidation, getRiskLevel } from '../utils';
+
+describe('PerpsPositionSection utils', () => {
+  describe('calculateDistanceToLiquidation', () => {
+    it('calculates absolute distance for liquidation prices below or above mark price', () => {
+      expect(calculateDistanceToLiquidation(90, 100)).toBe(0.1);
+      expect(calculateDistanceToLiquidation(110, 100)).toBe(0.1);
+    });
+
+    it('accepts numeric strings from position payloads', () => {
+      expect(calculateDistanceToLiquidation('95000', '100000')).toBe(0.05);
+    });
+
+    it('returns zero when mark price is missing or zero', () => {
+      expect(calculateDistanceToLiquidation(100, 0)).toBe(0);
+      expect(calculateDistanceToLiquidation(100, undefined)).toBe(0);
+    });
+  });
+
+  describe('getRiskLevel', () => {
+    it('marks positions at or below 3% from liquidation as danger', () => {
+      expect(getRiskLevel(0)).toBe(PERPS_POSITION_RISK_LEVEL.DANGER);
+      expect(getRiskLevel(0.03)).toBe(PERPS_POSITION_RISK_LEVEL.DANGER);
+    });
+
+    it('marks positions between 3% and 8% from liquidation as warning', () => {
+      expect(getRiskLevel(0.030001)).toBe(PERPS_POSITION_RISK_LEVEL.WARNING);
+      expect(getRiskLevel(0.079999)).toBe(PERPS_POSITION_RISK_LEVEL.WARNING);
+    });
+
+    it('marks positions at or above 8% from liquidation as safe', () => {
+      expect(getRiskLevel(0.08)).toBe(PERPS_POSITION_RISK_LEVEL.SAFE);
+      expect(getRiskLevel(0.2)).toBe(PERPS_POSITION_RISK_LEVEL.SAFE);
+    });
+  });
+});

--- a/apps/mobile/src/screens/Swap/__tests__/utils.test.ts
+++ b/apps/mobile/src/screens/Swap/__tests__/utils.test.ts
@@ -1,0 +1,109 @@
+import type { TokenItem } from '@rabby-wallet/rabby-api/dist/types';
+
+import { isSwapWrapToken, tokenAmountBn } from '../utils';
+
+const mockNativeEth = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+const mockWeth = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+const mockBnb = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+const mockWbnb = '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c';
+const mockUsdc = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+
+jest.mock('@debank/common', () => ({
+  CHAINS_ENUM: {
+    ETH: 'ETH',
+    BSC: 'BSC',
+  },
+  CHAINS: {
+    ETH: {
+      nativeTokenAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+    },
+    BSC: {
+      nativeTokenAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+    },
+  },
+}));
+
+jest.mock('@rabby-wallet/rabby-swap', () => ({
+  WrapTokenAddressMap: {
+    ETH: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+    BSC: '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c',
+  },
+}));
+
+jest.mock('@/utils/chain', () => ({
+  findChainByEnum: jest.fn(chain =>
+    chain === 'ETH'
+      ? {
+          nativeTokenAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+        }
+      : null,
+  ),
+}));
+
+const token = (params: Partial<TokenItem>): TokenItem =>
+  ({
+    id: 'token',
+    decimals: 18,
+    raw_amount_hex_str: '0x0',
+    ...params,
+  } as TokenItem);
+
+describe('Swap utils', () => {
+  describe('tokenAmountBn', () => {
+    it('converts raw hex amount using token decimals', () => {
+      expect(
+        tokenAmountBn(
+          token({
+            decimals: 18,
+            raw_amount_hex_str: '0xde0b6b3a7640000',
+          }),
+        ).toString(10),
+      ).toBe('1');
+    });
+
+    it('keeps sub-unit precision for small raw balances', () => {
+      expect(
+        tokenAmountBn(
+          token({
+            decimals: 6,
+            raw_amount_hex_str: '0x1',
+          }),
+        ).toString(10),
+      ).toBe('0.000001');
+    });
+
+    it('treats a missing raw amount as zero', () => {
+      expect(
+        tokenAmountBn(
+          token({
+            decimals: 18,
+            raw_amount_hex_str: undefined,
+          }),
+        ).toString(10),
+      ).toBe('0');
+    });
+  });
+
+  describe('isSwapWrapToken', () => {
+    it('identifies native-to-wrapped and wrapped-to-native swaps', () => {
+      expect(isSwapWrapToken(mockNativeEth, mockWeth, 'ETH' as any)).toBe(true);
+      expect(isSwapWrapToken(mockWeth, mockNativeEth, 'ETH' as any)).toBe(true);
+    });
+
+    it('falls back to CHAINS native token metadata when chain lookup misses', () => {
+      expect(isSwapWrapToken(mockBnb, mockWbnb, 'BSC' as any)).toBe(true);
+    });
+
+    it('does not classify the same wrapped token with different address casing as a wrap swap', () => {
+      expect(
+        isSwapWrapToken(mockWeth, mockWeth.toUpperCase(), 'ETH' as any),
+      ).toBe(false);
+    });
+
+    it('rejects unrelated tokens and missing token ids', () => {
+      expect(isSwapWrapToken(mockUsdc, mockWeth, 'ETH' as any)).toBe(false);
+      expect(isSwapWrapToken('', mockWeth, 'ETH' as any)).toBe(false);
+      expect(isSwapWrapToken(mockNativeEth, '', 'ETH' as any)).toBe(false);
+    });
+  });
+});

--- a/apps/mobile/src/screens/Swap/hooks/quote.tsx
+++ b/apps/mobile/src/screens/Swap/hooks/quote.tsx
@@ -880,7 +880,7 @@ export function isSwapWrapToken(
   return (
     !!payTokenId &&
     !!receiveId &&
-    payTokenId !== receiveId &&
+    !isSameAddress(payTokenId, receiveId) &&
     !!wrapTokens.find(token => isSameAddress(payTokenId, token)) &&
     !!wrapTokens.find(token => isSameAddress(receiveId, token))
   );

--- a/apps/mobile/src/screens/Swap/utils.ts
+++ b/apps/mobile/src/screens/Swap/utils.ts
@@ -26,7 +26,7 @@ export function isSwapWrapToken(
   return (
     !!payTokenId &&
     !!receiveId &&
-    payTokenId !== receiveId &&
+    !isSameAddress(payTokenId, receiveId) &&
     !!wrapTokens.find(token => isSameAddress(payTokenId, token)) &&
     !!wrapTokens.find(token => isSameAddress(receiveId, token))
   );


### PR DESCRIPTION
## Summary
- add swap utility coverage for raw hex token balances and native/wrapped token detection
- add perps liquidation distance and risk level boundary coverage
- fix wrap-token detection to compare pay/receive ids case-insensitively via isSameAddress in both swap utility implementations

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand apps/mobile/src/screens/Swap/__tests__/utils.test.ts apps/mobile/src/screens/Perps/components/PerpsPositionSection/__tests__/utils.test.ts
- corepack yarn workspace rabby-mobile eslint src/screens/Swap/utils.ts src/screens/Swap/hooks/quote.tsx src/screens/Swap/__tests__/utils.test.ts src/screens/Perps/components/PerpsPositionSection/__tests__/utils.test.ts
- git diff --check

Note: local symlink worktree typecheck/lint:cycles still hits the known cross-worktree package resolution baseline noise; CI should validate from a fresh checkout.