### PR TITLE
test: cover native permission and share utilities

### DIFF
--- a/apps/mobile/src/utils/bluetoothPermissions.test.ts
+++ b/apps/mobile/src/utils/bluetoothPermissions.test.ts
@@ -1,0 +1,189 @@
+const mockAlert = jest.fn();
+const mockOpenURL = jest.fn();
+const mockSendIntent = jest.fn();
+const mockOpenSettings = jest.fn();
+const mockCheckMultiple = jest.fn();
+const mockRequest = jest.fn();
+const mockRequestMultiple = jest.fn();
+
+jest.mock('react-native', () => ({
+  Alert: {
+    alert: (...args: unknown[]) => mockAlert(...args),
+  },
+  Linking: {
+    openURL: (...args: unknown[]) => mockOpenURL(...args),
+    sendIntent: (...args: unknown[]) => mockSendIntent(...args),
+    openSettings: (...args: unknown[]) => mockOpenSettings(...args),
+  },
+  Platform: {
+    OS: 'ios',
+  },
+}));
+
+jest.mock('react-native-permissions', () => ({
+  checkMultiple: (...args: unknown[]) => mockCheckMultiple(...args),
+  request: (...args: unknown[]) => mockRequest(...args),
+  requestMultiple: (...args: unknown[]) => mockRequestMultiple(...args),
+  PERMISSIONS: {
+    ANDROID: {
+      ACCESS_FINE_LOCATION: 'android.permission.ACCESS_FINE_LOCATION',
+      BLUETOOTH_CONNECT: 'android.permission.BLUETOOTH_CONNECT',
+      BLUETOOTH_SCAN: 'android.permission.BLUETOOTH_SCAN',
+    },
+  },
+  RESULTS: {
+    BLOCKED: 'blocked',
+    DENIED: 'denied',
+    GRANTED: 'granted',
+    UNAVAILABLE: 'unavailable',
+  },
+}));
+
+jest.mock('./i18n', () => ({
+  t: (key: string) => key,
+}));
+
+import { Platform } from 'react-native';
+import { PERMISSIONS, RESULTS } from 'react-native-permissions';
+import {
+  UpdateFirmwareAlert,
+  checkAndRequestAndroidBluetooth,
+  showBluetoothPermissionsAlert,
+  showBluetoothPoweredOffAlert,
+} from './bluetoothPermissions';
+
+const androidPermissions = [
+  PERMISSIONS.ANDROID.BLUETOOTH_CONNECT,
+  PERMISSIONS.ANDROID.BLUETOOTH_SCAN,
+  PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION,
+];
+
+describe('bluetoothPermissions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Platform as any).OS = 'ios';
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('opens platform-specific Bluetooth settings from the powered-off alert', async () => {
+    await showBluetoothPoweredOffAlert();
+    mockAlert.mock.calls[0][2][0].onPress();
+
+    expect(mockOpenURL).toHaveBeenCalledWith('App-Prefs:Bluetooth');
+
+    jest.clearAllMocks();
+    (Platform as any).OS = 'android';
+
+    await showBluetoothPoweredOffAlert();
+    mockAlert.mock.calls[0][2][0].onPress();
+
+    expect(mockSendIntent).toHaveBeenCalledWith(
+      'android.settings.BLUETOOTH_SETTINGS',
+    );
+  });
+
+  it('opens app settings and firmware docs from alerts', async () => {
+    await showBluetoothPermissionsAlert();
+    mockAlert.mock.calls[0][2][0].onPress();
+
+    expect(mockOpenSettings).toHaveBeenCalled();
+
+    jest.clearAllMocks();
+
+    await UpdateFirmwareAlert();
+    mockAlert.mock.calls[0][2][0].onPress();
+
+    expect(mockOpenURL).toHaveBeenCalledWith(
+      'https://support.ledger.com/hc/articles/360003117594-Ledger-device-firmware-update-FAQ',
+    );
+  });
+
+  it('returns true when all Android Bluetooth permissions are already granted', async () => {
+    mockCheckMultiple.mockResolvedValue(
+      Object.fromEntries(
+        androidPermissions.map(permission => [permission, RESULTS.GRANTED]),
+      ),
+    );
+
+    await expect(checkAndRequestAndroidBluetooth()).resolves.toBe(true);
+
+    expect(mockCheckMultiple).toHaveBeenCalledWith(androidPermissions);
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(mockRequestMultiple).not.toHaveBeenCalled();
+  });
+
+  it('requests a single missing Android Bluetooth permission', async () => {
+    mockCheckMultiple.mockResolvedValue({
+      [PERMISSIONS.ANDROID.BLUETOOTH_CONNECT]: RESULTS.GRANTED,
+      [PERMISSIONS.ANDROID.BLUETOOTH_SCAN]: RESULTS.DENIED,
+      [PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION]: RESULTS.GRANTED,
+    });
+    mockRequest.mockResolvedValue(RESULTS.GRANTED);
+
+    await expect(checkAndRequestAndroidBluetooth()).resolves.toBe(true);
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      PERMISSIONS.ANDROID.BLUETOOTH_SCAN,
+    );
+    expect(mockAlert).not.toHaveBeenCalled();
+  });
+
+  it('shows the permissions alert when a single requested permission is denied', async () => {
+    mockCheckMultiple.mockResolvedValue({
+      [PERMISSIONS.ANDROID.BLUETOOTH_CONNECT]: RESULTS.GRANTED,
+      [PERMISSIONS.ANDROID.BLUETOOTH_SCAN]: RESULTS.DENIED,
+      [PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION]: RESULTS.GRANTED,
+    });
+    mockRequest.mockResolvedValue(RESULTS.DENIED);
+
+    await expect(checkAndRequestAndroidBluetooth()).resolves.toBe(false);
+
+    expect(mockAlert).toHaveBeenCalledWith(
+      'bluetooth.permissions_alert.title',
+      'bluetooth.permissions_alert.message',
+      expect.any(Array),
+    );
+  });
+
+  it('requests multiple missing permissions and reports denied results', async () => {
+    mockCheckMultiple.mockResolvedValue({
+      [PERMISSIONS.ANDROID.BLUETOOTH_CONNECT]: RESULTS.DENIED,
+      [PERMISSIONS.ANDROID.BLUETOOTH_SCAN]: RESULTS.BLOCKED,
+      [PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION]: RESULTS.GRANTED,
+    });
+    mockRequestMultiple.mockResolvedValue({
+      [PERMISSIONS.ANDROID.BLUETOOTH_CONNECT]: RESULTS.GRANTED,
+      [PERMISSIONS.ANDROID.BLUETOOTH_SCAN]: RESULTS.BLOCKED,
+    });
+
+    await expect(checkAndRequestAndroidBluetooth()).resolves.toBe(false);
+
+    expect(mockRequestMultiple).toHaveBeenCalledWith([
+      PERMISSIONS.ANDROID.BLUETOOTH_CONNECT,
+      PERMISSIONS.ANDROID.BLUETOOTH_SCAN,
+    ]);
+    expect(mockAlert).toHaveBeenCalledWith(
+      'bluetooth.permissions_alert.title',
+      'bluetooth.permissions_alert.message',
+      expect.any(Array),
+    );
+  });
+
+  it('returns true when a grouped permission request grants everything', async () => {
+    mockCheckMultiple.mockResolvedValue({
+      [PERMISSIONS.ANDROID.BLUETOOTH_CONNECT]: RESULTS.DENIED,
+      [PERMISSIONS.ANDROID.BLUETOOTH_SCAN]: RESULTS.DENIED,
+      [PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION]: RESULTS.GRANTED,
+    });
+    mockRequestMultiple.mockResolvedValue({
+      [PERMISSIONS.ANDROID.BLUETOOTH_CONNECT]: RESULTS.GRANTED,
+      [PERMISSIONS.ANDROID.BLUETOOTH_SCAN]: RESULTS.GRANTED,
+    });
+
+    await expect(checkAndRequestAndroidBluetooth()).resolves.toBe(true);
+  });
+});

--- a/apps/mobile/src/utils/shareLocalFile.test.ts
+++ b/apps/mobile/src/utils/shareLocalFile.test.ts
@@ -1,0 +1,122 @@
+const mockShare = jest.fn();
+const mockExists = jest.fn();
+const mockUnlink = jest.fn();
+const mockShareFile = jest.fn();
+
+jest.mock('react-native', () => ({
+  Platform: {
+    OS: 'ios',
+  },
+  Share: {
+    dismissedAction: 'dismissedAction',
+    share: (...args: unknown[]) => mockShare(...args),
+  },
+}));
+
+jest.mock('react-native-fs', () => ({
+  exists: (...args: unknown[]) => mockExists(...args),
+  unlink: (...args: unknown[]) => mockUnlink(...args),
+}));
+
+jest.mock('@/core/native/RNHelpers', () => ({
+  shareFile: (...args: unknown[]) => mockShareFile(...args),
+}));
+
+import { Platform, Share } from 'react-native';
+import { shareLocalFile } from './shareLocalFile';
+
+describe('shareLocalFile', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Platform as any).OS = 'ios';
+    mockExists.mockResolvedValue(true);
+    mockShare.mockResolvedValue({ action: 'sharedAction' });
+    mockShareFile.mockResolvedValue(undefined);
+  });
+
+  it('shares existing files through iOS Share with file URLs and fallback names', async () => {
+    mockShare.mockResolvedValue({ action: Share.dismissedAction });
+
+    await expect(
+      shareLocalFile({
+        path: '/tmp/export/report.csv',
+        mimeType: 'text/csv',
+        message: 'exported',
+      }),
+    ).resolves.toEqual({ dismissed: true });
+
+    expect(mockShare).toHaveBeenCalledWith(
+      {
+        title: 'report.csv',
+        url: 'file:///tmp/export/report.csv',
+        message: 'exported',
+      },
+      {
+        subject: 'report.csv',
+      },
+    );
+    expect(mockShareFile).not.toHaveBeenCalled();
+  });
+
+  it('shares existing files through the Android native helper', async () => {
+    (Platform as any).OS = 'android';
+
+    await expect(
+      shareLocalFile({
+        path: '/tmp/export/wallet.json',
+        name: 'backup.json',
+        mimeType: 'application/json',
+        title: 'Wallet backup',
+        subject: 'Backup subject',
+      }),
+    ).resolves.toEqual({ dismissed: false });
+
+    expect(mockShareFile).toHaveBeenCalledWith({
+      filePath: '/tmp/export/wallet.json',
+      mimeType: 'application/json',
+      title: 'Wallet backup',
+      subject: 'Backup subject',
+    });
+    expect(mockShare).not.toHaveBeenCalled();
+  });
+
+  it('throws when the source file is missing and still cleans existing cleanup paths', async () => {
+    mockExists.mockImplementation(async (path: string) => {
+      return path === '/tmp/export/cleanup.tmp';
+    });
+
+    await expect(
+      shareLocalFile({
+        path: '/tmp/export/missing.csv',
+        mimeType: 'text/csv',
+        cleanupPaths: [
+          '/tmp/export/cleanup.tmp',
+          '/tmp/export/already-gone.tmp',
+        ],
+      }),
+    ).rejects.toThrow('Share source file missing: /tmp/export/missing.csv');
+
+    expect(mockUnlink).toHaveBeenCalledWith('/tmp/export/cleanup.tmp');
+    expect(mockUnlink).not.toHaveBeenCalledWith('/tmp/export/already-gone.tmp');
+  });
+
+  it('cleans temporary files after successful sharing', async () => {
+    const existingPaths = new Set([
+      '/tmp/export/report.csv',
+      '/tmp/a',
+      '/tmp/b',
+    ]);
+    mockExists.mockImplementation(async (path: string) =>
+      existingPaths.has(path),
+    );
+
+    await shareLocalFile({
+      path: '/tmp/export/report.csv',
+      mimeType: 'text/csv',
+      cleanupPaths: ['/tmp/a', '/tmp/b'],
+    });
+
+    expect(mockUnlink).toHaveBeenCalledWith('/tmp/a');
+    expect(mockUnlink).toHaveBeenCalledWith('/tmp/b');
+  });
+});


### PR DESCRIPTION
## Summary
- add Bluetooth permission tests for powered-off/settings/firmware alerts, granted permissions, single permission requests, denied permission alerts, and grouped Android permission requests
- add local file share tests for iOS Share payloads, Android native helper payloads, missing source errors, and cleanup path handling

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/utils/bluetoothPermissions.test.ts src/utils/shareLocalFile.test.ts
- corepack yarn workspace rabby-mobile eslint src/utils/bluetoothPermissions.test.ts src/utils/shareLocalFile.test.ts --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached