### PR TITLE
test: cover UI logic utilities

### DIFF
--- a/apps/mobile/src/components/Approval/components/Actions/__tests__/utils.test.ts
+++ b/apps/mobile/src/components/Approval/components/Actions/__tests__/utils.test.ts
@@ -1,0 +1,117 @@
+import { getActionTypeText, getActionTypeTextByType } from '../utils';
+
+jest.mock('@/utils/i18n', () => ({
+  __esModule: true,
+  default: {
+    t: jest.fn((key: string) => `t:${key}`),
+  },
+}));
+
+describe('Approval Actions utils', () => {
+  it.each([
+    ['swap', { swap: {} }, 'page.signTx.swap.title'],
+    ['crossToken', { crossToken: {} }, 'page.signTx.crossChain.title'],
+    [
+      'crossSwapToken',
+      { crossSwapToken: {} },
+      'page.signTx.swapAndCross.title',
+    ],
+    ['wrapToken', { wrapToken: {} }, 'page.signTx.wrapToken'],
+    ['unWrapToken', { unWrapToken: {} }, 'page.signTx.unwrap'],
+    ['send', { send: {} }, 'page.signTx.send.title'],
+    ['approveToken', { approveToken: {} }, 'page.signTx.tokenApprove.title'],
+    [
+      'revokeToken',
+      { revokeToken: {} },
+      'page.signTx.revokeTokenApprove.title',
+    ],
+    ['sendNFT', { sendNFT: {} }, 'page.signTx.sendNFT.title'],
+    ['approveNFT', { approveNFT: {} }, 'page.signTx.nftApprove.title'],
+    ['revokeNFT', { revokeNFT: {} }, 'page.signTx.revokeNFTApprove.title'],
+    [
+      'approveNFTCollection',
+      { approveNFTCollection: {} },
+      'page.signTx.nftCollectionApprove.title',
+    ],
+    [
+      'revokeNFTCollection',
+      { revokeNFTCollection: {} },
+      'page.signTx.revokeNFTCollectionApprove.title',
+    ],
+    [
+      'deployContract',
+      { deployContract: {} },
+      'page.signTx.deployContract.title',
+    ],
+    ['cancelTx', { cancelTx: {} }, 'page.signTx.cancelTx.title'],
+    ['pushMultiSig', { pushMultiSig: {} }, 'page.signTx.submitMultisig.title'],
+    ['contractCall', { contractCall: {} }, 'page.signTx.unknownAction'],
+    ['revokePermit2', { revokePermit2: {} }, 'page.signTx.revokePermit2.title'],
+    ['assetOrder', { assetOrder: {} }, 'page.signTx.assetOrder.title'],
+    [
+      'permit2BatchRevokeToken',
+      { permit2BatchRevokeToken: {} },
+      'page.signTx.batchRevokePermit2.title',
+    ],
+    ['transferOwner', { transferOwner: {} }, 'page.signTx.transferOwner.title'],
+    ['swapLimitPay', { swapLimitPay: {} }, 'page.signTx.swapLimitPay.title'],
+    ['multiSwap', { multiSwap: {} }, 'page.signTx.swap.title'],
+    ['addLiquidity', { addLiquidity: {} }, 'page.signTx.addLiquidity.title'],
+  ])('maps %s action data to the expected i18n key', (_name, data, key) => {
+    expect(getActionTypeText(data as any)).toBe(`t:${key}`);
+  });
+
+  it('uses common title when no earlier action branch matches', () => {
+    expect(
+      getActionTypeText({ common: { title: 'Common title' } } as any),
+    ).toBe('Common title');
+  });
+
+  it('falls back to unknown action when action data does not match a known branch', () => {
+    expect(getActionTypeText({} as any)).toBe('t:page.signTx.unknownAction');
+  });
+
+  it('keeps branch priority stable when multiple action flags are present', () => {
+    expect(
+      getActionTypeText({
+        swap: {},
+        send: {},
+        common: { title: 'Common title' },
+      } as any),
+    ).toBe('t:page.signTx.swap.title');
+  });
+
+  it.each([
+    ['swap_token', 'page.signTx.swap.title'],
+    ['cross_token', 'page.signTx.crossChain.title'],
+    ['cross_swap_token', 'page.signTx.swapAndCross.title'],
+    ['send_token', 'page.signTx.send.title'],
+    ['approve_token', 'page.signTx.tokenApprove.title'],
+    ['revoke_token', 'page.signTx.revokeTokenApprove.title'],
+    ['permit2_revoke_token', 'page.signTx.revokePermit2.title'],
+    ['wrap_token', 'page.signTx.wrapToken'],
+    ['unwrap_token', 'page.signTx.unwrap'],
+    ['send_nft', 'page.signTx.sendNFT.title'],
+    ['approve_nft', 'page.signTx.nftApprove.title'],
+    ['revoke_nft', 'page.signTx.revokeNFTApprove.title'],
+    ['approve_collection', 'page.signTx.nftCollectionApprove.title'],
+    ['revoke_collection', 'page.signTx.revokeNFTCollectionApprove.title'],
+    ['deploy_contract', 'page.signTx.deployContract.title'],
+    ['cancel_tx', 'page.signTx.cancelTx.title'],
+    ['push_multisig', 'page.signTx.submitMultisig.title'],
+    ['contract_call', 'page.signTx.contractCall.title'],
+    ['swap_order', 'page.signTx.assetOrder.title'],
+    ['permit2_batch_revoke_token', 'page.signTx.batchRevokePermit2.title'],
+    ['transfer_owner', 'page.signTx.transferOwner.title'],
+    ['multiSwap', 'page.signTx.swap.title'],
+    ['swapLimitPay', 'page.signTx.swapLimitPay.title'],
+  ])('maps action type %s to the expected i18n key', (type, key) => {
+    expect(getActionTypeTextByType(type)).toBe(`t:${key}`);
+  });
+
+  it('falls back to unknown action for unknown action types', () => {
+    expect(getActionTypeTextByType('unknown')).toBe(
+      't:page.signTx.unknownAction',
+    );
+  });
+});

--- a/apps/mobile/src/components/Approval/components/TextActions/__tests__/utils.test.ts
+++ b/apps/mobile/src/components/Approval/components/TextActions/__tests__/utils.test.ts
@@ -1,0 +1,39 @@
+import { getActionTypeText } from '../utils';
+
+jest.mock('@/utils/i18n', () => ({
+  __esModule: true,
+  default: {
+    t: jest.fn((key: string) => `t:${key}`),
+  },
+}));
+
+describe('Approval TextActions utils', () => {
+  it('maps typed-data create-key and verify-address actions to i18n keys', () => {
+    expect(getActionTypeText({ createKey: {} } as any)).toBe(
+      't:page.signTypedData.createKey.title',
+    );
+    expect(getActionTypeText({ verifyAddress: {} } as any)).toBe(
+      't:page.signTypedData.verifyAddress.title',
+    );
+  });
+
+  it('uses the common title when no earlier typed-data branch matches', () => {
+    expect(
+      getActionTypeText({ common: { title: 'Typed common' } } as any),
+    ).toBe('Typed common');
+  });
+
+  it('falls back to unknown action for null or unknown typed-data actions', () => {
+    expect(getActionTypeText(null)).toBe('t:page.signTx.unknownAction');
+    expect(getActionTypeText({} as any)).toBe('t:page.signTx.unknownAction');
+  });
+
+  it('keeps typed-data branch priority before common titles', () => {
+    expect(
+      getActionTypeText({
+        createKey: {},
+        common: { title: 'Typed common' },
+      } as any),
+    ).toBe('t:page.signTypedData.createKey.title');
+  });
+});

--- a/apps/mobile/src/screens/GasAccount/components/__tests__/GasAccountEmptyState.utils.test.ts
+++ b/apps/mobile/src/screens/GasAccount/components/__tests__/GasAccountEmptyState.utils.test.ts
@@ -1,0 +1,38 @@
+import { getGasAccountEmptyStatePrimaryMode } from '../GasAccountEmptyState.utils';
+
+describe('GasAccountEmptyState utils', () => {
+  it('uses claimGift only for logged-out users without pending hardware account and with an eligible gift address', () => {
+    expect(
+      getGasAccountEmptyStatePrimaryMode({
+        isLogin: false,
+        hasPendingHardwareAccount: false,
+        hasEligibleGiftAddress: true,
+      }),
+    ).toBe('claimGift');
+  });
+
+  it.each([
+    {
+      isLogin: true,
+      hasPendingHardwareAccount: false,
+      hasEligibleGiftAddress: true,
+    },
+    {
+      isLogin: false,
+      hasPendingHardwareAccount: true,
+      hasEligibleGiftAddress: true,
+    },
+    {
+      isLogin: false,
+      hasPendingHardwareAccount: false,
+      hasEligibleGiftAddress: false,
+    },
+    {
+      isLogin: true,
+      hasPendingHardwareAccount: true,
+      hasEligibleGiftAddress: false,
+    },
+  ])('uses deposit for non-claimable state %#', state => {
+    expect(getGasAccountEmptyStatePrimaryMode(state)).toBe('deposit');
+  });
+});

--- a/apps/mobile/src/screens/TokenDetail/components/Market/__tests__/utils.test.ts
+++ b/apps/mobile/src/screens/TokenDetail/components/Market/__tests__/utils.test.ts
@@ -1,0 +1,53 @@
+import { sortTokenWithSymbol } from '../utils';
+
+const makeToken = (symbol: string, id = symbol) => ({
+  id,
+  symbol,
+  amount: 1,
+  price: 1,
+  usd_value: 1,
+});
+
+describe('TokenDetail Market utils', () => {
+  it('sorts exact symbol matches before wrapped and partial matches', () => {
+    const tokens = [
+      makeToken('DAI'),
+      makeToken('WETH'),
+      makeToken('stETH'),
+      makeToken('ETH'),
+      makeToken('RETH'),
+    ];
+
+    expect(
+      sortTokenWithSymbol(tokens, 'ETH').map(token => token.symbol),
+    ).toEqual(['ETH', 'WETH', 'stETH', 'RETH', 'DAI']);
+  });
+
+  it('matches symbols case-insensitively and keeps stable order within the same rank', () => {
+    const tokens = [
+      makeToken('eth', 'a'),
+      makeToken('ETH', 'b'),
+      makeToken('weth', 'c'),
+      makeToken('WETH', 'd'),
+      makeToken('DAI', 'e'),
+    ];
+
+    expect(sortTokenWithSymbol(tokens, 'eTh').map(token => token.id)).toEqual([
+      'a',
+      'b',
+      'c',
+      'd',
+      'e',
+    ]);
+  });
+
+  it('preserves original order when the target symbol is empty', () => {
+    const tokens = [makeToken('DAI'), makeToken('USDC'), makeToken('ETH')];
+
+    expect(sortTokenWithSymbol(tokens, '').map(token => token.symbol)).toEqual([
+      'DAI',
+      'USDC',
+      'ETH',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add approval transaction action title mapping coverage for action data and action type strings
- add typed-data action title mapping coverage
- add token market symbol sorting coverage and GasAccount empty-state primary action coverage

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand apps/mobile/src/components/Approval/components/Actions/__tests__/utils.test.ts apps/mobile/src/components/Approval/components/TextActions/__tests__/utils.test.ts apps/mobile/src/screens/TokenDetail/components/Market/__tests__/utils.test.ts apps/mobile/src/screens/GasAccount/components/__tests__/GasAccountEmptyState.utils.test.ts
- corepack yarn workspace rabby-mobile eslint src/components/Approval/components/Actions/__tests__/utils.test.ts src/components/Approval/components/TextActions/__tests__/utils.test.ts src/screens/TokenDetail/components/Market/__tests__/utils.test.ts src/screens/GasAccount/components/__tests__/GasAccountEmptyState.utils.test.ts
- git diff --check