### PR TITLE
test: cover legacy wallet info utilities

### DIFF
--- a/apps/mobile/src/utils/walletInfo.test.ts
+++ b/apps/mobile/src/utils/walletInfo.test.ts
@@ -1,0 +1,65 @@
+import {
+  HARDWARE_KEYRING_TYPES,
+  KEYRING_CLASS,
+  WALLET_NAME,
+} from '@rabby-wallet/keyring-utils';
+
+jest.mock('@/assets/icons/address', () => ({
+  PrivateKeySVG: 'PrivateKeySVG',
+  SeedPhraseSVG: 'SeedPhraseSVG',
+  RcIconWatchAddress: 'RcIconWatchAddress',
+  PrivateKeySVGLight: 'PrivateKeySVGLight',
+  SeedPhraseSVGLight: 'SeedPhraseSVGLight',
+}));
+
+import { getWalletIcon, WALLET_INFO } from './walletInfo';
+
+describe('walletInfo legacy icon mapping', () => {
+  it('keeps external wallet metadata for WalletConnect brands', () => {
+    expect(WALLET_INFO[WALLET_NAME.MetaMask]).toMatchObject({
+      brand: WALLET_NAME.MetaMask,
+      deepLink: 'metamask:',
+      androidPackageName: 'io.metamask',
+    });
+    expect(WALLET_INFO[WALLET_NAME.UnknownWallet]).toMatchObject({
+      brand: WALLET_NAME.UnknownWallet,
+      deepLink: '',
+      androidPackageName: '',
+    });
+  });
+
+  it('maps special account keyring classes before wallet brand fallback', () => {
+    const watchIcon = getWalletIcon(KEYRING_CLASS.WATCH);
+    const ledgerIcon = getWalletIcon(KEYRING_CLASS.HARDWARE.LEDGER);
+    const safeIcon = getWalletIcon(KEYRING_CLASS.GNOSIS);
+    const unknownIcon = getWalletIcon(undefined);
+
+    expect(watchIcon).toBeDefined();
+    expect(ledgerIcon).toBeDefined();
+    expect(safeIcon).toBeDefined();
+    expect(watchIcon).not.toBe(unknownIcon);
+    expect(ledgerIcon).not.toBe(unknownIcon);
+    expect(safeIcon).not.toBe(unknownIcon);
+  });
+
+  it('switches private key and mnemonic icons for light mode variants', () => {
+    expect(getWalletIcon(KEYRING_CLASS.PRIVATE_KEY, true)).not.toBe(
+      getWalletIcon(KEYRING_CLASS.PRIVATE_KEY, false),
+    );
+    expect(getWalletIcon(KEYRING_CLASS.MNEMONIC, true)).not.toBe(
+      getWalletIcon(KEYRING_CLASS.MNEMONIC, false),
+    );
+  });
+
+  it('maps Keystone brand aliases and known wallet names to their dedicated icons', () => {
+    expect(
+      getWalletIcon(HARDWARE_KEYRING_TYPES.Keystone.brandName),
+    ).toBeDefined();
+    expect(getWalletIcon(WALLET_NAME.MetaMask)).toBe(
+      WALLET_INFO[WALLET_NAME.MetaMask].icon,
+    );
+    expect(getWalletIcon('missing-wallet-brand')).toBe(
+      WALLET_INFO[WALLET_NAME.UnknownWallet].icon,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add legacy wallet info tests for external wallet metadata and unknown fallback
- cover special keyring icon mapping and light-mode private key/mnemonic variants
- cover Keystone brand alias and known WalletConnect brand icon lookup

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/utils/walletInfo.test.ts
- corepack yarn workspace rabby-mobile eslint src/utils/walletInfo.test.ts --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached