### PR TITLE
test: cover device and auto-lock api utilities

### DIFF
--- a/apps/mobile/src/core/apis/autoLock.test.ts
+++ b/apps/mobile/src/core/apis/autoLock.test.ts
@@ -1,0 +1,164 @@
+const mockGetPreference = jest.fn();
+const mockSetPreference = jest.fn();
+const mockIsUnlocked = jest.fn();
+
+const createEventClass = () =>
+  class EventEmitter {
+    private listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+
+    on(event: string, listener: (...args: unknown[]) => void) {
+      this.listeners[event] = [...(this.listeners[event] || []), listener];
+      return this;
+    }
+
+    emit(event: string, ...args: unknown[]) {
+      (this.listeners[event] || []).forEach(listener => listener(...args));
+      return true;
+    }
+  };
+
+const loadAutoLockModule = () => {
+  jest.resetModules();
+
+  jest.doMock('react-native', () => ({
+    AppState: {
+      currentState: 'active',
+      isAvailable: true,
+      addEventListener: jest.fn(() => ({
+        remove: jest.fn(),
+      })),
+    },
+  }));
+
+  jest.doMock('@/constant/autoLock', () => ({
+    DEFAULT_AUTO_LOCK_MINUTES: 15,
+  }));
+
+  jest.doMock('../services', () => ({
+    keyringService: {
+      isUnlocked: (...args: unknown[]) => mockIsUnlocked(...args),
+    },
+    preferenceService: {
+      getPreference: (...args: unknown[]) => mockGetPreference(...args),
+      setPreference: (...args: unknown[]) => mockSetPreference(...args),
+    },
+  }));
+
+  jest.doMock('./event', () => ({
+    makeEEClass: () => ({
+      EventEmitter: createEventClass(),
+    }),
+  }));
+
+  return require('./autoLock') as typeof import('./autoLock');
+};
+
+describe('core/apis/autoLock', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-30T12:00:00.000Z'));
+    jest.clearAllMocks();
+    mockGetPreference.mockImplementation((key: string) => {
+      if (key === 'autoLockTime') {
+        return 2;
+      }
+      if (key === 'lastUnlockTime') {
+        return Date.now() - 1000;
+      }
+      if (key === 'unlockSessionExpireTime') {
+        return 0;
+      }
+      return undefined;
+    });
+    mockIsUnlocked.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('coerces auto-lock timeout values into minute and millisecond precision', () => {
+    const { coerceAutoLockTimeout, isValidAutoLockTime } = loadAutoLockModule();
+
+    expect(isValidAutoLockTime(1)).toBe(true);
+    expect(isValidAutoLockTime(0)).toBe(false);
+    expect(coerceAutoLockTimeout(90_123)).toEqual({
+      minutes: 1.5,
+      timeoutMs: 90_000,
+    });
+    expect(coerceAutoLockTimeout(0)).toEqual({
+      minutes: -1,
+      timeoutMs: -1,
+    });
+  });
+
+  it('builds persisted auto-lock times from the configured preference', () => {
+    const { getPersistedAutoLockTimes } = loadAutoLockModule();
+
+    expect(getPersistedAutoLockTimes()).toEqual({
+      minutes: 2,
+      timeoutMs: 120_000,
+      expireTime: Date.now() + 120_000,
+    });
+  });
+
+  it('derives unlock session expiry from explicit preference or last unlock time', () => {
+    const { getPersistedUnlockSessionExpireTime } = loadAutoLockModule();
+
+    mockGetPreference.mockImplementation((key: string) => {
+      if (key === 'unlockSessionExpireTime') {
+        return -1;
+      }
+      return undefined;
+    });
+    expect(getPersistedUnlockSessionExpireTime()).toBe(-1);
+
+    mockGetPreference.mockImplementation((key: string) => {
+      if (key === 'unlockSessionExpireTime') {
+        return Date.now() + 10_000;
+      }
+      return undefined;
+    });
+    expect(getPersistedUnlockSessionExpireTime()).toBe(Date.now() + 10_000);
+
+    mockGetPreference.mockImplementation((key: string) => {
+      if (key === 'autoLockTime') {
+        return 2;
+      }
+      if (key === 'lastUnlockTime') {
+        return Date.now() - 1_000;
+      }
+      return 0;
+    });
+    expect(getPersistedUnlockSessionExpireTime()).toBe(
+      Date.now() - 1_000 + 120_000,
+    );
+  });
+
+  it('refreshes foreground expiry and persisted unlock session when refresh is allowed', () => {
+    const { autoLockEvent, refreshAutolockTimeout } = loadAutoLockModule();
+    const changes: number[] = [];
+    autoLockEvent.on('change', expireTime => {
+      changes.push(expireTime as number);
+    });
+
+    expect(refreshAutolockTimeout()).toBe(Date.now() + 120_000);
+
+    expect(mockSetPreference).toHaveBeenCalledWith({
+      unlockSessionExpireTime: Date.now() + 120_000,
+    });
+    expect(changes).toEqual([Date.now() + 120_000]);
+  });
+
+  it('clears foreground expiry without writing persisted unlock session', () => {
+    const { autoLockEvent, refreshAutolockTimeout } = loadAutoLockModule();
+    const changes: number[] = [];
+    autoLockEvent.on('change', expireTime => {
+      changes.push(expireTime as number);
+    });
+
+    expect(refreshAutolockTimeout('clear')).toBe(-1);
+
+    expect(mockSetPreference).not.toHaveBeenCalled();
+    expect(changes).toEqual([-1]);
+  });
+});

--- a/apps/mobile/src/core/apis/device.test.ts
+++ b/apps/mobile/src/core/apis/device.test.ts
@@ -1,0 +1,95 @@
+const mockGetItem = jest.fn();
+const mockSetItem = jest.fn();
+const mockUuidV4 = jest.fn();
+const mockGetUniqueIdSync = jest.fn();
+const mockGetSystemVersion = jest.fn();
+const mockGetSystemName = jest.fn();
+
+jest.mock('@/constant', () => ({
+  APP_VERSIONS: {
+    fromNative: '1.2.3',
+    buildNumber: '456',
+  },
+  APPLICATION_ID: 'com.rabby.mobile',
+}));
+
+jest.mock('@/constant/env', () => ({
+  BUILD_GIT_INFO: {
+    BUILD_GIT_HASH: 'abc123',
+  },
+}));
+
+jest.mock('react-native', () => ({
+  Platform: {
+    OS: 'android',
+  },
+}));
+
+jest.mock('react-native-device-info', () => ({
+  getUniqueIdSync: (...args: unknown[]) => mockGetUniqueIdSync(...args),
+  getSystemVersion: (...args: unknown[]) => mockGetSystemVersion(...args),
+  getSystemName: (...args: unknown[]) => mockGetSystemName(...args),
+}));
+
+jest.mock('uuid', () => ({
+  v4: (...args: unknown[]) => mockUuidV4(...args),
+}));
+
+jest.mock('../storage/mmkv', () => ({
+  appJsonStore: {
+    getItem: (...args: unknown[]) => mockGetItem(...args),
+    setItem: (...args: unknown[]) => mockSetItem(...args),
+  },
+}));
+
+import {
+  ensureDeviceUUID,
+  makeDeviceUUID,
+  makeMobileClientPushInfo,
+} from './device';
+
+describe('core/apis/device', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetItem.mockReturnValue('persisted-uuid');
+    mockUuidV4.mockReturnValue('new-uuid');
+    mockGetUniqueIdSync.mockReturnValue('native-unique-id');
+    mockGetSystemVersion.mockReturnValue('14');
+    mockGetSystemName.mockReturnValue('Android');
+  });
+
+  it('reuses an existing persisted device uuid', () => {
+    expect(ensureDeviceUUID()).toBe('persisted-uuid');
+    expect(mockGetItem).toHaveBeenCalledWith('rabbymobile_uuid', null);
+    expect(mockSetItem).not.toHaveBeenCalled();
+  });
+
+  it('generates and persists a uuid when none exists', () => {
+    mockGetItem.mockReturnValue(null);
+
+    expect(ensureDeviceUUID()).toBe('new-uuid');
+    expect(mockSetItem).toHaveBeenCalledWith('rabbymobile_uuid', 'new-uuid');
+  });
+
+  it('combines persisted uuid, platform, and native unique id', () => {
+    expect(makeDeviceUUID()).toEqual({
+      uniqId: 'native-unique-id',
+      deviceUUID: 'persisted-uuid-android-native-unique-id',
+    });
+  });
+
+  it('builds mobile push client info from native and build metadata', () => {
+    expect(makeMobileClientPushInfo('push-token', true)).toEqual({
+      deviceUUID: 'persisted-uuid-android-native-unique-id',
+      platform: 'android',
+      packageName: 'com.rabby.mobile',
+      systemVersion: '14',
+      systemName: 'Android',
+      appVersion: '1.2.3',
+      appBuildNumber: '456',
+      appBuildRevision: 'abc123',
+      enabledNotifications: true,
+      pushToken: 'push-token',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add device API tests for persisted UUID reuse/generation, device UUID composition, and push client info payloads
- add auto-lock API tests for timeout coercion, persisted lock times, unlock-session expiry derivation, refresh writes, and clear behavior

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/core/apis/device.test.ts src/core/apis/autoLock.test.ts
- corepack yarn workspace rabby-mobile eslint src/core/apis/device.test.ts src/core/apis/autoLock.test.ts --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached