### PR TITLE
test: cover lending swap utilities

### DIFF
--- a/apps/mobile/src/screens/Lending/components/actions/RepayWithCollateralContent/__tests__/utils.test.ts
+++ b/apps/mobile/src/screens/Lending/components/actions/RepayWithCollateralContent/__tests__/utils.test.ts
@@ -1,0 +1,41 @@
+import {
+  DEFAULT_REPAY_WITH_COLLATERAL_SLIPPAGE,
+  isSupportRepayWithCollateral,
+} from '../utils';
+
+const enabledMarket = {
+  enabledFeatures: {
+    collateralRepay: true,
+  },
+  addresses: {
+    REPAY_WITH_COLLATERAL_ADAPTER: '0x0000000000000000000000000000000000000001',
+  },
+} as any;
+
+describe('RepayWithCollateralContent utils', () => {
+  it('keeps the repay-with-collateral default slippage stable', () => {
+    expect(DEFAULT_REPAY_WITH_COLLATERAL_SLIPPAGE).toBe(100);
+  });
+
+  it('returns true only for supported chains with enabled market adapter', () => {
+    expect(isSupportRepayWithCollateral(1, enabledMarket)).toBe(true);
+    expect(isSupportRepayWithCollateral(42161, enabledMarket)).toBe(true);
+    expect(isSupportRepayWithCollateral(8453, enabledMarket)).toBe(false);
+  });
+
+  it('returns a boolean false when market feature flags or adapter addresses are missing', () => {
+    expect(
+      isSupportRepayWithCollateral(1, {
+        ...enabledMarket,
+        enabledFeatures: { collateralRepay: false },
+      }),
+    ).toBe(false);
+    expect(
+      isSupportRepayWithCollateral(1, {
+        ...enabledMarket,
+        addresses: { REPAY_WITH_COLLATERAL_ADAPTER: '' },
+      }),
+    ).toBe(false);
+    expect(isSupportRepayWithCollateral(1)).toBe(false);
+  });
+});

--- a/apps/mobile/src/screens/Lending/components/actions/RepayWithCollateralContent/utils.ts
+++ b/apps/mobile/src/screens/Lending/components/actions/RepayWithCollateralContent/utils.ts
@@ -17,9 +17,8 @@ export const isSupportRepayWithCollateral = (
   market?: MarketDataType,
 ) => {
   const marketEnabledFeatures =
-    market &&
-    market.enabledFeatures?.collateralRepay &&
-    market.addresses.REPAY_WITH_COLLATERAL_ADAPTER;
+    !!market?.enabledFeatures?.collateralRepay &&
+    !!market.addresses.REPAY_WITH_COLLATERAL_ADAPTER;
   return (
     REPAY_WITH_COLLATERAL_SUPPORTED_CHAINs.includes(chainId) &&
     marketEnabledFeatures

--- a/apps/mobile/src/screens/Lending/modals/DebtSwapModal/__tests__/utils.test.ts
+++ b/apps/mobile/src/screens/Lending/modals/DebtSwapModal/__tests__/utils.test.ts
@@ -1,0 +1,122 @@
+import { BigNumber as EthersBigNumber, constants } from 'ethers';
+
+import {
+  DEFAULT_DEBT_SWAP_SLIPPAGE,
+  ZERO_PERMIT,
+  formatTx,
+  getParaswapSlippage,
+  maxInputAmountWithSlippage,
+  sliderHapticTriggerNumbers,
+  swapTypesThatRequiresInvertedQuote,
+} from '../utils';
+
+describe('DebtSwapModal utils', () => {
+  describe('constants', () => {
+    it('keeps debt swap UI and permit defaults stable', () => {
+      expect(sliderHapticTriggerNumbers).toEqual([0, 50, 100]);
+      expect(DEFAULT_DEBT_SWAP_SLIPPAGE).toBe(40);
+      expect(ZERO_PERMIT).toEqual({
+        value: '0',
+        deadline: '0',
+        v: 0,
+        r: constants.HashZero,
+        s: constants.HashZero,
+      });
+      expect(swapTypesThatRequiresInvertedQuote).toEqual([
+        'debt_swap',
+        'repay_with_collateral',
+      ]);
+    });
+  });
+
+  describe('maxInputAmountWithSlippage', () => {
+    it('adds basis-point slippage and rounds up to a raw integer amount', () => {
+      expect(maxInputAmountWithSlippage('1000', 40)).toBe('1004');
+      expect(maxInputAmountWithSlippage('1', 1)).toBe('2');
+    });
+
+    it('returns zero for empty, zero or negative inputs', () => {
+      expect(maxInputAmountWithSlippage('', 40)).toBe('0');
+      expect(maxInputAmountWithSlippage('0', 40)).toBe('0');
+      expect(maxInputAmountWithSlippage('-1', 40)).toBe('0');
+    });
+  });
+
+  describe('formatTx', () => {
+    it('formats populated transactions with fallback from address, hex value and nonce zero', () => {
+      expect(
+        formatTx(
+          {
+            to: '0x0000000000000000000000000000000000000001',
+            data: '0x1234',
+            value: EthersBigNumber.from('1000000000000000000'),
+            nonce: 0,
+          },
+          '0x0000000000000000000000000000000000000002',
+          1,
+        ),
+      ).toEqual({
+        from: '0x0000000000000000000000000000000000000002',
+        to: '0x0000000000000000000000000000000000000001',
+        data: '0x1234',
+        value: '0x0de0b6b3a7640000',
+        chainId: 1,
+        nonce: 0,
+      });
+    });
+
+    it('preserves explicit from, string value and non-zero nonce', () => {
+      expect(
+        formatTx(
+          {
+            from: '0x0000000000000000000000000000000000000003',
+            to: '0x0000000000000000000000000000000000000001',
+            data: '0xabcd',
+            value: '0x2a',
+            nonce: 7,
+          },
+          '0x0000000000000000000000000000000000000002',
+          42161,
+        ),
+      ).toEqual({
+        from: '0x0000000000000000000000000000000000000003',
+        to: '0x0000000000000000000000000000000000000001',
+        data: '0xabcd',
+        value: '0x2a',
+        chainId: 42161,
+        nonce: 7,
+      });
+    });
+
+    it('returns null when populated transaction data is missing', () => {
+      expect(
+        formatTx(
+          {
+            to: '0x0000000000000000000000000000000000000001',
+            value: '0x0',
+          },
+          '0x0000000000000000000000000000000000000002',
+          1,
+        ),
+      ).toBe(null);
+    });
+  });
+
+  describe('getParaswapSlippage', () => {
+    it('uses lower base slippage for assets in the same group', () => {
+      expect(getParaswapSlippage('USDC', 'USDT', 'swap' as any)).toBe(10);
+      expect(getParaswapSlippage('USDC', 'USDT', 'debt_swap' as any)).toBe(20);
+      expect(
+        getParaswapSlippage('USDC', 'USDT', 'repay_with_collateral' as any),
+      ).toBe(50);
+    });
+
+    it('uses higher base slippage for assets in different groups', () => {
+      expect(getParaswapSlippage('USDC', 'WETH', 'swap' as any)).toBe(20);
+      expect(getParaswapSlippage('USDC', 'WETH', 'debt_swap' as any)).toBe(40);
+      expect(
+        getParaswapSlippage('USDC', 'WETH', 'repay_with_collateral' as any),
+      ).toBe(100);
+    });
+  });
+});

--- a/apps/mobile/src/screens/Lending/modals/DebtSwapModal/utils.ts
+++ b/apps/mobile/src/screens/Lending/modals/DebtSwapModal/utils.ts
@@ -50,7 +50,7 @@ export const formatTx = (
           : tx.value ?? '0x0',
       chainId,
     };
-    if (tx.nonce) {
+    if (tx.nonce !== undefined) {
       (formattedTx as any).nonce = tx.nonce;
     }
     return formattedTx as Tx;


### PR DESCRIPTION
## Summary
- add DebtSwapModal utility coverage for slippage rounding, tx formatting, inverted quote swap types and ParaSwap slippage defaults
- add RepayWithCollateral support coverage for chain allowlist, market feature flags and adapter availability
- fix formatTx to preserve nonce 0 and make isSupportRepayWithCollateral return a boolean instead of an adapter address string

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand apps/mobile/src/screens/Lending/modals/DebtSwapModal/__tests__/utils.test.ts apps/mobile/src/screens/Lending/components/actions/RepayWithCollateralContent/__tests__/utils.test.ts
- corepack yarn workspace rabby-mobile eslint src/screens/Lending/modals/DebtSwapModal/utils.ts src/screens/Lending/modals/DebtSwapModal/__tests__/utils.test.ts src/screens/Lending/components/actions/RepayWithCollateralContent/utils.ts src/screens/Lending/components/actions/RepayWithCollateralContent/__tests__/utils.test.ts
- git diff --check