### PR TITLE
test: cover webview utilities

### DIFF
--- a/apps/mobile/src/components/WebView/LocalWebView/__tests__/utils.test.ts
+++ b/apps/mobile/src/components/WebView/LocalWebView/__tests__/utils.test.ts
@@ -1,0 +1,137 @@
+import { Platform } from 'react-native';
+
+import {
+  formatDevURI,
+  getBaseURL,
+  getLocalWebViewDefaultProps,
+  makeRuntimeInfo,
+  sendMessageToWebview,
+} from '../utils';
+
+jest.mock('@/utils/i18n', () => ({
+  SupportedLang: {
+    'en-US': 'en-US',
+    'zh-CN': 'zh-CN',
+  },
+}));
+
+jest.mock('react-native-webview', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('LocalWebView utils', () => {
+  describe('formatDevURI and getBaseURL', () => {
+    it('formats development resource URLs with protocol, host, port and path', () => {
+      expect(
+        formatDevURI({
+          host: 'localhost',
+          port: 3000,
+          path: 'assets/index.html',
+        }),
+      ).toBe('http://localhost:3000/assets/index.html');
+
+      expect(
+        formatDevURI({
+          protocol: 'https:',
+          host: 'rabby.io',
+          path: '/mobile',
+        }),
+      ).toBe('https://rabby.io/mobile');
+    });
+
+    it('extracts a normalized base URL or returns undefined for invalid URLs', () => {
+      expect(getBaseURL('http://localhost:3000/assets/index.html?x=1')).toBe(
+        'http://localhost:3000/',
+      );
+      expect(getBaseURL('https://rabby.io/mobile')).toBe('https://rabby.io/');
+      expect(getBaseURL('not a url')).toBeUndefined();
+    });
+  });
+
+  it('builds platform-specific default WebView props from the same base flags', () => {
+    const { iosWebViewProps, androidWebViewProps } =
+      getLocalWebViewDefaultProps();
+
+    expect(iosWebViewProps).toMatchObject({
+      javaScriptEnabled: true,
+      domStorageEnabled: true,
+      originWhitelist: ['*'],
+      scrollEnabled: false,
+      cacheEnabled: false,
+      incognito: true,
+      allowsInlineMediaPlayback: true,
+    });
+    expect(androidWebViewProps).toMatchObject({
+      javaScriptEnabled: true,
+      domStorageEnabled: true,
+      originWhitelist: ['*'],
+      scrollEnabled: false,
+      nestedScrollEnabled: true,
+      allowFileAccess: true,
+    });
+  });
+
+  it('creates runtime info with platform, theme, language and resource mode', () => {
+    expect(
+      makeRuntimeInfo({
+        baseUrl: 'http://localhost:3000/',
+        useDevResource: false,
+        isDark: true,
+        language: 'zh-CN' as any,
+        i18nTexts: { hello: 'hello' },
+        backGroundColor: '#000000',
+      }),
+    ).toEqual({
+      runtimeBaseUrl: 'http://localhost:3000/',
+      platform: Platform.OS,
+      useDevResource: false,
+      isDark: true,
+      language: 'zh-CN',
+      i18nTexts: { hello: 'hello' },
+      backGroundColor: '#000000',
+    });
+  });
+
+  describe('sendMessageToWebview', () => {
+    it('warns and returns when webview is missing', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+
+      sendMessageToWebview(null, { type: 'ping' });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'sendMessageToWebview: webview is null',
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('injects object messages as escaped CustomEvent detail payloads', () => {
+      const webview = {
+        injectJavaScript: jest.fn(),
+      } as any;
+
+      sendMessageToWebview(webview, {
+        type: 'quote',
+        text: "Rabby's \\\\ path",
+      });
+
+      const script = webview.injectJavaScript.mock.calls[0][0];
+      expect(script).toContain("CustomEvent('messageFromRN'");
+      expect(script).toContain('"type":"quote"');
+      expect(script).toContain("Rabby\\'s");
+      expect(script).toContain('true;');
+    });
+
+    it('allows string messages to be injected as raw JavaScript expressions', () => {
+      const webview = {
+        injectJavaScript: jest.fn(),
+      } as any;
+
+      sendMessageToWebview(webview, 'window.__RABBY_MESSAGE__');
+
+      expect(webview.injectJavaScript.mock.calls[0][0]).toContain(
+        'detail: window.__RABBY_MESSAGE__',
+      );
+    });
+  });
+});

--- a/apps/mobile/src/components/WebView/__tests__/utils.test.ts
+++ b/apps/mobile/src/components/WebView/__tests__/utils.test.ts
@@ -1,0 +1,131 @@
+import { Alert } from 'react-native';
+
+import { allowLinkOpen } from '@/constant/dappView';
+import {
+  checkShouldStartLoadingWithRequestForDappWebView,
+  checkShouldStartLoadingWithRequestForTrustedContent,
+} from '../utils';
+
+jest.mock('@/constant/dappView', () => ({
+  protocolAllowList: ['about:', 'http:', 'https:'],
+  trustedProtocolToDeeplink: ['wc:', 'metamask:', 'ethereum:', 'dapp:'],
+  allowLinkOpen: jest.fn(),
+  getAlertMessage: jest.fn((protocol: string) => {
+    switch (protocol) {
+      case 'blob:':
+        return {
+          needAlert: false,
+          allowOpenLink: true,
+          message: '',
+        };
+      case 'tel:':
+        return {
+          needAlert: true,
+          allowOpenLink: false,
+          message:
+            'This website has been blocked from automatically making a phone call',
+        };
+      default:
+        return {
+          needAlert: true,
+          allowOpenLink: false,
+          message:
+            'This website has been blocked from automatically opening an external application',
+        };
+    }
+  }),
+}));
+
+describe('WebView utils', () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  describe('checkShouldStartLoadingWithRequestForDappWebView', () => {
+    it('allows normal web protocols to keep loading inside the dapp webview', () => {
+      expect(
+        checkShouldStartLoadingWithRequestForDappWebView({
+          url: 'https://rabby.io',
+        }),
+      ).toBe(true);
+      expect(allowLinkOpen).not.toHaveBeenCalled();
+      expect(Alert.alert).not.toHaveBeenCalled();
+    });
+
+    it('opens trusted deeplink protocols externally and stops webview loading', () => {
+      expect(
+        checkShouldStartLoadingWithRequestForDappWebView({
+          url: 'wc:topic@2?relay-protocol=irn',
+        }),
+      ).toBe(false);
+      expect(allowLinkOpen).toHaveBeenCalledWith(
+        'wc:topic@2?relay-protocol=irn',
+      );
+      expect(Alert.alert).not.toHaveBeenCalled();
+    });
+
+    it('shows a warning alert for blocked external protocols and wires the allow action', () => {
+      expect(
+        checkShouldStartLoadingWithRequestForDappWebView({
+          url: 'tel:123456',
+        }),
+      ).toBe(false);
+
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Warning',
+        'This website has been blocked from automatically making a phone call',
+        expect.any(Array),
+      );
+
+      const buttons = (Alert.alert as jest.Mock).mock.calls[0][2];
+      buttons[1].onPress();
+      expect(allowLinkOpen).toHaveBeenCalledWith('tel:123456');
+    });
+
+    it('allows blob URLs without opening an alert', () => {
+      expect(
+        checkShouldStartLoadingWithRequestForDappWebView({
+          url: 'blob:https://rabby.io/asset',
+        }),
+      ).toBe(true);
+      expect(Alert.alert).not.toHaveBeenCalled();
+      expect(allowLinkOpen).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('checkShouldStartLoadingWithRequestForTrustedContent', () => {
+    it('opens known trusted content domains externally and stops webview loading', () => {
+      expect(
+        checkShouldStartLoadingWithRequestForTrustedContent({
+          url: 'https://debank.com/profile',
+        }),
+      ).toBe(false);
+      expect(allowLinkOpen).toHaveBeenCalledWith('https://debank.com/profile');
+      expect(Alert.alert).not.toHaveBeenCalled();
+    });
+
+    it('prompts before leaving trusted content to an untrusted https domain', () => {
+      expect(
+        checkShouldStartLoadingWithRequestForTrustedContent({
+          url: 'https://example.com',
+        }),
+      ).toBe(false);
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Warning',
+        'This website has been blocked from automatically opening an external application',
+        expect.any(Array),
+      );
+
+      const buttons = (Alert.alert as jest.Mock).mock.calls[0][2];
+      buttons[1].onPress();
+      expect(allowLinkOpen).toHaveBeenCalledWith('https://example.com');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add dapp/trusted WebView navigation coverage for allowlisted protocols, deeplinks, blocked external protocols, blob URLs and trusted domains
- add LocalWebView utility coverage for dev URLs, base URL parsing, default props, runtime info and RN-to-web message injection escaping

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand apps/mobile/src/components/WebView/__tests__/utils.test.ts apps/mobile/src/components/WebView/LocalWebView/__tests__/utils.test.ts
- corepack yarn workspace rabby-mobile eslint src/components/WebView/utils.ts src/components/WebView/__tests__/utils.test.ts src/components/WebView/LocalWebView/utils.ts src/components/WebView/LocalWebView/__tests__/utils.test.ts
- git diff --check

Note: targeted lint exits clean with one existing curly warning in src/components/WebView/utils.ts.