### PR TITLE
test: cover style and render utilities

### DIFF
--- a/apps/mobile/src/utils/renderNode.test.tsx
+++ b/apps/mobile/src/utils/renderNode.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+
+jest.mock('@/components/Text', () => ({
+  Text: 'Text',
+}));
+
+import { renderNode, renderText } from './renderNode';
+
+const Box = 'Box' as unknown as React.FC<any>;
+
+describe('renderNode', () => {
+  it('returns null for empty-like content', () => {
+    expect(renderNode(Box, null)).toBeNull();
+    expect(renderNode(Box, false)).toBeNull();
+    expect(renderNode(Box, '')).toBeNull();
+  });
+
+  it('returns existing React elements and function results unchanged', () => {
+    const element = <Box testID="existing" />;
+    const fromFunction = <Box testID="from-function" />;
+
+    expect(renderNode(Box, element)).toBe(element);
+    expect(renderNode(Box, () => fromFunction)).toBe(fromFunction);
+  });
+
+  it('renders boolean true, string, number, and bigint values as children', () => {
+    expect(renderNode(Box, true, { role: 'empty' })).toMatchObject({
+      type: Box,
+      props: { role: 'empty' },
+    });
+    expect(renderNode(Box, 'hello', { role: 'text' })).toMatchObject({
+      type: Box,
+      props: { children: 'hello', role: 'text' },
+    });
+    expect(renderNode(Box, 42, { role: 'number' })).toMatchObject({
+      type: Box,
+      props: { children: 42, role: 'number' },
+    });
+    expect(renderNode(Box, 42n, { role: 'bigint' })).toMatchObject({
+      type: Box,
+      props: { children: 42n, role: 'bigint' },
+    });
+  });
+
+  it('merges object content over default props', () => {
+    expect(
+      renderNode(
+        Box,
+        {
+          role: 'content',
+          value: 1,
+        },
+        {
+          role: 'default',
+          testID: 'box',
+        },
+      ),
+    ).toMatchObject({
+      type: Box,
+      props: {
+        role: 'content',
+        testID: 'box',
+        value: 1,
+      },
+    });
+  });
+
+  it('renders text with flattened caller and default styles', () => {
+    expect(
+      renderText(
+        'hello',
+        {
+          numberOfLines: 1,
+          style: {
+            color: 'red',
+          },
+        },
+        {
+          fontSize: 12,
+        },
+      ),
+    ).toMatchObject({
+      type: 'Text',
+      props: {
+        children: 'hello',
+        numberOfLines: 1,
+        style: {
+          color: 'red',
+          fontSize: 12,
+        },
+      },
+    });
+  });
+});

--- a/apps/mobile/src/utils/styles.test.ts
+++ b/apps/mobile/src/utils/styles.test.ts
@@ -1,0 +1,173 @@
+jest.mock('@/core/native/utils', () => ({
+  IS_IOS: false,
+}));
+
+jest.mock('@/core/utils/fonts', () => ({
+  FontNames: {
+    sf_pro: 'SF-Pro',
+    sf_pro_rounded_bold: 'SF-Pro-Rounded-Bold',
+    sf_pro_rounded_heavy: 'SF-Pro-Rounded-Heavy',
+    sf_pro_rounded_medium: 'SF-Pro-Rounded-Medium',
+    sf_pro_rounded_regular: 'SF-Pro-Rounded-Regular',
+  },
+  FontWeightEnum: {
+    bold: 'bold',
+    heavy: 'heavy',
+    medium: 'medium',
+    normal: 'normal',
+  },
+  getFontWeightType: (fontWeight?: string | number) => {
+    if (fontWeight === '900' || fontWeight === 900) {
+      return { supertype: 'heavy' };
+    }
+    if (fontWeight === '700' || fontWeight === 700 || fontWeight === 'bold') {
+      return { supertype: 'bold' };
+    }
+    if (fontWeight === '500' || fontWeight === 500) {
+      return { supertype: 'medium' };
+    }
+    return { supertype: 'normal' };
+  },
+}));
+
+import {
+  createGetStyles,
+  createGetStyles2024,
+  makeDebugBorder,
+  makeDevOnlyStyle,
+  makeProdBorder,
+  makeTriangleStyle,
+  mutateStyles,
+} from './styles';
+
+const colors = {
+  blueDefault: '#0000ff',
+} as any;
+
+const ctx = {
+  classicalColors: colors,
+  colors,
+  colors2024: {
+    neutral: '#111111',
+  },
+  isLight: true,
+  safeAreaInsets: {
+    bottom: 4,
+    left: 1,
+    right: 2,
+    top: 3,
+  },
+} as any;
+
+describe('style utilities', () => {
+  it('creates directional triangle styles with transparent opposite borders', () => {
+    expect(makeTriangleStyle()).toMatchObject({
+      borderBottomColor: 'blue',
+      borderLeftColor: 'transparent',
+      borderRightColor: 'transparent',
+      borderTopColor: 'transparent',
+      borderWidth: 6,
+      height: 0,
+      width: 0,
+    });
+    expect(makeTriangleStyle('down')).toMatchObject({
+      borderTopColor: 'blue',
+    });
+    expect(
+      makeTriangleStyle({
+        backgroundColor: '#fff',
+        color: '#f00',
+        dir: 'right',
+        size: 10,
+      }),
+    ).toMatchObject({
+      borderLeftColor: '#f00',
+      borderRightColor: '#fff',
+      borderWidth: 10,
+    });
+  });
+
+  it('mutates SF Pro font families for Android while preserving the input shape', () => {
+    const styles = mutateStyles({
+      roundedBold: {
+        fontFamily: 'SF Pro Rounded',
+        fontWeight: '700',
+      },
+      roundedRegular: {
+        fontFamily: 'SFProRounded',
+      },
+      sfPro: {
+        fontFamily: 'SF Pro Display',
+        fontWeight: '500',
+      },
+    });
+
+    expect(styles.roundedBold).toEqual({
+      fontFamily: 'SF-Pro-Rounded-Bold',
+    });
+    expect(styles.roundedRegular).toEqual({
+      fontFamily: 'SF-Pro-Rounded-Regular',
+    });
+    expect(styles.sfPro).toEqual({
+      fontFamily: 'SF-Pro',
+      fontWeight: '500',
+    });
+  });
+
+  it('creates style factories that run through mutateStyles', () => {
+    const getStyles = createGetStyles(inputColors => ({
+      title: {
+        color: inputColors.blueDefault,
+        fontFamily: 'SF Pro Rounded',
+        fontWeight: '900',
+      },
+    }));
+
+    expect(getStyles(colors, ctx)).toEqual({
+      title: {
+        color: '#0000ff',
+        fontFamily: 'SF-Pro-Rounded-Heavy',
+      },
+    });
+  });
+
+  it('creates 2024 style factories and preserves reanimated style functions', () => {
+    const reanimatedStyle = jest.fn(() => ({ opacity: 1 }));
+    const styles = createGetStyles2024(
+      {
+        reanimatedStyles: {
+          fade: reanimatedStyle,
+        },
+      },
+      inputCtx => ({
+        panel: {
+          color: inputCtx.colors2024.neutral,
+          paddingBottom: inputCtx.safeAreaInsets.bottom,
+        },
+      }),
+    );
+
+    expect(styles.getStyles(ctx)).toEqual({
+      panel: {
+        color: '#111111',
+        paddingBottom: 4,
+      },
+    });
+    expect(styles.getReanimatedStyles.fade).toBe(reanimatedStyle);
+    expect(createGetStyles2024().getStyles(ctx)).toEqual({});
+  });
+
+  it('returns dev-only and production border helpers', () => {
+    const input = { opacity: 0.5 };
+
+    expect(makeDevOnlyStyle(input)).toBe(input);
+    expect(makeDebugBorder('red')).toEqual({
+      borderColor: 'red',
+      borderWidth: 1,
+    });
+    expect(makeProdBorder('green')).toEqual({
+      borderColor: 'green',
+      borderWidth: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add style utility tests for triangle styles, SF Pro font mutation, classic/2024 style factories, dev-only/debug borders, and production borders
- add renderNode/renderText tests for empty inputs, existing elements, function content, primitive children, prop merging, and style flattening

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/utils/styles.test.ts src/utils/renderNode.test.tsx
- corepack yarn workspace rabby-mobile eslint src/utils/styles.test.ts src/utils/renderNode.test.tsx --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached