### PR TITLE
test: cover clipboard sensitive data utilities

### DIFF
--- a/apps/mobile/src/utils/clipboard.test.ts
+++ b/apps/mobile/src/utils/clipboard.test.ts
@@ -1,0 +1,163 @@
+const mockToastSuccess = jest.fn();
+const mockGetTimeTip = jest.fn();
+const mockClipboardSetString = jest.fn();
+const mockClipboardGetString = jest.fn();
+const mockDimensionsGet = jest.fn();
+const mockT = jest.fn((key: string) => key);
+
+jest.mock('@/components2024/Toast', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+  },
+}));
+
+jest.mock('@/constant', () => ({
+  isNonPublicProductionEnv: false,
+}));
+
+jest.mock('@/hooks/appSettings', () => ({
+  storeApiExpSettingData: {
+    getTimeTipAboutSeedPhraseAndPrivateKey: (...args: unknown[]) =>
+      mockGetTimeTip(...args),
+  },
+}));
+
+jest.mock('@react-native-clipboard/clipboard', () => ({
+  getString: (...args: unknown[]) => mockClipboardGetString(...args),
+  setString: (...args: unknown[]) => mockClipboardSetString(...args),
+}));
+
+jest.mock('i18next', () => ({
+  t: (...args: unknown[]) => mockT(...args),
+}));
+
+jest.mock('react-native', () => ({
+  Dimensions: {
+    get: (...args: unknown[]) => mockDimensionsGet(...args),
+  },
+}));
+
+import {
+  isNewlyInputTextSameWithContentFromClipboard,
+  onCopiedSensitiveData,
+  onPastedSensitiveData,
+  startCheckClearAction,
+} from './clipboard';
+
+describe('clipboard sensitive data helpers', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    mockDimensionsGet.mockReturnValue({ height: 800, width: 400 });
+    mockGetTimeTip.mockReturnValue('copy');
+    mockClipboardGetString.mockResolvedValue('');
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('shows a seed phrase copy toast and schedules clipboard clearing', () => {
+    onCopiedSensitiveData({ type: 'seedPhrase' });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      'global.toast.clipboard.copiedSeedPhrase',
+      {
+        position: 400,
+      },
+    );
+    expect(mockClipboardSetString).not.toHaveBeenCalled();
+  });
+
+  it('shows a private-key copy toast with caller toast overrides', () => {
+    onCopiedSensitiveData({
+      type: 'privateKey',
+      toastOptions: {
+        position: 123,
+        duration: 10,
+      },
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      'global.toast.clipboard.copiedPrivateKey',
+      {
+        position: 123,
+        duration: 10,
+      },
+    );
+  });
+
+  it('does nothing for copy events when the setting is not copy mode', () => {
+    mockGetTimeTip.mockReturnValue('pasted');
+
+    onCopiedSensitiveData({ type: 'privateKey' });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(mockClipboardSetString).not.toHaveBeenCalled();
+  });
+
+  it('clears the clipboard and shows a pasted-and-cleared toast in pasted mode', () => {
+    mockGetTimeTip.mockReturnValue('pasted');
+
+    onPastedSensitiveData({
+      type: 'seedPhrase',
+      toastOptions: {
+        duration: 20,
+      },
+    });
+
+    expect(mockClipboardSetString).toHaveBeenCalledWith('');
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      'global.toast.clipboard.pasted_and_cleared',
+      {
+        position: 400,
+        duration: 20,
+      },
+    );
+  });
+
+  it('does nothing for paste events when the setting is not pasted mode', () => {
+    mockGetTimeTip.mockReturnValue('copy');
+
+    onPastedSensitiveData({ type: 'privateKey' });
+
+    expect(mockClipboardSetString).not.toHaveBeenCalled();
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  it('clears copied sensitive data on the periodic clear action', () => {
+    mockGetTimeTip.mockReturnValue('copy');
+
+    startCheckClearAction();
+    onCopiedSensitiveData({ type: 'privateKey' });
+    jest.advanceTimersByTime(30_000);
+
+    expect(mockClipboardSetString).toHaveBeenCalledWith('');
+  });
+
+  it('skips periodic clearing when copy mode is disabled before the interval fires', () => {
+    mockGetTimeTip.mockReturnValueOnce('copy');
+
+    startCheckClearAction();
+    onCopiedSensitiveData({ type: 'privateKey' });
+    mockGetTimeTip.mockReturnValue('off');
+    jest.advanceTimersByTime(30_000);
+
+    expect(mockClipboardSetString).not.toHaveBeenCalled();
+  });
+
+  it('compares new input text with current clipboard content', async () => {
+    mockClipboardGetString.mockResolvedValueOnce('secret');
+
+    await expect(
+      isNewlyInputTextSameWithContentFromClipboard('secret'),
+    ).resolves.toBe(true);
+
+    mockClipboardGetString.mockResolvedValueOnce('different');
+
+    await expect(
+      isNewlyInputTextSameWithContentFromClipboard('secret'),
+    ).resolves.toBe(false);
+  });
+});

--- a/apps/mobile/src/utils/toastUnlocking.test.ts
+++ b/apps/mobile/src/utils/toastUnlocking.test.ts
@@ -1,0 +1,27 @@
+const mockToastIndicator = jest.fn();
+const mockT = jest.fn((key: string) => key);
+
+jest.mock('@/components2024/Toast', () => ({
+  toastIndicator: (...args: unknown[]) => mockToastIndicator(...args),
+}));
+
+jest.mock('i18next', () => ({
+  t: (...args: unknown[]) => mockT(...args),
+}));
+
+import { toastUnlocking } from './toastUnlocking';
+
+describe('toastUnlocking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the unlocking toast as a top indicator', () => {
+    toastUnlocking();
+
+    expect(mockT).toHaveBeenCalledWith('page.unlock.unlocking');
+    expect(mockToastIndicator).toHaveBeenCalledWith('page.unlock.unlocking', {
+      isTop: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add clipboard sensitive-data tests for seed phrase/private key copy toasts, paste-and-clear behavior, disabled setting branches, periodic clear checks, and clipboard content comparison
- add unlock toast test for translation and top-indicator options

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/utils/clipboard.test.ts src/utils/toastUnlocking.test.ts
- corepack yarn workspace rabby-mobile eslint src/utils/clipboard.test.ts src/utils/toastUnlocking.test.ts --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached