### PR TITLE
test: cover address and contact api utilities

### DIFF
--- a/apps/mobile/src/core/apis/contact.test.ts
+++ b/apps/mobile/src/core/apis/contact.test.ts
@@ -1,0 +1,62 @@
+const mockGetAliasByAddress = jest.fn();
+const mockGetContactsByMap = jest.fn();
+
+jest.mock('../services', () => ({
+  contactService: {
+    getAliasByAddress: (...args: unknown[]) => mockGetAliasByAddress(...args),
+    getContactsByMap: (...args: unknown[]) => mockGetContactsByMap(...args),
+  },
+}));
+
+import { getAliasName, getContactsByAddress } from './contact';
+
+describe('core/apis/contact', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns alias text and preserves lookup options', () => {
+    mockGetAliasByAddress.mockReturnValue({
+      alias: 'Main wallet',
+    });
+
+    expect(getAliasName('0xABC', { fallbackToAddr: false } as never)).toBe(
+      'Main wallet',
+    );
+    expect(mockGetAliasByAddress).toHaveBeenCalledWith('0xABC', {
+      fallbackToAddr: false,
+    });
+  });
+
+  it('returns undefined when no alias item exists', () => {
+    mockGetAliasByAddress.mockReturnValue(undefined);
+
+    expect(getAliasName('0xABC')).toBeUndefined();
+  });
+
+  it('normalizes contact addresses to lowercase in the returned map', () => {
+    const contacts = {
+      a: {
+        name: 'Alice',
+        address: '0xABCDEF',
+      },
+      b: {
+        name: 'Empty',
+        address: '',
+      },
+    };
+    mockGetContactsByMap.mockReturnValue(contacts);
+
+    expect(getContactsByAddress()).toBe(contacts);
+    expect(contacts).toEqual({
+      a: {
+        name: 'Alice',
+        address: '0xabcdef',
+      },
+      b: {
+        name: 'Empty',
+        address: '',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add address API tests for watch-address import, report partitioning, and remove-address cleanup/reset/broadcast behavior
- add contact API tests for alias lookup and lowercase contact-map normalization

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/core/apis/address.test.ts src/core/apis/contact.test.ts
- corepack yarn workspace rabby-mobile eslint src/core/apis/address.test.ts src/core/apis/contact.test.ts --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached