### PR TITLE
test: cover signing and unlock utilities

### DIFF
--- a/apps/mobile/src/utils/sendPersonalMessage.test.ts
+++ b/apps/mobile/src/utils/sendPersonalMessage.test.ts
@@ -1,0 +1,132 @@
+const mockEthPersonalSign = jest.fn();
+const mockMatomoRequestEvent = jest.fn();
+const mockStatsReport = jest.fn();
+const mockGetKRCategoryByType = jest.fn();
+const mockEventBusEmit = jest.fn();
+
+jest.mock('@/core/apis/provider', () => ({
+  ethPersonalSign: (...args: unknown[]) => mockEthPersonalSign(...args),
+}));
+
+jest.mock('@/constant', () => ({
+  INTERNAL_REQUEST_SESSION: { name: 'internal-session' },
+}));
+
+jest.mock('./analytics', () => ({
+  matomoRequestEvent: (...args: unknown[]) => mockMatomoRequestEvent(...args),
+}));
+
+jest.mock('./stats', () => ({
+  stats: {
+    report: (...args: unknown[]) => mockStatsReport(...args),
+  },
+}));
+
+jest.mock('./transaction', () => ({
+  getKRCategoryByType: (...args: unknown[]) => mockGetKRCategoryByType(...args),
+}));
+
+jest.mock('./events', () => ({
+  eventBus: {
+    emit: (...args: unknown[]) => mockEventBusEmit(...args),
+  },
+  EVENTS: {
+    COMMON_HARDWARE: {
+      REJECTED: 'COMMON_HARDWARE.REJECTED',
+    },
+  },
+}));
+
+import { INTERNAL_REQUEST_SESSION } from '@/constant';
+import { FailedCode, sendPersonalMessage } from './sendPersonalMessage';
+
+const account = {
+  address: '0x1111111111111111111111111111111111111111',
+  type: 'SimpleKeyring',
+  brandName: 'Rabby',
+} as any;
+
+describe('sendPersonalMessage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetKRCategoryByType.mockReturnValue('private-key');
+    mockStatsReport.mockResolvedValue(undefined);
+  });
+
+  it('reports progress, signs with the internal session, and returns the signature', async () => {
+    const onProgress = jest.fn();
+    mockEthPersonalSign.mockResolvedValue('0xsigned');
+
+    await expect(
+      sendPersonalMessage({
+        data: ['0x68656c6c6f', account.address],
+        onProgress,
+        account,
+      }),
+    ).resolves.toEqual({ txHash: '0xsigned' });
+
+    expect(onProgress.mock.calls.map(call => call[0])).toEqual([
+      'building',
+      'builded',
+      'signed',
+    ]);
+    expect(mockEthPersonalSign).toHaveBeenCalledWith({
+      data: {
+        params: ['0x68656c6c6f', account.address],
+      },
+      approvalRes: {
+        extra: {
+          brandName: account.brandName,
+          signTextMethod: 'personalSign',
+        },
+      },
+      session: INTERNAL_REQUEST_SESSION,
+      account,
+    });
+    expect(mockMatomoRequestEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'SignText',
+        action: 'createSignText',
+        label: 'private-key|Rabby',
+      }),
+    );
+    expect(mockStatsReport).toHaveBeenCalledWith(
+      'startSignText',
+      expect.objectContaining({
+        type: 'Rabby',
+        category: 'private-key',
+        method: 'personalSign',
+      }),
+    );
+    expect(mockEventBusEmit).not.toHaveBeenCalled();
+  });
+
+  it('emits hardware rejection and throws a named submit error on signing failure', async () => {
+    const onProgress = jest.fn();
+    mockEthPersonalSign.mockRejectedValue(new Error('user rejected'));
+
+    await expect(
+      sendPersonalMessage({
+        data: ['0x68656c6c6f', account.address],
+        onProgress,
+        account,
+      }),
+    ).rejects.toMatchObject({
+      name: FailedCode.SubmitTxFailed,
+      message: 'user rejected',
+    });
+
+    expect(onProgress.mock.calls.map(call => call[0])).toEqual([
+      'building',
+      'builded',
+    ]);
+    expect(mockEventBusEmit).toHaveBeenCalledWith(
+      'COMMON_HARDWARE.REJECTED',
+      'user rejected',
+    );
+    expect(mockStatsReport).toHaveBeenCalledWith(
+      'completeSignText',
+      expect.objectContaining({ method: 'personalSign' }),
+    );
+  });
+});

--- a/apps/mobile/src/utils/sendTypedData.test.ts
+++ b/apps/mobile/src/utils/sendTypedData.test.ts
@@ -1,0 +1,172 @@
+const mockSignTypedData = jest.fn();
+const mockMatomoRequestEvent = jest.fn();
+const mockStatsReport = jest.fn();
+const mockGetKRCategoryByType = jest.fn();
+const mockEventBusEmit = jest.fn();
+const mockConsoleError = jest.spyOn(console, 'error').mockImplementation();
+
+jest.mock('@/core/apis/keyring', () => ({
+  apisKeyring: {
+    signTypedData: (...args: unknown[]) => mockSignTypedData(...args),
+  },
+}));
+
+jest.mock('./analytics', () => ({
+  matomoRequestEvent: (...args: unknown[]) => mockMatomoRequestEvent(...args),
+}));
+
+jest.mock('./stats', () => ({
+  stats: {
+    report: (...args: unknown[]) => mockStatsReport(...args),
+  },
+}));
+
+jest.mock('./transaction', () => ({
+  getKRCategoryByType: (...args: unknown[]) => mockGetKRCategoryByType(...args),
+}));
+
+jest.mock('@rabby-wallet/keyring-utils', () => ({
+  eventBus: {
+    emit: (...args: unknown[]) => mockEventBusEmit(...args),
+  },
+}));
+
+jest.mock('./events', () => ({
+  EVENTS: {
+    COMMON_HARDWARE: {
+      REJECTED: 'COMMON_HARDWARE.REJECTED',
+    },
+  },
+}));
+
+import { FailedCode, sendSignTypedData } from './sendTypedData';
+
+const account = {
+  address: '0x1111111111111111111111111111111111111111',
+  type: 'SimpleKeyring',
+  brandName: 'Rabby',
+} as any;
+
+const typedData = {
+  domain: {
+    name: 'Rabby Test',
+  },
+  message: {
+    value: 'hello',
+  },
+};
+
+describe('sendSignTypedData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetKRCategoryByType.mockReturnValue('private-key');
+    mockStatsReport.mockResolvedValue(undefined);
+  });
+
+  afterAll(() => {
+    mockConsoleError.mockRestore();
+  });
+
+  it('requires an account before building typed-data signing', async () => {
+    await expect(
+      sendSignTypedData({
+        data: typedData,
+        from: account.address,
+        version: 'V4',
+      }),
+    ).rejects.toThrow('Account is required for signing typed data');
+    expect(mockSignTypedData).not.toHaveBeenCalled();
+  });
+
+  it('signs V4 typed data with the derived method and returns the signature', async () => {
+    const onProgress = jest.fn();
+    mockSignTypedData.mockResolvedValue('0xtyped');
+
+    await expect(
+      sendSignTypedData({
+        data: typedData,
+        from: account.address,
+        version: 'V4',
+        onProgress,
+        account,
+      }),
+    ).resolves.toEqual({ txHash: '0xtyped' });
+
+    expect(onProgress.mock.calls).toEqual([
+      ['building'],
+      ['builded'],
+      ['signed', '0xtyped'],
+    ]);
+    expect(mockSignTypedData).toHaveBeenCalledWith(
+      account.type,
+      account.address,
+      typedData,
+      {
+        brandName: account.brandName,
+        signTextMethod: 'ethSignTypedDataV4',
+        version: 'V4',
+      },
+    );
+    expect(mockStatsReport).toHaveBeenCalledWith(
+      'startSignText',
+      expect.objectContaining({
+        type: 'Rabby',
+        category: 'private-key',
+        method: 'ethSignTypedDataV4',
+      }),
+    );
+    expect(mockMatomoRequestEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'SignText',
+        action: 'completeSignText',
+        label: 'private-key|Rabby',
+      }),
+    );
+  });
+
+  it('uses the legacy method name for V1 typed data', async () => {
+    mockSignTypedData.mockResolvedValue('0xv1');
+
+    await sendSignTypedData({
+      data: typedData,
+      from: account.address,
+      version: 'V1',
+      account,
+    });
+
+    expect(mockSignTypedData).toHaveBeenCalledWith(
+      account.type,
+      account.address,
+      typedData,
+      expect.objectContaining({
+        signTextMethod: 'ethSignTypedData',
+        version: 'V1',
+      }),
+    );
+  });
+
+  it('emits hardware rejection and throws a named submit error on failure', async () => {
+    mockSignTypedData.mockRejectedValue(new Error('ledger rejected'));
+
+    await expect(
+      sendSignTypedData({
+        data: typedData,
+        from: account.address,
+        version: 'V3',
+        account,
+      }),
+    ).rejects.toMatchObject({
+      name: FailedCode.SubmitTxFailed,
+      message: 'ledger rejected',
+    });
+
+    expect(mockEventBusEmit).toHaveBeenCalledWith(
+      'COMMON_HARDWARE.REJECTED',
+      'ledger rejected',
+    );
+    expect(mockStatsReport).toHaveBeenCalledWith(
+      'completeSignText',
+      expect.objectContaining({ method: 'ethSignTypedDataV3' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add personal message signing tests for progress, internal session payload, SignText analytics, and hardware rejection errors
- add typed-data signing tests for account requirement, V1/V4 method selection, SignText reporting, and rejection errors
- add wallet unlock guard tests for requester delegation, unlock-required detection, sensitive keyring checks, and wrapper helpers

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/utils/sendPersonalMessage.test.ts src/utils/sendTypedData.test.ts src/utils/walletUnlockGuard.test.ts
- corepack yarn workspace rabby-mobile eslint src/utils/sendPersonalMessage.test.ts src/utils/sendTypedData.test.ts src/utils/walletUnlockGuard.test.ts --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached