### PR TITLE
test: cover portfolio api utilities

### DIFF
--- a/apps/mobile/src/core/apis/portfolio.test.ts
+++ b/apps/mobile/src/core/apis/portfolio.test.ts
@@ -1,0 +1,132 @@
+const mockOpenapiGetComplexProtocolList = jest.fn();
+const mockTestOpenapiGetComplexProtocolList = jest.fn();
+const mockOpenapiGetProtocol = jest.fn();
+const mockTestOpenapiGetProtocol = jest.fn();
+const mockPQueueAdd = jest.fn((fn: () => unknown) => fn());
+
+jest.mock('@/core/request', () => ({
+  openapi: {
+    getComplexProtocolList: (...args: unknown[]) =>
+      mockOpenapiGetComplexProtocolList(...args),
+    getProtocol: (...args: unknown[]) => mockOpenapiGetProtocol(...args),
+  },
+  testOpenapi: {
+    getComplexProtocolList: (...args: unknown[]) =>
+      mockTestOpenapiGetComplexProtocolList(...args),
+    getProtocol: (...args: unknown[]) => mockTestOpenapiGetProtocol(...args),
+  },
+}));
+
+jest.mock('@/core/utils/concurrency', () => ({
+  makeSWRKeyAsyncFunc: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
+jest.mock('@/utils/requestQueue', () => ({
+  pQueue: {
+    add: (...args: unknown[]) => mockPQueueAdd(...args),
+  },
+}));
+
+import {
+  batchLoadProjects,
+  loadPortfolioSnapshot,
+  loadTestnetPortfolioSnapshot,
+} from './portfolio';
+
+describe('core/apis/portfolio', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockOpenapiGetComplexProtocolList.mockResolvedValue(['mainnet-snapshot']);
+    mockTestOpenapiGetComplexProtocolList.mockResolvedValue([
+      'testnet-snapshot',
+    ]);
+    mockOpenapiGetProtocol.mockImplementation(({ id }) =>
+      Promise.resolve({ id, network: 'mainnet' }),
+    );
+    mockTestOpenapiGetProtocol.mockImplementation(({ id }) =>
+      Promise.resolve({ id, network: 'testnet' }),
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('loads mainnet and testnet portfolio snapshots through the shared queue', async () => {
+    await expect(loadPortfolioSnapshot('0xabc')).resolves.toEqual([
+      'mainnet-snapshot',
+    ]);
+    await expect(loadTestnetPortfolioSnapshot('0xabc')).resolves.toEqual([
+      'testnet-snapshot',
+    ]);
+
+    expect(mockPQueueAdd).toHaveBeenCalledTimes(2);
+    expect(mockOpenapiGetComplexProtocolList).toHaveBeenCalledWith('0xabc');
+    expect(mockTestOpenapiGetComplexProtocolList).toHaveBeenCalledWith('0xabc');
+  });
+
+  it('loads mainnet project details in queue order', async () => {
+    await expect(
+      batchLoadProjects('0xabc', ['aave', 'curve']),
+    ).resolves.toEqual([
+      {
+        id: 'aave',
+        network: 'mainnet',
+      },
+      {
+        id: 'curve',
+        network: 'mainnet',
+      },
+    ]);
+
+    expect(mockOpenapiGetProtocol).toHaveBeenCalledWith({
+      addr: '0xabc',
+      id: 'aave',
+    });
+    expect(mockOpenapiGetProtocol).toHaveBeenCalledWith({
+      addr: '0xabc',
+      id: 'curve',
+    });
+    expect(mockTestOpenapiGetProtocol).not.toHaveBeenCalled();
+  });
+
+  it('loads testnet project details when requested', async () => {
+    await expect(
+      batchLoadProjects('0xabc', ['test-protocol'], true),
+    ).resolves.toEqual([
+      {
+        id: 'test-protocol',
+        network: 'testnet',
+      },
+    ]);
+
+    expect(mockTestOpenapiGetProtocol).toHaveBeenCalledWith({
+      addr: '0xabc',
+      id: 'test-protocol',
+    });
+  });
+
+  it('returns null for failed single project loads only when ignoreSingleError is enabled', async () => {
+    mockOpenapiGetProtocol.mockImplementation(({ id }) => {
+      if (id === 'bad') {
+        return Promise.reject(new Error('bad project'));
+      }
+      return Promise.resolve({ id, network: 'mainnet' });
+    });
+
+    await expect(
+      batchLoadProjects('0xabc', ['good', 'bad'], false, true),
+    ).resolves.toEqual([
+      {
+        id: 'good',
+        network: 'mainnet',
+      },
+      null,
+    ]);
+
+    await expect(
+      batchLoadProjects('0xabc', ['bad'], false, false),
+    ).rejects.toThrow('bad project');
+  });
+});


### PR DESCRIPTION
## Summary
- add portfolio API tests for mainnet and testnet snapshot routing through the shared queue
- cover batch project loading for mainnet/testnet and strict vs ignore-single-error behavior

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/core/apis/portfolio.test.ts
- corepack yarn workspace rabby-mobile eslint src/core/apis/portfolio.test.ts --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached
