### PR TITLE
test: cover native and dapp utilities

### DIFF
--- a/apps/mobile/src/constant/__tests__/dappView.test.ts
+++ b/apps/mobile/src/constant/__tests__/dappView.test.ts
@@ -1,0 +1,102 @@
+import { Linking } from 'react-native';
+
+import {
+  allowLinkOpen,
+  getAlertMessage,
+  isOrHasWithAllowedProtocol,
+  parsePossibleURL,
+  protocolAllowList,
+  trustedProtocolToDeeplink,
+} from '../dappView';
+
+jest.mock('@/utils/url', () => ({
+  isPossibleDomain: jest.fn((input: string) =>
+    /^(?:\S(?:\S{0,61}\S)?\.)+\S{2,}$/.test(input),
+  ),
+}));
+
+describe('dappView constants and helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps webview protocol allowlists stable', () => {
+    expect(protocolAllowList).toEqual(['about:', 'http:', 'https:']);
+    expect(trustedProtocolToDeeplink).toEqual([
+      'wc:',
+      'metamask:',
+      'ethereum:',
+      'dapp:',
+    ]);
+  });
+
+  it('checks direct protocols and URLs for webview-allowed protocols', () => {
+    expect(isOrHasWithAllowedProtocol()).toBe(false);
+    expect(isOrHasWithAllowedProtocol('https:')).toBe(true);
+    expect(isOrHasWithAllowedProtocol('https://rabby.io')).toBe(true);
+    expect(isOrHasWithAllowedProtocol('wc:topic@2')).toBe(false);
+  });
+
+  it('parses possible domain input into https URLs and rejects unsupported protocols', () => {
+    expect(parsePossibleURL(' rabby.io ')).toBe('https://rabby.io');
+    expect(parsePossibleURL('')).toBe(null);
+    expect(parsePossibleURL('wc:topic@2')).toBe(null);
+    expect(parsePossibleURL('not a domain')).toBeUndefined();
+  });
+
+  it('returns expected alert decisions by protocol', () => {
+    expect(getAlertMessage('tel:')).toEqual({
+      needAlert: true,
+      allowOpenLink: false,
+      message:
+        'This website has been blocked from automatically making a phone call',
+    });
+    expect(getAlertMessage('mailto:')).toEqual({
+      needAlert: true,
+      allowOpenLink: false,
+      message:
+        'This website has been blocked from automatically composing an email.',
+    });
+    expect(getAlertMessage('blob:')).toEqual({
+      needAlert: false,
+      allowOpenLink: true,
+      message: '',
+    });
+    expect(getAlertMessage('unknown:')).toEqual({
+      needAlert: true,
+      allowOpenLink: false,
+      message:
+        'This website has been blocked from automatically opening an external application',
+    });
+  });
+
+  it('opens supported external links through React Native Linking', async () => {
+    const canOpenURL = jest
+      .spyOn(Linking, 'canOpenURL')
+      .mockResolvedValueOnce(true);
+    const openURL = jest.spyOn(Linking, 'openURL').mockResolvedValueOnce();
+
+    await allowLinkOpen('https://rabby.io');
+
+    expect(canOpenURL).toHaveBeenCalledWith('https://rabby.io');
+    expect(openURL).toHaveBeenCalledWith('https://rabby.io');
+  });
+
+  it('warns when external links are unsupported or Linking throws', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+    jest.spyOn(Linking, 'canOpenURL').mockResolvedValueOnce(false);
+
+    await expect(allowLinkOpen('unsupported:link')).resolves.toBe(null);
+    expect(warnSpy).toHaveBeenCalledWith("Can't open url: unsupported:link");
+
+    (Linking.canOpenURL as jest.Mock).mockRejectedValueOnce(
+      new Error('linking failed'),
+    );
+    await allowLinkOpen('https://rabby.io');
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Error opening URL: Error: linking failed',
+    );
+
+    warnSpy.mockRestore();
+  });
+});

--- a/apps/mobile/src/core/native/__tests__/utils.test.ts
+++ b/apps/mobile/src/core/native/__tests__/utils.test.ts
@@ -1,0 +1,125 @@
+import { NativeModules, Platform } from 'react-native';
+
+import {
+  makeRnEEClass,
+  resolveNativeModule,
+  wrapPlatformOnlyMethod,
+} from '../utils';
+
+const originalPlatformOS = Platform.OS;
+
+const setPlatformOS = (os: typeof Platform.OS) => {
+  Object.defineProperty(Platform, 'OS', {
+    configurable: true,
+    get: () => os,
+  });
+};
+
+describe('native utils', () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(jest.fn());
+    setPlatformOS(originalPlatformOS);
+    delete (NativeModules as any).RNHelpers;
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    setPlatformOS(originalPlatformOS);
+    delete (NativeModules as any).RNHelpers;
+  });
+
+  describe('resolveNativeModule', () => {
+    it('returns an existing native module by name', () => {
+      const forceExitApp = jest.fn();
+      (NativeModules as any).RNHelpers = { forceExitApp };
+
+      expect(resolveNativeModule('RNHelpers').RNHelpers.forceExitApp).toBe(
+        forceExitApp,
+      );
+    });
+
+    it('returns a throwing proxy when the native module is missing', () => {
+      const { RNHelpers } = resolveNativeModule('RNHelpers');
+
+      expect(() => RNHelpers.forceExitApp).toThrow(
+        "The native module 'RNHelpers' doesn't seem to be added",
+      );
+    });
+  });
+
+  it('exposes the React Native NativeEventEmitter class for typed event emitters', () => {
+    const { NativeEventEmitter } = makeRnEEClass<{
+      changed: () => void;
+    }>();
+
+    expect(typeof NativeEventEmitter).toBe('function');
+  });
+
+  describe('wrapPlatformOnlyMethod', () => {
+    it('uses the native method on supported platforms', async () => {
+      setPlatformOS('ios');
+      const method = jest.fn(async () => undefined);
+      const fallbackFn = jest.fn(async () => undefined);
+
+      await wrapPlatformOnlyMethod({
+        method,
+        fallbackFn,
+        platform: 'ios',
+      })('arg');
+
+      expect(method).toHaveBeenCalledWith('arg');
+      expect(fallbackFn).not.toHaveBeenCalled();
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('throws when a required platform method is missing', () => {
+      setPlatformOS('android');
+
+      expect(() =>
+        wrapPlatformOnlyMethod({
+          method: undefined,
+          fallbackFn: jest.fn(),
+          platform: 'android',
+        }),
+      ).toThrow(
+        'Method is not implemented on platform android, but it should be',
+      );
+    });
+
+    it('uses and returns fallback result on unsupported platforms', async () => {
+      setPlatformOS('android');
+      const method = jest.fn(async () => undefined);
+      const fallbackFn = jest.fn(async () => undefined);
+
+      await expect(
+        wrapPlatformOnlyMethod({
+          method,
+          fallbackFn,
+          platform: 'ios',
+        })('arg'),
+      ).resolves.toBeUndefined();
+
+      expect(method).not.toHaveBeenCalled();
+      expect(fallbackFn).toHaveBeenCalledWith('arg');
+      expect(console.error).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    it('supports multiple allowed platforms', () => {
+      setPlatformOS('android');
+      const method = jest.fn();
+      const fallbackFn = jest.fn();
+
+      wrapPlatformOnlyMethod({
+        method,
+        fallbackFn,
+        platform: ['ios', 'android'],
+      })();
+
+      expect(method).toHaveBeenCalledTimes(1);
+      expect(fallbackFn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/mobile/src/core/native/utils.ts
+++ b/apps/mobile/src/core/native/utils.ts
@@ -151,7 +151,7 @@ export function wrapPlatformOnlyMethod<
       );
 
       console.error(err);
-      fallbackFn(...args);
+      return fallbackFn(...args);
     } as T;
   }
 


### PR DESCRIPTION
## Summary
- add native utility coverage for module resolution, missing module proxy errors, typed native event emitter export and platform-only method dispatch
- add dappView coverage for protocol allowlists, possible URL parsing, alert decisions and Linking open/warn branches
- fix wrapPlatformOnlyMethod to return fallbackFn result on unsupported platforms, preserving async fallback behavior

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand apps/mobile/src/core/native/__tests__/utils.test.ts apps/mobile/src/constant/__tests__/dappView.test.ts
- corepack yarn workspace rabby-mobile eslint src/core/native/utils.ts src/core/native/__tests__/utils.test.ts src/constant/dappView.ts src/constant/__tests__/dappView.test.ts
- git diff --check

Note: targeted lint exits clean with existing curly warnings in src/constant/dappView.ts.