### PR TITLE
test: cover OpenAPI debug instrumentation

### DIFF
--- a/apps/mobile/src/utils/appchain.test.ts
+++ b/apps/mobile/src/utils/appchain.test.ts
@@ -1,0 +1,31 @@
+import type { AppChainItem } from '@rabby-wallet/rabby-api/dist/types';
+import {
+  APP_CHAIN_PREFIX,
+  formatAppChain,
+  isAppChain,
+  makeAppChainFromId,
+} from './appchain';
+
+describe('appchain utils', () => {
+  it('creates and recognizes Rabby app-chain ids', () => {
+    expect(APP_CHAIN_PREFIX).toBe('RABBY_APP_CHAIN_');
+    expect(makeAppChainFromId('aave')).toBe('RABBY_APP_CHAIN_aave');
+    expect(isAppChain('RABBY_APP_CHAIN_aave')).toBe(true);
+    expect(isAppChain('eth')).toBe(false);
+  });
+
+  it('formats app-chain items into complex protocol-like objects', () => {
+    const app = {
+      id: 'aave',
+      name: 'Aave',
+      logo_url: 'https://assets.example/aave.png',
+    } as AppChainItem;
+
+    expect(formatAppChain(app)).toEqual({
+      ...app,
+      chain: 'RABBY_APP_CHAIN_aave',
+      has_supported_portfolio: true,
+      tvl: 0,
+    });
+  });
+});

--- a/apps/mobile/src/utils/openapiDebugToast.test.ts
+++ b/apps/mobile/src/utils/openapiDebugToast.test.ts
@@ -1,0 +1,128 @@
+const mockToastError = jest.fn();
+const mockGetExpSetting = jest.fn();
+
+jest.mock('@/components2024/Toast', () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+jest.mock('@/hooks/appSettings', () => ({
+  storeApiExpSettingData: {
+    get: (...args: unknown[]) => mockGetExpSetting(...args),
+  },
+}));
+
+const loadSubject = () => {
+  jest.resetModules();
+  const subject =
+    require('./openapiDebugToast') as typeof import('./openapiDebugToast');
+  const events =
+    require('./openapiDebugEvents') as typeof import('./openapiDebugEvents');
+  return {
+    ...subject,
+    ...events,
+  };
+};
+
+const detail = {
+  source: 'openapi' as const,
+  status: 503,
+  method: 'GET',
+  url: '/v1/wallet',
+  message: '[openapi] HTTP 503 GET /v1/wallet',
+};
+
+describe('openapiDebugToast', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-05-30T12:00:00.000Z'));
+    jest.clearAllMocks();
+    mockGetExpSetting.mockReturnValue({
+      toastOpenApiHttpErrorStatus: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetModules();
+  });
+
+  it('shows OpenAPI HTTP error toasts when the experiment setting is enabled', () => {
+    const {
+      OPENAPI_HTTP_ERROR_DEBUG,
+      openApiDebugEvents,
+      startSubscribeOpenApiHttpErrorDebugToast,
+    } = loadSubject();
+
+    startSubscribeOpenApiHttpErrorDebugToast();
+    openApiDebugEvents.emit(OPENAPI_HTTP_ERROR_DEBUG, detail);
+
+    expect(mockToastError).toHaveBeenCalledWith(detail.message);
+  });
+
+  it('does not subscribe twice when started multiple times', () => {
+    const {
+      OPENAPI_HTTP_ERROR_DEBUG,
+      openApiDebugEvents,
+      startSubscribeOpenApiHttpErrorDebugToast,
+    } = loadSubject();
+
+    startSubscribeOpenApiHttpErrorDebugToast();
+    startSubscribeOpenApiHttpErrorDebugToast();
+    openApiDebugEvents.emit(OPENAPI_HTTP_ERROR_DEBUG, detail);
+
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes identical messages for the configured toast window', () => {
+    const {
+      OPENAPI_HTTP_ERROR_DEBUG,
+      openApiDebugEvents,
+      startSubscribeOpenApiHttpErrorDebugToast,
+    } = loadSubject();
+
+    startSubscribeOpenApiHttpErrorDebugToast();
+    openApiDebugEvents.emit(OPENAPI_HTTP_ERROR_DEBUG, detail);
+    jest.advanceTimersByTime(2_999);
+    openApiDebugEvents.emit(OPENAPI_HTTP_ERROR_DEBUG, detail);
+    jest.advanceTimersByTime(1);
+    openApiDebugEvents.emit(OPENAPI_HTTP_ERROR_DEBUG, detail);
+
+    expect(mockToastError).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not dedupe different error messages', () => {
+    const {
+      OPENAPI_HTTP_ERROR_DEBUG,
+      openApiDebugEvents,
+      startSubscribeOpenApiHttpErrorDebugToast,
+    } = loadSubject();
+
+    startSubscribeOpenApiHttpErrorDebugToast();
+    openApiDebugEvents.emit(OPENAPI_HTTP_ERROR_DEBUG, detail);
+    openApiDebugEvents.emit(OPENAPI_HTTP_ERROR_DEBUG, {
+      ...detail,
+      message: '[openapi] HTTP 504 GET /v1/wallet',
+      status: 504,
+    });
+
+    expect(mockToastError).toHaveBeenCalledTimes(2);
+  });
+
+  it('respects the experiment setting on every emitted event', () => {
+    const {
+      OPENAPI_HTTP_ERROR_DEBUG,
+      openApiDebugEvents,
+      startSubscribeOpenApiHttpErrorDebugToast,
+    } = loadSubject();
+
+    startSubscribeOpenApiHttpErrorDebugToast();
+    mockGetExpSetting.mockReturnValue({
+      toastOpenApiHttpErrorStatus: false,
+    });
+    openApiDebugEvents.emit(OPENAPI_HTTP_ERROR_DEBUG, detail);
+
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/utils/openapiFailureLogging.test.ts
+++ b/apps/mobile/src/utils/openapiFailureLogging.test.ts
@@ -17,11 +17,56 @@ import {
   buildOpenApiHttpErrorToastMessage,
   buildOpenApiFailurePayload,
   extractOpenApiResponseCode,
+  instrumentOpenApiFailureLogging,
   shouldLogOpenApiFailureResponse,
   shouldToastOpenApiHttpErrorStatus,
 } from './openapiFailureLogging';
+import {
+  OPENAPI_HTTP_ERROR_DEBUG,
+  openApiDebugEvents,
+} from './openapiDebugEvents';
+import { logger } from './logger';
+
+const createRequestLike = () => {
+  const requestUse = jest.fn();
+  const responseUse = jest.fn((fulfilled, rejected) => {
+    request.interceptors.response.handlers.push({ fulfilled, rejected });
+    return request.interceptors.response.handlers.length - 1;
+  });
+  const originalFulfilled = jest.fn(response => ({
+    ...response,
+    handled: true,
+  }));
+  const request = {
+    interceptors: {
+      request: {
+        use: requestUse,
+      },
+      response: {
+        handlers: [
+          {
+            fulfilled: originalFulfilled,
+          },
+        ],
+        use: responseUse,
+      },
+    },
+  };
+
+  return {
+    request,
+    requestUse,
+    responseUse,
+    originalFulfilled,
+  };
+};
 
 describe('openapi failure logging', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    openApiDebugEvents.removeAllListeners();
+  });
+
   it('detects http and api-level non-200 responses', () => {
     expect(
       shouldLogOpenApiFailureResponse({
@@ -123,6 +168,111 @@ describe('openapi failure logging', () => {
       }),
     ).toBe(
       '[notificationOpenapi] HTTP 503 POST /v1/notification/device/heartbeat?foo=bar',
+    );
+  });
+
+  it('instruments requests with source/request id metadata and wraps failed fulfilled responses', () => {
+    const listener = jest.fn();
+    const { request, requestUse, originalFulfilled } = createRequestLike();
+    const service = {
+      initSync: jest.fn(),
+      request,
+    } as never;
+
+    openApiDebugEvents.on(OPENAPI_HTTP_ERROR_DEBUG, listener);
+    instrumentOpenApiFailureLogging(service, 'openapi');
+
+    const config = requestUse.mock.calls[0][0]({
+      method: 'get',
+      baseURL: 'https://app-api.rabby.io',
+      url: '/v1/wallet',
+    });
+
+    expect(config.__rabbyOpenApiFailureMeta).toMatchObject({
+      source: 'openapi',
+      requestId: expect.stringMatching(/^openapi-/),
+    });
+
+    const response = {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: {},
+      data: { err_code: 503 },
+      config,
+    } as never;
+
+    expect(
+      request.interceptors.response.handlers[0].fulfilled(response),
+    ).toMatchObject({
+      handled: true,
+    });
+
+    expect(originalFulfilled).toHaveBeenCalledWith(response);
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[openapi] non-200 request detected',
+      expect.objectContaining({
+        requestId: config.__rabbyOpenApiFailureMeta.requestId,
+        source: 'openapi',
+      }),
+    );
+    expect(listener).toHaveBeenCalledWith({
+      source: 'openapi',
+      status: 503,
+      method: 'GET',
+      url: '/v1/wallet',
+      message: '[openapi] HTTP 503 GET /v1/wallet',
+    });
+  });
+
+  it('logs rejected request failures and keeps instrumentation idempotent', async () => {
+    const { request, requestUse, responseUse } = createRequestLike();
+    const originalInitSync = jest.fn();
+    const service = {
+      initSync: originalInitSync,
+      request,
+    } as any;
+
+    instrumentOpenApiFailureLogging(service, 'testOpenapi');
+    instrumentOpenApiFailureLogging(service, 'testOpenapi');
+
+    expect(requestUse).toHaveBeenCalledTimes(1);
+    expect(responseUse).toHaveBeenCalledTimes(1);
+
+    service.initSync({ from: 'bootstrap' });
+    expect(originalInitSync).toHaveBeenCalledWith({ from: 'bootstrap' });
+    expect(requestUse).toHaveBeenCalledTimes(1);
+
+    const rejected = request.interceptors.response.handlers.at(-1)?.rejected;
+    const error = Object.assign(new Error('network down'), {
+      code: 'ECONNABORTED',
+      config: {
+        method: 'post',
+        baseURL: 'https://test-api.rabby.io',
+        url: '/v1/tx',
+      },
+      response: {
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: {},
+        data: { error_code: '500' },
+      },
+    });
+
+    await expect(rejected?.(error)).rejects.toBe(error);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[openapi] non-200 request detected',
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: 'ECONNABORTED',
+          message: 'network down',
+        }),
+        response: expect.objectContaining({
+          apiCode: 500,
+          status: 500,
+        }),
+        source: 'testOpenapi',
+      }),
     );
   });
 });


### PR DESCRIPTION
## Summary
- add OpenAPI debug toast tests for subscription gating, dedupe, different-message handling, and experiment setting checks
- add OpenAPI failure logging instrumentation tests for request metadata, fulfilled response wrapping, rejected response logging, idempotency, and initSync wrapping
- add app-chain formatting tests

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/utils/openapiDebugToast.test.ts src/utils/appchain.test.ts src/utils/openapiFailureLogging.test.ts
- corepack yarn workspace rabby-mobile eslint src/utils/openapiDebugToast.test.ts src/utils/appchain.test.ts src/utils/openapiFailureLogging.test.ts --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached