### PR TITLE
chore: normalize iOS hashcheck inputs

### DIFF
--- a/apps/mobile/scripts/validate-hash/common.sh
+++ b/apps/mobile/scripts/validate-hash/common.sh
@@ -129,6 +129,8 @@ setup_environment() {
   export SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
   export SENTRY_DISABLE_AUTO_UPLOAD=true
   export APP_ENV=hashing
+  # 避免宿主 DEBUG 变量影响 Babel/Metro 对 process.env.DEBUG 的内联
+  unset DEBUG
 
   # --- 覆盖代码中用到的环境变量 ---
   export RABBY_MOBILE_CODE="RABBY_MOBILE_CODE_DEV"

--- a/apps/mobile/scripts/validate-hash/ios.sh
+++ b/apps/mobile/scripts/validate-hash/ios.sh
@@ -54,6 +54,9 @@ run_ios_build_and_hash() {
     sed -i '' -e 's/"DumpToolVersion" : .*/"DumpToolVersion" : 0,/' "$app_path/Assets.car.json"
     # "Authoring Tool": "@(#)PROGRAM:CoreThemeDefinition  PROJECT:CoreThemeDefinition-611  [IIO-2661.3.6]", 版本号会不一样
     sed -i '' -e 's/"Authoring Tool" : .*/"Authoring Tool" : "",/' "$app_path/Assets.car.json"
+    # CoreUI 记录的是 assetutil/CoreUI 工具版本，系统补丁版本不同也可能变化
+    sed -i '' -e 's/"CoreUIVersion" : [0-9]*/"CoreUIVersion" : 0/' "$app_path/Assets.car.json"
+    sed -i '' -e 's/"MainVersion" : "@(#)PROGRAM:CoreUI  PROJECT:CoreUI-[^"]*"/"MainVersion" : "@(#)PROGRAM:CoreUI  PROJECT:CoreUI-0"/' "$app_path/Assets.car.json"
     rm -f "$app_path/Assets.car"
   fi
 


### PR DESCRIPTION
## Summary
- Normalize CoreUI asset catalog metadata in iOS hashcheck output (`CoreUIVersion`, `MainVersion`).
- Clear host `DEBUG` before hashing so Metro/Babel does not inline local shell state into the bundle.

## Validation
- `bash -n apps/mobile/scripts/validate-hash/common.sh`
- `bash -n apps/mobile/scripts/validate-hash/ios.sh`
- `bash -n apps/mobile/scripts/validate-hash/run.sh`
- Local `./scripts/validate-hash/run.sh ios`: `c6f4a4090f2dffaad2543b4c6a5e87537ae35566325a66e41022a72c108afd32`
- Manual CI hashcheck: https://github.com/RabbyHub/rabby-mobile/actions/runs/26652199199
  - iOS: `c6f4a4090f2dffaad2543b4c6a5e87537ae35566325a66e41022a72c108afd32`
  - Android: `aa041d7ad808d37b83810833255bd882ec82e2765af16e81bf119bcc8fdbf010`
  - Combined: `2d1c1e68c1fa3cbf0beafe3b93fa2cc1242e27b6ffa5ee9954ea57c28a0bce0d`

## Notes
- Full mobile lint/type/test was not run; this change is limited to hashcheck scripts and was validated with local/CI hashcheck.