### PR TITLE
test: cover core network api utilities

### DIFF
--- a/apps/mobile/src/core/apis/customTestnet.test.ts
+++ b/apps/mobile/src/core/apis/customTestnet.test.ts
@@ -1,0 +1,133 @@
+const mockMatomoRequestEvent = jest.fn();
+const mockCustomTestnetAdd = jest.fn();
+const mockGetTransactionCount = jest.fn();
+const mockGetNonceByChain = jest.fn();
+const mockFindChain = jest.fn();
+const mockGetChainListByIds = jest.fn();
+
+jest.mock('@/utils/analytics', () => ({
+  matomoRequestEvent: (...args: unknown[]) => mockMatomoRequestEvent(...args),
+}));
+
+jest.mock('../services/shared', () => ({
+  customTestnetService: {
+    add: (...args: unknown[]) => mockCustomTestnetAdd(...args),
+    update: jest.fn(),
+    remove: jest.fn(),
+    getList: jest.fn(),
+    getTransactionCount: (...args: unknown[]) =>
+      mockGetTransactionCount(...args),
+    estimateGas: jest.fn(),
+    getGasPrice: jest.fn(),
+    getGasMarket: jest.fn(),
+    getToken: jest.fn(),
+    removeToken: jest.fn(),
+    addToken: jest.fn(),
+    getTokenList: jest.fn(),
+    hasToken: jest.fn(),
+    getTx: jest.fn(),
+    getTransactionReceipt: jest.fn(),
+  },
+  transactionHistoryService: {
+    getNonceByChain: (...args: unknown[]) => mockGetNonceByChain(...args),
+    store: {
+      transactions: {},
+    },
+  },
+}));
+
+jest.mock('@/utils/chain', () => ({
+  findChain: (...args: unknown[]) => mockFindChain(...args),
+}));
+
+jest.mock('../request', () => ({
+  openapi: {
+    getChainListByIds: (...args: unknown[]) => mockGetChainListByIds(...args),
+  },
+}));
+
+import { apiCustomTestnet } from './customTestnet';
+import { transactionHistoryService } from '../services/shared';
+
+describe('apiCustomTestnet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCustomTestnetAdd.mockResolvedValue({ id: 9001 });
+    mockGetTransactionCount.mockResolvedValue(7);
+    mockGetNonceByChain.mockResolvedValue(0);
+    mockFindChain.mockReturnValue(undefined);
+    mockGetChainListByIds.mockResolvedValue([]);
+    transactionHistoryService.store.transactions = {};
+  });
+
+  it('tracks successful custom testnet additions with the requested source', async () => {
+    const chain = {
+      id: 9001,
+      name: 'Local devnet',
+      rpcUrl: 'https://rpc.example',
+    };
+
+    await expect(
+      apiCustomTestnet.addCustomTestnet(chain as never, {
+        ga: { source: 'dapp' },
+      }),
+    ).resolves.toEqual({ id: 9001 });
+
+    expect(mockCustomTestnetAdd).toHaveBeenCalledWith(chain);
+    expect(mockMatomoRequestEvent).toHaveBeenCalledWith({
+      category: 'Custom Network',
+      action: 'Success Add Network',
+      label: 'dapp_9001',
+    });
+  });
+
+  it('does not track failed custom testnet additions', async () => {
+    mockCustomTestnetAdd.mockResolvedValue({
+      error: 'invalid rpc',
+    });
+
+    await expect(
+      apiCustomTestnet.addCustomTestnet({ id: 9002 } as never),
+    ).resolves.toEqual({ error: 'invalid rpc' });
+
+    expect(mockMatomoRequestEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns the larger nonce between custom RPC and local history', async () => {
+    mockGetTransactionCount.mockResolvedValue(3);
+    mockGetNonceByChain.mockResolvedValue(11);
+
+    await expect(
+      apiCustomTestnet.getCustomTestnetNonce({
+        address: '0xabc',
+        chainId: 9001,
+      }),
+    ).resolves.toBe(11);
+
+    expect(mockGetTransactionCount).toHaveBeenCalledWith({
+      address: '0xabc',
+      chainId: 9001,
+      blockTag: 'latest',
+    });
+    expect(mockGetNonceByChain).toHaveBeenCalledWith('0xabc', 9001);
+  });
+
+  it('fetches only unknown custom chains used in transaction history', async () => {
+    transactionHistoryService.store.transactions = {
+      a: { chainId: 1 },
+      b: { chainId: 9001 },
+      c: { chainId: 9001 },
+      d: { chainId: 9002 },
+    };
+    mockFindChain.mockImplementation(({ id }) => (id === 1 ? { id } : null));
+    mockGetChainListByIds.mockResolvedValue([{ id: 9001 }, { id: 9002 }]);
+
+    await expect(
+      apiCustomTestnet.getUsedCustomTestnetChainList(),
+    ).resolves.toEqual([{ id: 9001 }, { id: 9002 }]);
+
+    expect(mockGetChainListByIds).toHaveBeenCalledWith({
+      ids: '9001,9002',
+    });
+  });
+});

--- a/apps/mobile/src/core/apis/recommendNonce.test.ts
+++ b/apps/mobile/src/core/apis/recommendNonce.test.ts
@@ -1,0 +1,173 @@
+const mockFindChain = jest.fn();
+const mockIsTempoChain = jest.fn();
+const mockRequestReadOnlyETHRpc = jest.fn();
+const mockGetNonceByChain = jest.fn();
+const mockTranslate = jest.fn((key: string) => `translated:${key}`);
+const mockEncodeFunctionData = jest.fn(() => '0xencodedNonceCall');
+const mockDecodeFunctionResult = jest.fn(() => 31n);
+
+jest.mock('@/utils/chain', () => ({
+  findChain: (...args: unknown[]) => mockFindChain(...args),
+}));
+
+jest.mock('@/utils/tempoChain', () => ({
+  isTempoChain: (...args: unknown[]) => mockIsTempoChain(...args),
+}));
+
+jest.mock('@/core/services', () => ({
+  transactionHistoryService: {
+    getNonceByChain: (...args: unknown[]) => mockGetNonceByChain(...args),
+  },
+}));
+
+jest.mock('./readOnlyRpc', () => ({
+  requestReadOnlyETHRpc: (...args: unknown[]) =>
+    mockRequestReadOnlyETHRpc(...args),
+}));
+
+jest.mock('i18next', () => ({
+  t: (...args: unknown[]) => mockTranslate(...args),
+}));
+
+jest.mock('viem', () => ({
+  encodeFunctionData: (...args: unknown[]) => mockEncodeFunctionData(...args),
+  decodeFunctionResult: (...args: unknown[]) =>
+    mockDecodeFunctionResult(...args),
+}));
+
+jest.mock('viem/tempo', () => ({
+  Abis: {
+    nonce: [{ type: 'function', name: 'getNonce' }],
+  },
+  Addresses: {
+    nonceManager: '0x0000000000000000000000000000000000001000',
+  },
+}));
+
+import { getRecommendNonce } from './recommendNonce';
+
+describe('getRecommendNonce', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindChain.mockReturnValue({
+      id: 1,
+      serverId: 'eth',
+    });
+    mockIsTempoChain.mockReturnValue(false);
+    mockRequestReadOnlyETHRpc.mockResolvedValue('0x9');
+    mockGetNonceByChain.mockResolvedValue(0);
+  });
+
+  it('throws a translated invalid-chain error when chain id is unknown', async () => {
+    mockFindChain.mockReturnValue(null);
+
+    await expect(
+      getRecommendNonce({
+        from: '0xabc',
+        chainId: 999_999,
+        account: null,
+      }),
+    ).rejects.toThrow('translated:background.error.invalidChainId');
+
+    expect(mockTranslate).toHaveBeenCalledWith(
+      'background.error.invalidChainId',
+    );
+    expect(mockRequestReadOnlyETHRpc).not.toHaveBeenCalled();
+  });
+
+  it('uses the larger value between on-chain and local nonce for normal chains', async () => {
+    mockRequestReadOnlyETHRpc.mockResolvedValue('0x9');
+    mockGetNonceByChain.mockResolvedValue(12);
+
+    await expect(
+      getRecommendNonce({
+        from: '0xabc',
+        chainId: 1,
+        account: { address: '0xabc' } as never,
+      }),
+    ).resolves.toBe('0xc');
+
+    expect(mockRequestReadOnlyETHRpc).toHaveBeenCalledWith(
+      {
+        method: 'eth_getTransactionCount',
+        params: ['0xabc', 'latest'],
+      },
+      'eth',
+      { address: '0xabc' },
+    );
+    expect(mockGetNonceByChain).toHaveBeenCalledWith('0xabc', 1);
+  });
+
+  it('falls back to transaction count when a Tempo nonce key is empty or non-positive', async () => {
+    mockFindChain.mockReturnValue({
+      id: 777,
+      serverId: 'tempo',
+    });
+    mockIsTempoChain.mockReturnValue(true);
+
+    await expect(
+      getRecommendNonce({
+        from: '0xabc',
+        chainId: 777,
+        account: null,
+        nonceKey: '0x',
+      }),
+    ).resolves.toBe('0x9');
+
+    expect(mockEncodeFunctionData).not.toHaveBeenCalled();
+    expect(mockRequestReadOnlyETHRpc).toHaveBeenCalledWith(
+      {
+        method: 'eth_getTransactionCount',
+        params: ['0xabc', 'latest'],
+      },
+      'tempo',
+      null,
+    );
+  });
+
+  it('reads Tempo nonce manager when a positive nonce key is provided', async () => {
+    mockFindChain.mockReturnValue({
+      id: 777,
+      serverId: 'tempo',
+    });
+    mockIsTempoChain.mockReturnValue(true);
+    mockRequestReadOnlyETHRpc.mockResolvedValue('0xencodedNonceResult');
+
+    await expect(
+      getRecommendNonce({
+        from: '0xabc',
+        chainId: 777,
+        account: null,
+        nonceKey: 2.9,
+      }),
+    ).resolves.toBe('0x1f');
+
+    expect(mockEncodeFunctionData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: 'getNonce',
+        args: ['0xabc', 2n],
+      }),
+    );
+    expect(mockRequestReadOnlyETHRpc).toHaveBeenCalledWith(
+      {
+        method: 'eth_call',
+        params: [
+          {
+            to: '0x0000000000000000000000000000000000001000',
+            data: '0xencodedNonceCall',
+          },
+          'latest',
+        ],
+      },
+      'tempo',
+      null,
+    );
+    expect(mockDecodeFunctionResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: 'getNonce',
+        data: '0xencodedNonceResult',
+      }),
+    );
+    expect(mockGetNonceByChain).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add getRecommendNonce tests for invalid chains, normal nonce maxing, Tempo nonceKey fallback, and Tempo nonce-manager calls
- add custom testnet API tests for success analytics, failed-add suppression, nonce maxing, and used custom-chain filtering

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/core/apis/recommendNonce.test.ts src/core/apis/customTestnet.test.ts
- corepack yarn workspace rabby-mobile eslint src/core/apis/recommendNonce.test.ts src/core/apis/customTestnet.test.ts --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached