### PR TITLE
test: cover rpc routing api utilities

### DIFF
--- a/apps/mobile/src/core/apis/customRPC.test.ts
+++ b/apps/mobile/src/core/apis/customRPC.test.ts
@@ -1,0 +1,69 @@
+const mockFindChain = jest.fn();
+const mockCustomRPCService = {
+  setRPC: jest.fn(),
+  removeCustomRPC: jest.fn(),
+  getAllRPC: jest.fn(),
+  getRPCByChain: jest.fn(),
+  ping: jest.fn(),
+  setRPCEnable: jest.fn(),
+  request: jest.fn(),
+  hasCustomRPC: jest.fn(),
+};
+
+const loadCustomRPCModule = () => {
+  jest.resetModules();
+
+  jest.doMock('../services/shared', () => ({
+    customRPCService: mockCustomRPCService,
+  }));
+
+  jest.doMock('@/utils/chain', () => ({
+    findChain: (...args: unknown[]) => mockFindChain(...args),
+  }));
+
+  return require('./customRPC') as typeof import('./customRPC');
+};
+
+describe('apiCustomRPC', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindChain.mockReturnValue({
+      id: 1,
+      enum: 'ETH',
+    });
+    mockCustomRPCService.ping.mockResolvedValue(true);
+    mockCustomRPCService.request.mockResolvedValue('0x1');
+  });
+
+  it('rejects validation for unsupported chain ids before touching the RPC url', async () => {
+    const { apiCustomRPC } = loadCustomRPCModule();
+    mockFindChain.mockReturnValue(undefined);
+
+    await expect(
+      apiCustomRPC.validateRPC('https://rpc.example', 999_999),
+    ).rejects.toThrow('ChainId 999999 is not supported');
+
+    expect(mockCustomRPCService.ping).not.toHaveBeenCalled();
+    expect(mockCustomRPCService.request).not.toHaveBeenCalled();
+  });
+
+  it('validates RPC endpoints by pinging the chain and comparing eth_chainId', async () => {
+    const { apiCustomRPC } = loadCustomRPCModule();
+
+    await expect(
+      apiCustomRPC.validateRPC('https://rpc.example', 1),
+    ).resolves.toBe(true);
+
+    expect(mockCustomRPCService.ping).toHaveBeenCalledWith('ETH');
+    expect(mockCustomRPCService.request).toHaveBeenCalledWith(
+      'https://rpc.example',
+      'eth_chainId',
+      [],
+    );
+
+    mockCustomRPCService.request.mockResolvedValue('0x38');
+    await expect(
+      apiCustomRPC.validateRPC('https://rpc.example', 1),
+    ).resolves.toBe(false);
+  });
+});

--- a/apps/mobile/src/core/apis/readOnlyRpc.test.ts
+++ b/apps/mobile/src/core/apis/readOnlyRpc.test.ts
@@ -1,0 +1,200 @@
+const mockRpcCacheGet = jest.fn();
+const mockRpcCacheSet = jest.fn();
+const mockFindChain = jest.fn();
+const mockHasCustomRPC = jest.fn();
+const mockRequestCustomRPC = jest.fn();
+const mockDefaultEthRPC = jest.fn();
+const mockGetTestnetClient = jest.fn();
+const mockTestnetRequest = jest.fn();
+
+jest.mock('@/constant', () => ({
+  INTERNAL_REQUEST_SESSION: {
+    origin: 'rabby-internal',
+  },
+}));
+
+jest.mock('@/constant/chains', () => ({
+  CHAINS_ENUM: {
+    ETH: 'ETH',
+  },
+}));
+
+jest.mock('@/core/services/customRPCService', () => ({
+  customRPCService: {
+    hasCustomRPC: (...args: unknown[]) => mockHasCustomRPC(...args),
+    requestCustomRPC: (...args: unknown[]) => mockRequestCustomRPC(...args),
+    defaultEthRPC: (...args: unknown[]) => mockDefaultEthRPC(...args),
+  },
+}));
+
+jest.mock('@/core/services/customTestnetService', () => ({
+  customTestnetService: {
+    getClient: (...args: unknown[]) => mockGetTestnetClient(...args),
+  },
+}));
+
+jest.mock('@/core/services/rpcCache', () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => mockRpcCacheGet(...args),
+    set: (...args: unknown[]) => mockRpcCacheSet(...args),
+  },
+}));
+
+jest.mock('@/utils/chain', () => ({
+  findChain: (...args: unknown[]) => mockFindChain(...args),
+}));
+
+import { requestReadOnlyETHRpc } from './readOnlyRpc';
+
+const mainnetChain = {
+  id: 1,
+  enum: 'ETH',
+  serverId: 'eth',
+  isTestnet: false,
+};
+const testnetChain = {
+  id: 9001,
+  enum: 'TESTNET',
+  serverId: 'testnet',
+  isTestnet: true,
+};
+
+describe('requestReadOnlyETHRpc', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRpcCacheGet.mockReturnValue(undefined);
+    mockFindChain.mockReturnValue(mainnetChain);
+    mockHasCustomRPC.mockReturnValue(false);
+    mockRequestCustomRPC.mockResolvedValue('custom-result');
+    mockDefaultEthRPC.mockResolvedValue('default-result');
+    mockTestnetRequest.mockResolvedValue('testnet-result');
+    mockGetTestnetClient.mockReturnValue({
+      request: (...args: unknown[]) => mockTestnetRequest(...args),
+    });
+  });
+
+  it('returns cached read-only RPC results without hitting any transport', async () => {
+    mockRpcCacheGet.mockReturnValue('cached-result');
+
+    await expect(
+      requestReadOnlyETHRpc(
+        {
+          method: 'eth_blockNumber',
+          params: [],
+        },
+        'eth',
+        { address: '0xABC' } as never,
+      ),
+    ).resolves.toBe('cached-result');
+
+    expect(mockRpcCacheGet).toHaveBeenCalledWith('0xabc', {
+      method: 'eth_blockNumber',
+      params: [],
+      chainId: 'eth',
+    });
+    expect(mockRequestCustomRPC).not.toHaveBeenCalled();
+    expect(mockDefaultEthRPC).not.toHaveBeenCalled();
+    expect(mockRpcCacheSet).not.toHaveBeenCalled();
+  });
+
+  it('routes mainnet requests through custom RPC when enabled and caches the promise and result', async () => {
+    mockHasCustomRPC.mockReturnValue(true);
+
+    await expect(
+      requestReadOnlyETHRpc(
+        {
+          method: 'eth_getBalance',
+          params: ['0xabc', 'latest'],
+        },
+        'eth',
+        { address: '0xABC' } as never,
+      ),
+    ).resolves.toBe('custom-result');
+
+    expect(mockRequestCustomRPC).toHaveBeenCalledWith('ETH', 'eth_getBalance', [
+      '0xabc',
+      'latest',
+    ]);
+    expect(mockRpcCacheSet).toHaveBeenNthCalledWith(1, '0xabc', {
+      method: 'eth_getBalance',
+      params: ['0xabc', 'latest'],
+      result: expect.any(Promise),
+      chainId: 'eth',
+    });
+    expect(mockRpcCacheSet).toHaveBeenNthCalledWith(2, '0xabc', {
+      method: 'eth_getBalance',
+      params: ['0xabc', 'latest'],
+      result: 'custom-result',
+      chainId: 'eth',
+    });
+  });
+
+  it('routes mainnet requests through default RPC when no custom RPC is enabled', async () => {
+    await expect(
+      requestReadOnlyETHRpc(
+        {
+          method: 'eth_chainId',
+          params: [],
+        },
+        'eth',
+        null,
+      ),
+    ).resolves.toBe('default-result');
+
+    expect(mockDefaultEthRPC).toHaveBeenCalledWith({
+      chainServerId: 'eth',
+      origin: 'rabby-internal',
+      method: 'eth_chainId',
+      params: [],
+    });
+  });
+
+  it('falls back unknown chains to ETH default routing', async () => {
+    mockFindChain.mockImplementation(({ serverId, enum: chainEnum }) => {
+      if (serverId === 'unknown') {
+        return undefined;
+      }
+      if (chainEnum === 'ETH') {
+        return mainnetChain;
+      }
+      return undefined;
+    });
+
+    await requestReadOnlyETHRpc(
+      {
+        method: 'eth_chainId',
+        params: [],
+      },
+      'unknown',
+    );
+
+    expect(mockDefaultEthRPC).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chainServerId: 'unknown',
+      }),
+    );
+  });
+
+  it('routes testnet requests through the custom testnet client', async () => {
+    mockFindChain.mockReturnValue(testnetChain);
+
+    await expect(
+      requestReadOnlyETHRpc(
+        {
+          method: 'eth_call',
+          params: [{ to: '0xabc' }, 'latest'],
+        },
+        'testnet',
+        { address: '0xABC' } as never,
+      ),
+    ).resolves.toBe('testnet-result');
+
+    expect(mockGetTestnetClient).toHaveBeenCalledWith(9001);
+    expect(mockTestnetRequest).toHaveBeenCalledWith({
+      method: 'eth_call',
+      params: [{ to: '0xabc' }, 'latest'],
+    });
+    expect(mockDefaultEthRPC).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add custom RPC validation tests for unsupported chain ids and eth_chainId comparison
- add read-only RPC tests for cache hits, custom RPC routing, default RPC routing, ETH fallback, and testnet client routing

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/core/apis/customRPC.test.ts src/core/apis/readOnlyRpc.test.ts
- corepack yarn workspace rabby-mobile eslint src/core/apis/customRPC.test.ts src/core/apis/readOnlyRpc.test.ts --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached