### PR TITLE
test: cover navigation router utilities

### DIFF
--- a/apps/mobile/src/utils/CustomStackRouter.test.ts
+++ b/apps/mobile/src/utils/CustomStackRouter.test.ts
@@ -1,0 +1,83 @@
+const loadSubject = () => {
+  jest.resetModules();
+  const baseGetStateForAction = jest.fn(() => ({ key: 'next-state' }));
+  const stackRouter = jest.fn(() => ({
+    getStateForAction: baseGetStateForAction,
+  }));
+
+  jest.doMock('@react-navigation/native', () => ({
+    StackRouter: (...args: unknown[]) => stackRouter(...args),
+  }));
+
+  const { CustomStackRouter } =
+    require('./CustomStackRouter') as typeof import('./CustomStackRouter');
+
+  return {
+    CustomStackRouter,
+    baseGetStateForAction,
+    stackRouter,
+  };
+};
+
+describe('CustomStackRouter', () => {
+  afterEach(() => {
+    jest.dontMock('@react-navigation/native');
+    jest.resetModules();
+  });
+
+  it('returns null for duplicate PUSH actions with deeply equal params', () => {
+    const { CustomStackRouter, baseGetStateForAction } = loadSubject();
+    const router = CustomStackRouter({} as any);
+    const state = {
+      routes: [
+        { name: 'Home', params: undefined },
+        { name: 'Detail', params: { id: 1, nested: { tab: 'token' } } },
+      ],
+    } as any;
+
+    expect(
+      router.getStateForAction(
+        state,
+        {
+          type: 'PUSH',
+          payload: {
+            name: 'Detail',
+            params: { id: 1, nested: { tab: 'token' } },
+          },
+        } as any,
+        {} as any,
+      ),
+    ).toBeNull();
+    expect(baseGetStateForAction).not.toHaveBeenCalled();
+  });
+
+  it('delegates non-duplicate pushes and non-push actions to the base router', () => {
+    const { CustomStackRouter, baseGetStateForAction } = loadSubject();
+    const router = CustomStackRouter({ initialRouteName: 'Home' } as any);
+    const state = {
+      routes: [{ name: 'Detail', params: { id: 1 } }],
+    } as any;
+
+    expect(
+      router.getStateForAction(
+        state,
+        {
+          type: 'PUSH',
+          payload: { name: 'Detail', params: { id: 2 } },
+        } as any,
+        { routeNames: ['Detail'] } as any,
+      ),
+    ).toEqual({ key: 'next-state' });
+    expect(
+      router.getStateForAction(
+        state,
+        {
+          type: 'POP',
+          payload: { count: 1 },
+        } as any,
+        {} as any,
+      ),
+    ).toEqual({ key: 'next-state' });
+    expect(baseGetStateForAction).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/mobile/src/utils/navigation.test.ts
+++ b/apps/mobile/src/utils/navigation.test.ts
@@ -1,0 +1,211 @@
+const rootNames = {
+  GetStarted: 'GetStarted',
+  Home: 'Home',
+  ImportNewAddress: 'ImportNewAddress',
+  StackAddress: 'StackAddress',
+  StackGetStarted: 'StackGetStarted',
+  StackRoot: 'StackRoot',
+};
+
+const createMockRef = () => ({
+  current: { id: 'nav-current' },
+  dispatch: jest.fn(),
+  getCurrentRoute: jest.fn(),
+  isReady: jest.fn(),
+  navigate: jest.fn(),
+  navigateDeprecated: jest.fn(),
+  resetRoot: jest.fn(),
+});
+
+const loadSubject = () => {
+  jest.resetModules();
+  const mockRef = createMockRef();
+  const push = jest.fn((name, params) => ({
+    type: 'PUSH',
+    payload: { name, params },
+  }));
+  const replace = jest.fn((name, params) => ({
+    type: 'REPLACE',
+    payload: { name, params },
+  }));
+  const reset = jest.fn(payload => ({
+    type: 'RESET',
+    payload,
+  }));
+
+  jest.doMock('@/constant/layout', () => ({
+    RootNames: rootNames,
+  }));
+  jest.doMock('@react-navigation/native', () => ({
+    CommonActions: { reset },
+    StackActions: { push, replace },
+    createNavigationContainerRef: () => mockRef,
+  }));
+  jest.doMock('@react-navigation/native-stack', () => ({}));
+
+  const navigation = require('./navigation') as typeof import('./navigation');
+  return {
+    ...navigation,
+    mockRef,
+    push,
+    replace,
+    reset,
+  };
+};
+
+describe('navigation utils', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.dontMock('@/constant/layout');
+    jest.dontMock('@react-navigation/native');
+    jest.dontMock('@react-navigation/native-stack');
+    jest.resetModules();
+  });
+
+  it('returns ready navigation refs and current route names defensively', () => {
+    const subject = loadSubject();
+
+    subject.mockRef.isReady.mockReturnValue(false);
+    expect(subject.getReadyNavigationInstance()).toBeNull();
+    expect(subject.getLatestNavigationName()).toBeUndefined();
+
+    subject.mockRef.isReady.mockReturnValue(true);
+    subject.mockRef.getCurrentRoute.mockReturnValue({ name: 'Home' });
+    expect(subject.getReadyNavigationInstance()).toBe(subject.mockRef.current);
+    expect(subject.getLatestNavigationName()).toBe('Home');
+
+    subject.mockRef.isReady.mockImplementation(() => {
+      throw new Error('not mounted');
+    });
+    expect(subject.getLatestNavigationName()).toBeUndefined();
+  });
+
+  it('dispatches navigation helpers only when the ref is ready', () => {
+    const subject = loadSubject();
+
+    subject.mockRef.isReady.mockReturnValue(false);
+    subject.navigate('Home' as never);
+    subject.navigateDeprecated('Home' as never);
+    subject.naviPush('Home' as never, { id: 1 } as never);
+    subject.naviReplace('Home' as never, { id: 2 });
+
+    expect(subject.mockRef.navigate).not.toHaveBeenCalled();
+    expect(subject.mockRef.navigateDeprecated).not.toHaveBeenCalled();
+    expect(subject.mockRef.dispatch).not.toHaveBeenCalled();
+
+    subject.mockRef.isReady.mockReturnValue(true);
+    subject.navigate('Home' as never);
+    subject.navigateDeprecated('Home' as never);
+    subject.naviPush('Detail' as never, { id: 1 } as never);
+    subject.naviReplace('Detail' as never, { id: 2 });
+
+    expect(subject.mockRef.navigate).toHaveBeenCalledWith('Home');
+    expect(subject.mockRef.navigateDeprecated).toHaveBeenCalledWith('Home');
+    expect(subject.push).toHaveBeenCalledWith('Detail', { id: 1 });
+    expect(subject.replace).toHaveBeenCalledWith('Detail', { id: 2 });
+    expect(subject.mockRef.dispatch).toHaveBeenCalledWith({
+      type: 'PUSH',
+      payload: { name: 'Detail', params: { id: 1 } },
+    });
+    expect(subject.mockRef.dispatch).toHaveBeenCalledWith({
+      type: 'REPLACE',
+      payload: { name: 'Detail', params: { id: 2 } },
+    });
+  });
+
+  it('goes back when possible and otherwise resets to a default route', () => {
+    const subject = loadSubject();
+    const navigation = {
+      canGoBack: jest.fn().mockReturnValue(true),
+      goBack: jest.fn(),
+    };
+
+    subject.redirectBackErrorHandler(navigation, 'Fallback');
+
+    expect(navigation.goBack).toHaveBeenCalled();
+    expect(subject.mockRef.resetRoot).not.toHaveBeenCalled();
+
+    navigation.canGoBack.mockReturnValue(false);
+    subject.redirectBackErrorHandler(navigation, 'Fallback');
+
+    expect(subject.mockRef.resetRoot).toHaveBeenCalledWith({
+      index: 0,
+      routes: [
+        {
+          name: 'Root',
+          state: {
+            index: 0,
+            routes: [{ name: 'Fallback' }],
+          },
+        },
+      ],
+    });
+  });
+
+  it('routes add-address entry actions through classical and get-started stacks', () => {
+    const subject = loadSubject();
+    subject.mockRef.isReady.mockReturnValue(true);
+
+    subject.redirectToAddAddressEntry();
+    expect(subject.mockRef.navigateDeprecated).toHaveBeenCalledWith(
+      rootNames.StackAddress,
+      {
+        screen: rootNames.ImportNewAddress,
+      },
+    );
+
+    subject.redirectToAddAddressEntry({ action: 'classical:replace' });
+    expect(subject.mockRef.dispatch).toHaveBeenCalledWith({
+      type: 'REPLACE',
+      payload: {
+        name: rootNames.StackAddress,
+        params: { screen: rootNames.ImportNewAddress },
+      },
+    });
+
+    subject.redirectToAddAddressEntry({ action: 'resetTo' });
+    expect(subject.mockRef.resetRoot).toHaveBeenCalledWith({
+      index: 0,
+      routes: [
+        {
+          name: rootNames.StackGetStarted,
+          state: {
+            index: 0,
+            routes: [{ name: rootNames.GetStarted }],
+          },
+        },
+      ],
+    });
+  });
+
+  it('resets navigation on top of Home before replacing to a first screen', () => {
+    const subject = loadSubject();
+    subject.mockRef.isReady.mockReturnValue(true);
+
+    subject.replaceToFirst('Settings' as never, { tab: 'security' });
+
+    expect(subject.reset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [
+        {
+          name: rootNames.StackRoot,
+          params: {
+            screen: rootNames.Home,
+          },
+        },
+        {
+          name: 'Settings',
+          params: { tab: 'security' },
+        },
+      ],
+    });
+    expect(subject.mockRef.dispatch).toHaveBeenCalledWith({
+      type: 'RESET',
+      payload: expect.objectContaining({ index: 0 }),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add CustomStackRouter tests for duplicate PUSH suppression and base router delegation
- add navigation utility tests for ready/current route handling, navigate/push/replace dispatches, back fallback reset, add-address entry routing, and replaceToFirst reset action

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/utils/CustomStackRouter.test.ts src/utils/navigation.test.ts
- corepack yarn workspace rabby-mobile eslint src/utils/CustomStackRouter.test.ts src/utils/navigation.test.ts --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached