### PR TITLE
test: cover display and ENS utilities

### DIFF
--- a/apps/mobile/src/utils/curveDayType.test.ts
+++ b/apps/mobile/src/utils/curveDayType.test.ts
@@ -1,0 +1,8 @@
+import { CurveDayType } from './curveDayType';
+
+describe('CurveDayType', () => {
+  it('maps chart day types to the day counts used by balance curves', () => {
+    expect(CurveDayType.DAY).toBe(1);
+    expect(CurveDayType.WEEK).toBe(7);
+  });
+});

--- a/apps/mobile/src/utils/ens.test.ts
+++ b/apps/mobile/src/utils/ens.test.ts
@@ -1,0 +1,131 @@
+const mockGetEnsAddress = jest.fn();
+const mockGetEnsName = jest.fn();
+const mockCreatePublicClient = jest.fn();
+const mockCustom = jest.fn();
+const mockRequestETHRpc = jest.fn();
+
+const loadSubject = () => {
+  jest.resetModules();
+  jest.doMock('viem', () => {
+    const actual = jest.requireActual('viem');
+    return {
+      ...actual,
+      createPublicClient: (...args: unknown[]) => {
+        mockCreatePublicClient(...args);
+        return {
+          getEnsAddress: (...clientArgs: unknown[]) =>
+            mockGetEnsAddress(...clientArgs),
+          getEnsName: (...clientArgs: unknown[]) =>
+            mockGetEnsName(...clientArgs),
+        };
+      },
+      custom: (transport: unknown) => {
+        mockCustom(transport);
+        return transport;
+      },
+    };
+  });
+  jest.doMock('viem/chains', () => ({
+    mainnet: {
+      id: 1,
+      name: 'Ethereum',
+    },
+  }));
+  jest.doMock('@/core/apis/provider', () => ({
+    requestETHRpc: (...args: unknown[]) => mockRequestETHRpc(...args),
+  }));
+  jest.doMock('@/utils/chain', () => ({
+    findChain: () => ({ serverId: 'eth' }),
+  }));
+  return require('./ens') as typeof import('./ens');
+};
+
+describe('ens utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetEnsAddress.mockReset();
+    mockGetEnsName.mockReset();
+  });
+
+  afterEach(() => {
+    jest.dontMock('viem');
+    jest.dontMock('viem/chains');
+    jest.dontMock('@/core/apis/provider');
+    jest.dontMock('@/utils/chain');
+    jest.resetModules();
+  });
+
+  it('creates an ENS client backed by Rabby ETH RPC transport', async () => {
+    loadSubject();
+
+    expect(mockCreatePublicClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chain: expect.objectContaining({ id: 1 }),
+      }),
+    );
+
+    const transportArg = mockCustom.mock.calls[0][0];
+    mockRequestETHRpc.mockResolvedValue('0x1');
+
+    await expect(
+      transportArg.request({
+        method: 'eth_chainId',
+        params: [],
+      }),
+    ).resolves.toBe('0x1');
+
+    expect(mockRequestETHRpc).toHaveBeenCalledWith(
+      {
+        method: 'eth_chainId',
+        params: [],
+      },
+      'eth',
+    );
+  });
+
+  it('normalizes and resolves ENS names', async () => {
+    const { resolveEnsAddressByName } = loadSubject();
+    mockGetEnsAddress.mockResolvedValue(
+      '0x1111111111111111111111111111111111111111',
+    );
+
+    await expect(resolveEnsAddressByName('  Vitalik.eth  ')).resolves.toEqual({
+      addr: '0x1111111111111111111111111111111111111111',
+      name: 'vitalik.eth',
+    });
+
+    expect(mockGetEnsAddress).toHaveBeenCalledWith({ name: 'vitalik.eth' });
+  });
+
+  it('returns null for empty, unresolved, or invalid ENS names', async () => {
+    const { resolveEnsAddressByName } = loadSubject();
+
+    await expect(resolveEnsAddressByName('   ')).resolves.toBeNull();
+
+    mockGetEnsAddress.mockResolvedValueOnce(null);
+    await expect(resolveEnsAddressByName('missing.eth')).resolves.toBeNull();
+
+    await expect(
+      resolveEnsAddressByName('not a valid ens'),
+    ).resolves.toBeNull();
+  });
+
+  it('resolves reverse ENS names and handles empty or failing lookups', async () => {
+    const { resolveEnsNameByAddress } = loadSubject();
+    mockGetEnsName.mockResolvedValueOnce('vitalik.eth');
+
+    await expect(
+      resolveEnsNameByAddress(' 0x1111111111111111111111111111111111111111 '),
+    ).resolves.toBe('vitalik.eth');
+    expect(mockGetEnsName).toHaveBeenCalledWith({
+      address: '0x1111111111111111111111111111111111111111',
+    });
+
+    await expect(resolveEnsNameByAddress('   ')).resolves.toBeNull();
+
+    mockGetEnsName.mockRejectedValueOnce(new Error('rpc'));
+    await expect(
+      resolveEnsNameByAddress('0x2222222222222222222222222222222222222222'),
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/mobile/src/utils/fontSize.test.ts
+++ b/apps/mobile/src/utils/fontSize.test.ts
@@ -1,0 +1,23 @@
+import { getFontSizeByLength } from './fontSize';
+
+describe('getFontSizeByLength', () => {
+  const options = {
+    maxFontSize: 24,
+    minFontSize: 12,
+    threshold: 8,
+  };
+
+  it('keeps the max font size while the length is under the threshold', () => {
+    expect(getFontSizeByLength(8, options)).toBe(24);
+  });
+
+  it('reduces font size by the default step and clamps to the minimum', () => {
+    expect(getFontSizeByLength(10, options)).toBe(20);
+    expect(getFontSizeByLength(100, options)).toBe(12);
+  });
+
+  it('uses custom step values and treats non-positive steps as minimum size', () => {
+    expect(getFontSizeByLength(10, { ...options, step: 3 })).toBe(18);
+    expect(getFontSizeByLength(10, { ...options, step: 0 })).toBe(12);
+  });
+});

--- a/apps/mobile/src/utils/makeTestIDProps.test.ts
+++ b/apps/mobile/src/utils/makeTestIDProps.test.ts
@@ -1,0 +1,47 @@
+const loadSubject = (runtimeEnv: string) => {
+  jest.resetModules();
+  jest.doMock('@/constant/e2e', () => ({
+    E2E_ID: {
+      Button: {
+        Submit: 'button.submit',
+      },
+    },
+  }));
+  jest.doMock('@/constant/env', () => ({
+    APP_RUNTIME_ENV: runtimeEnv,
+  }));
+  return require('./makeTestIDProps') as typeof import('./makeTestIDProps');
+};
+
+describe('makeTestIDProps', () => {
+  afterEach(() => {
+    jest.dontMock('@/constant/e2e');
+    jest.dontMock('@/constant/env');
+    jest.resetModules();
+  });
+
+  it('returns testID and default accessibilityLabel outside production', () => {
+    const { makeTestIDProps } = loadSubject('development');
+
+    expect(makeTestIDProps('button.submit')).toEqual({
+      testID: 'button.submit',
+      accessibilityLabel: 'button.submit',
+    });
+  });
+
+  it('allows an explicit accessibility label outside production', () => {
+    const { makeTestIDProps } = loadSubject('regression');
+
+    expect(makeTestIDProps('button.submit', 'button.submit')).toEqual({
+      testID: 'button.submit',
+      accessibilityLabel: 'button.submit',
+    });
+  });
+
+  it('hides test IDs in production or when the id is empty', () => {
+    expect(loadSubject('production').makeTestIDProps('button.submit')).toEqual(
+      {},
+    );
+    expect(loadSubject('development').makeTestIDProps(null)).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- add ENS utility tests for RPC-backed client transport, name normalization, empty/unresolved/invalid name handling, and reverse lookup fallback
- add display helper tests for dynamic font-size clamping, E2E testID runtime gating, and curve day constants

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/utils/ens.test.ts src/utils/fontSize.test.ts src/utils/makeTestIDProps.test.ts src/utils/curveDayType.test.ts
- corepack yarn workspace rabby-mobile eslint src/utils/ens.test.ts src/utils/fontSize.test.ts src/utils/makeTestIDProps.test.ts src/utils/curveDayType.test.ts --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached