### PR TITLE
test: cover notification and concurrency utilities

### DIFF
--- a/apps/mobile/src/core/notifications/__tests__/utils.test.ts
+++ b/apps/mobile/src/core/notifications/__tests__/utils.test.ts
@@ -1,0 +1,117 @@
+import { filterOutTopAccounts, getAccountList } from '../../apis/account';
+import {
+  findMyAccountByOwnerAddress,
+  getTopMyAccountsOnNotifications,
+} from '../utils';
+
+jest.mock('../../apis/account', () => ({
+  getAccountList: jest.fn(),
+  filterOutTopAccounts: jest.fn((accounts, options) => {
+    const topAccounts = accounts.slice(0, options.topCount);
+    const restAccounts = accounts.slice(options.topCount);
+    return {
+      topAccounts,
+      topAddresses: topAccounts.map((account: { address: string }) =>
+        account.address.toLowerCase(),
+      ),
+      topRecords: topAccounts.map((account: { address: string }) => ({
+        address: account.address,
+        gatherSameAddress: options.gatherSameAddress,
+      })),
+      restAccounts,
+    };
+  }),
+}));
+
+const mockGetAccountList = getAccountList as jest.MockedFunction<
+  typeof getAccountList
+>;
+const mockFilterOutTopAccounts = filterOutTopAccounts as jest.MockedFunction<
+  typeof filterOutTopAccounts
+>;
+
+const accounts = [
+  { address: '0x00000000000000000000000000000000000000AA' },
+  { address: '0x00000000000000000000000000000000000000BB' },
+  { address: '0x00000000000000000000000000000000000000CC' },
+] as any[];
+
+describe('notification utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAccountList.mockResolvedValue({
+      sortedAccounts: accounts,
+    } as any);
+  });
+
+  it('returns top account records for notification targeting', async () => {
+    await expect(
+      getTopMyAccountsOnNotifications({ gatherSameAddress: true }),
+    ).resolves.toEqual({
+      top100Accounts: accounts,
+      top100Addresses: accounts.map(account => account.address.toLowerCase()),
+      top100Records: accounts.map(account => ({
+        address: account.address,
+        gatherSameAddress: true,
+      })),
+      restAccounts: [],
+    });
+
+    expect(mockGetAccountList).toHaveBeenCalledWith({ filter: 'onlyMine' });
+    expect(mockFilterOutTopAccounts).toHaveBeenCalledWith(accounts, {
+      topCount: 100,
+      gatherSameAddress: true,
+    });
+  });
+
+  it('shares the in-flight top-account request across concurrent callers', async () => {
+    let resolveAccounts: (value: any) => void = jest.fn();
+    mockGetAccountList.mockReset();
+    mockGetAccountList.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveAccounts = resolve;
+        }),
+    );
+
+    const p1 = getTopMyAccountsOnNotifications({ gatherSameAddress: false });
+    const p2 = getTopMyAccountsOnNotifications({ gatherSameAddress: true });
+
+    expect(mockGetAccountList).toHaveBeenCalledTimes(1);
+    resolveAccounts({ sortedAccounts: accounts });
+
+    await expect(Promise.all([p1, p2])).resolves.toEqual([
+      {
+        top100Accounts: accounts,
+        top100Addresses: accounts.map(account => account.address.toLowerCase()),
+        top100Records: accounts.map(account => ({
+          address: account.address,
+          gatherSameAddress: false,
+        })),
+        restAccounts: [],
+      },
+      {
+        top100Accounts: accounts,
+        top100Addresses: accounts.map(account => account.address.toLowerCase()),
+        top100Records: accounts.map(account => ({
+          address: account.address,
+          gatherSameAddress: false,
+        })),
+        restAccounts: [],
+      },
+    ]);
+  });
+
+  it('finds a top account by owner address case-insensitively', async () => {
+    await expect(
+      findMyAccountByOwnerAddress('0x00000000000000000000000000000000000000aa'),
+    ).resolves.toBe(accounts[0]);
+  });
+
+  it('returns null for empty or missing owner addresses', async () => {
+    await expect(findMyAccountByOwnerAddress('')).resolves.toBe(null);
+    await expect(
+      findMyAccountByOwnerAddress('0x00000000000000000000000000000000000000dd'),
+    ).resolves.toBe(null);
+  });
+});

--- a/apps/mobile/src/core/utils/__tests__/concurrency.test.ts
+++ b/apps/mobile/src/core/utils/__tests__/concurrency.test.ts
@@ -1,0 +1,112 @@
+import {
+  makeAvoidParallelAsyncFunc,
+  makeAvoidParallelFunc,
+  makeSWRKeyAsyncFunc,
+} from '../concurrency';
+
+describe('core concurrency utils', () => {
+  it('prevents re-entrant sync calls and allows later calls after completion', () => {
+    let calls = 0;
+    let wrapped: () => void;
+
+    wrapped = makeAvoidParallelFunc(() => {
+      calls += 1;
+      wrapped();
+    });
+
+    wrapped();
+    wrapped();
+
+    expect(calls).toBe(2);
+  });
+
+  it('resets sync execution state and rethrows errors', () => {
+    const error = new Error('boom');
+    const fn = jest
+      .fn()
+      .mockImplementationOnce(() => {
+        throw error;
+      })
+      .mockImplementationOnce(() => 'ok');
+    const wrapped = makeAvoidParallelFunc(fn);
+
+    expect(() => wrapped()).toThrow(error);
+    expect(() => wrapped()).not.toThrow();
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares an in-flight async call and resets after it resolves', async () => {
+    let resolveFirst: (value: string) => void = jest.fn();
+    const fn = jest
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<string>(resolve => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce('second');
+    const wrapped = makeAvoidParallelAsyncFunc(fn);
+
+    const p1 = wrapped('first');
+    const p2 = wrapped('ignored');
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    resolveFirst('first-result');
+    await expect(Promise.all([p1, p2])).resolves.toEqual([
+      'first-result',
+      'first-result',
+    ]);
+
+    await expect(wrapped('second')).resolves.toBe('second');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('resets async execution state and rethrows errors', async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('async boom'))
+      .mockResolvedValueOnce('ok');
+    const wrapped = makeAvoidParallelAsyncFunc(fn);
+
+    await expect(wrapped()).rejects.toThrow('async boom');
+    await expect(wrapped()).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('deduplicates async calls by static SWR key', async () => {
+    let resolveFirst: (value: string) => void = jest.fn();
+    const fn = jest
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<string>(resolve => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce('second');
+    const wrapped = makeSWRKeyAsyncFunc(fn, 'static-key');
+
+    const p1 = wrapped('a');
+    const p2 = wrapped('b');
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    resolveFirst('first');
+    await expect(Promise.all([p1, p2])).resolves.toEqual(['first', 'first']);
+
+    await expect(wrapped('c')).resolves.toBe('second');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('deduplicates async calls by computed SWR key', async () => {
+    const fn = jest.fn(async (scope: string, id: string) => `${scope}:${id}`);
+    const wrapped = makeSWRKeyAsyncFunc(fn, ({ args }) => args);
+
+    await expect(
+      Promise.all([wrapped('wallet', '1'), wrapped('wallet', '1')]),
+    ).resolves.toEqual(['wallet:1', 'wallet:1']);
+    await wrapped('wallet', '2');
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add core concurrency utility coverage for sync re-entry prevention, async in-flight sharing, error reset and SWR-key dedupe
- add notification utility coverage for top-account targeting shape, concurrent top-account request sharing, and owner-address lookup

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand apps/mobile/src/core/utils/__tests__/concurrency.test.ts apps/mobile/src/core/notifications/__tests__/utils.test.ts
- corepack yarn workspace rabby-mobile eslint src/core/utils/__tests__/concurrency.test.ts src/core/notifications/__tests__/utils.test.ts
- git diff --check