### PR TITLE
test: cover transaction rpc api utilities

### DIFF
--- a/apps/mobile/src/core/apis/readOnlyRpc.test.ts
+++ b/apps/mobile/src/core/apis/readOnlyRpc.test.ts
@@ -1,0 +1,218 @@
+function loadReadOnlyRpcModule() {
+  jest.resetModules();
+
+  const mockFindChain = jest.fn();
+  const mockRpcCacheGet = jest.fn();
+  const mockRpcCacheSet = jest.fn();
+  const mockHasCustomRPC = jest.fn();
+  const mockRequestCustomRPC = jest.fn();
+  const mockDefaultEthRPC = jest.fn();
+  const mockGetClient = jest.fn();
+  const mockClientRequest = jest.fn();
+
+  jest.doMock('@/constant', () => ({
+    INTERNAL_REQUEST_SESSION: {
+      origin: 'internal://rabby',
+    },
+  }));
+  jest.doMock('@/constant/chains', () => ({
+    CHAINS_ENUM: {
+      ETH: 'eth',
+    },
+  }));
+  jest.doMock('@/utils/chain', () => ({
+    findChain: (...args: unknown[]) => mockFindChain(...args),
+  }));
+  jest.doMock('@/core/services/customRPCService', () => ({
+    customRPCService: {
+      defaultEthRPC: (...args: unknown[]) => mockDefaultEthRPC(...args),
+      hasCustomRPC: (...args: unknown[]) => mockHasCustomRPC(...args),
+      requestCustomRPC: (...args: unknown[]) => mockRequestCustomRPC(...args),
+    },
+  }));
+  jest.doMock('@/core/services/customTestnetService', () => ({
+    customTestnetService: {
+      getClient: (...args: unknown[]) => mockGetClient(...args),
+    },
+  }));
+  jest.doMock('@/core/services/rpcCache', () => ({
+    __esModule: true,
+    default: {
+      get: (...args: unknown[]) => mockRpcCacheGet(...args),
+      set: (...args: unknown[]) => mockRpcCacheSet(...args),
+    },
+  }));
+
+  mockGetClient.mockReturnValue({
+    request: mockClientRequest,
+  });
+
+  const { requestReadOnlyETHRpc } =
+    require('./readOnlyRpc') as typeof import('./readOnlyRpc');
+
+  return {
+    requestReadOnlyETHRpc,
+    mocks: {
+      mockClientRequest,
+      mockDefaultEthRPC,
+      mockFindChain,
+      mockGetClient,
+      mockHasCustomRPC,
+      mockRequestCustomRPC,
+      mockRpcCacheGet,
+      mockRpcCacheSet,
+    },
+  };
+}
+
+describe('core/apis/readOnlyRpc', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('returns an account-scoped cached RPC result without touching services', async () => {
+    const { requestReadOnlyETHRpc, mocks } = loadReadOnlyRpcModule();
+    mocks.mockRpcCacheGet.mockReturnValue('cached-result');
+
+    await expect(
+      requestReadOnlyETHRpc(
+        {
+          method: 'eth_call',
+          params: [
+            {
+              to: '0xcontract',
+            },
+            'latest',
+          ],
+        },
+        'eth',
+        {
+          address: '0xABC',
+        } as never,
+      ),
+    ).resolves.toBe('cached-result');
+
+    expect(mocks.mockRpcCacheGet).toHaveBeenCalledWith('0xabc', {
+      chainId: 'eth',
+      method: 'eth_call',
+      params: [
+        {
+          to: '0xcontract',
+        },
+        'latest',
+      ],
+    });
+    expect(mocks.mockFindChain).not.toHaveBeenCalled();
+    expect(mocks.mockRequestCustomRPC).not.toHaveBeenCalled();
+    expect(mocks.mockDefaultEthRPC).not.toHaveBeenCalled();
+    expect(mocks.mockClientRequest).not.toHaveBeenCalled();
+  });
+
+  it('routes mainnet requests through a configured custom RPC and caches the pending promise and final result', async () => {
+    const { requestReadOnlyETHRpc, mocks } = loadReadOnlyRpcModule();
+    mocks.mockRpcCacheGet.mockReturnValue(undefined);
+    mocks.mockFindChain.mockReturnValue({
+      enum: 'eth',
+      id: 1,
+      isTestnet: false,
+      serverId: 'eth',
+    });
+    mocks.mockHasCustomRPC.mockReturnValue(true);
+    mocks.mockRequestCustomRPC.mockResolvedValue('0x123');
+
+    await expect(
+      requestReadOnlyETHRpc(
+        {
+          method: 'eth_getBalance',
+          params: ['0xabc', 'latest'],
+        },
+        'eth',
+        {
+          address: '0xabc',
+        } as never,
+      ),
+    ).resolves.toBe('0x123');
+
+    expect(mocks.mockRequestCustomRPC).toHaveBeenCalledWith(
+      'eth',
+      'eth_getBalance',
+      ['0xabc', 'latest'],
+    );
+    expect(mocks.mockRpcCacheSet).toHaveBeenNthCalledWith(1, '0xabc', {
+      chainId: 'eth',
+      method: 'eth_getBalance',
+      params: ['0xabc', 'latest'],
+      result: expect.any(Promise),
+    });
+    expect(mocks.mockRpcCacheSet).toHaveBeenNthCalledWith(2, '0xabc', {
+      chainId: 'eth',
+      method: 'eth_getBalance',
+      params: ['0xabc', 'latest'],
+      result: '0x123',
+    });
+  });
+
+  it('falls back to the default ETH RPC when no chain-specific custom RPC exists', async () => {
+    const { requestReadOnlyETHRpc, mocks } = loadReadOnlyRpcModule();
+    mocks.mockRpcCacheGet.mockReturnValue(undefined);
+    mocks.mockFindChain.mockImplementation(({ enum: chainEnum }) =>
+      chainEnum === 'eth'
+        ? {
+            enum: 'eth',
+            id: 1,
+            isTestnet: false,
+            serverId: 'eth',
+          }
+        : null,
+    );
+    mocks.mockHasCustomRPC.mockReturnValue(false);
+    mocks.mockDefaultEthRPC.mockResolvedValue('0x456');
+
+    await expect(
+      requestReadOnlyETHRpc(
+        {
+          method: 'eth_blockNumber',
+          params: [],
+        },
+        'unknown',
+        null,
+      ),
+    ).resolves.toBe('0x456');
+
+    expect(mocks.mockDefaultEthRPC).toHaveBeenCalledWith({
+      chainServerId: 'unknown',
+      method: 'eth_blockNumber',
+      origin: 'internal://rabby',
+      params: [],
+    });
+  });
+
+  it('routes testnet requests through the custom testnet client', async () => {
+    const { requestReadOnlyETHRpc, mocks } = loadReadOnlyRpcModule();
+    mocks.mockRpcCacheGet.mockReturnValue(undefined);
+    mocks.mockFindChain.mockReturnValue({
+      enum: 'custom9001',
+      id: 9001,
+      isTestnet: true,
+      serverId: 'custom9001',
+    });
+    mocks.mockClientRequest.mockResolvedValue('0xtestnet');
+
+    await expect(
+      requestReadOnlyETHRpc(
+        {
+          method: 'eth_getTransactionCount',
+          params: ['0xabc', 'latest'],
+        },
+        'custom9001',
+        undefined,
+      ),
+    ).resolves.toBe('0xtestnet');
+
+    expect(mocks.mockGetClient).toHaveBeenCalledWith(9001);
+    expect(mocks.mockClientRequest).toHaveBeenCalledWith({
+      method: 'eth_getTransactionCount',
+      params: ['0xabc', 'latest'],
+    });
+  });
+});

--- a/apps/mobile/src/core/apis/recommendNonce.test.ts
+++ b/apps/mobile/src/core/apis/recommendNonce.test.ts
@@ -1,0 +1,192 @@
+function loadRecommendNonceModule() {
+  jest.resetModules();
+
+  const mockDecodeFunctionResult = jest.fn();
+  const mockEncodeFunctionData = jest.fn();
+  const mockFindChain = jest.fn();
+  const mockGetNonceByChain = jest.fn();
+  const mockIsTempoChain = jest.fn();
+  const mockRequestReadOnlyETHRpc = jest.fn();
+
+  jest.doMock('i18next', () => ({
+    t: (key: string) => key,
+  }));
+  jest.doMock('viem', () => ({
+    decodeFunctionResult: (...args: unknown[]) =>
+      mockDecodeFunctionResult(...args),
+    encodeFunctionData: (...args: unknown[]) => mockEncodeFunctionData(...args),
+  }));
+  jest.doMock('viem/tempo', () => ({
+    Abis: {
+      nonce: ['nonce-abi'],
+    },
+    Addresses: {
+      nonceManager: '0xnonce',
+    },
+  }));
+  jest.doMock('@/core/services', () => ({
+    transactionHistoryService: {
+      getNonceByChain: (...args: unknown[]) => mockGetNonceByChain(...args),
+    },
+  }));
+  jest.doMock('@/utils/chain', () => ({
+    findChain: (...args: unknown[]) => mockFindChain(...args),
+  }));
+  jest.doMock('@/utils/tempoChain', () => ({
+    isTempoChain: (...args: unknown[]) => mockIsTempoChain(...args),
+  }));
+  jest.doMock('./readOnlyRpc', () => ({
+    requestReadOnlyETHRpc: (...args: unknown[]) =>
+      mockRequestReadOnlyETHRpc(...args),
+  }));
+
+  const { getRecommendNonce } =
+    require('./recommendNonce') as typeof import('./recommendNonce');
+
+  return {
+    getRecommendNonce,
+    mocks: {
+      mockDecodeFunctionResult,
+      mockEncodeFunctionData,
+      mockFindChain,
+      mockGetNonceByChain,
+      mockIsTempoChain,
+      mockRequestReadOnlyETHRpc,
+    },
+  };
+}
+
+describe('core/apis/recommendNonce', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('rejects unsupported chain ids before reading local or remote nonce', async () => {
+    const { getRecommendNonce, mocks } = loadRecommendNonceModule();
+    mocks.mockFindChain.mockReturnValue(null);
+
+    await expect(
+      getRecommendNonce({
+        account: null,
+        chainId: 12345,
+        from: '0xabc',
+      }),
+    ).rejects.toThrow('background.error.invalidChainId');
+
+    expect(mocks.mockRequestReadOnlyETHRpc).not.toHaveBeenCalled();
+    expect(mocks.mockGetNonceByChain).not.toHaveBeenCalled();
+  });
+
+  it('uses the larger value between standard on-chain and local transaction-history nonce', async () => {
+    const { getRecommendNonce, mocks } = loadRecommendNonceModule();
+    const account = {
+      address: '0xabc',
+    };
+    mocks.mockFindChain.mockReturnValue({
+      id: 1,
+      serverId: 'eth',
+    });
+    mocks.mockIsTempoChain.mockReturnValue(false);
+    mocks.mockRequestReadOnlyETHRpc.mockResolvedValue('0x5');
+    mocks.mockGetNonceByChain.mockResolvedValue(7);
+
+    await expect(
+      getRecommendNonce({
+        account: account as never,
+        chainId: 1,
+        from: '0xabc',
+      }),
+    ).resolves.toBe('0x7');
+
+    expect(mocks.mockRequestReadOnlyETHRpc).toHaveBeenCalledWith(
+      {
+        method: 'eth_getTransactionCount',
+        params: ['0xabc', 'latest'],
+      },
+      'eth',
+      account,
+    );
+    expect(mocks.mockGetNonceByChain).toHaveBeenCalledWith('0xabc', 1);
+  });
+
+  it('reads Tempo keyed nonce with eth_call when a positive nonce key is provided', async () => {
+    const { getRecommendNonce, mocks } = loadRecommendNonceModule();
+    const account = {
+      address: '0xabc',
+    };
+    mocks.mockFindChain.mockReturnValue({
+      id: 999,
+      serverId: 'tempo',
+    });
+    mocks.mockIsTempoChain.mockReturnValue(true);
+    mocks.mockEncodeFunctionData.mockReturnValue('0xencoded');
+    mocks.mockRequestReadOnlyETHRpc.mockResolvedValue('0xresult');
+    mocks.mockDecodeFunctionResult.mockReturnValue(10n);
+
+    await expect(
+      getRecommendNonce({
+        account: account as never,
+        chainId: 999,
+        from: '0xabc',
+        nonceKey: ' 0x2 ',
+      }),
+    ).resolves.toBe('0xa');
+
+    expect(mocks.mockEncodeFunctionData).toHaveBeenCalledWith({
+      abi: ['nonce-abi'],
+      args: ['0xabc', 2n],
+      functionName: 'getNonce',
+    });
+    expect(mocks.mockRequestReadOnlyETHRpc).toHaveBeenCalledWith(
+      {
+        method: 'eth_call',
+        params: [
+          {
+            data: '0xencoded',
+            to: '0xnonce',
+          },
+          'latest',
+        ],
+      },
+      'tempo',
+      account,
+    );
+    expect(mocks.mockDecodeFunctionResult).toHaveBeenCalledWith({
+      abi: ['nonce-abi'],
+      data: '0xresult',
+      functionName: 'getNonce',
+    });
+    expect(mocks.mockGetNonceByChain).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the standard nonce path for Tempo chains when the nonce key is empty or non-positive', async () => {
+    const { getRecommendNonce, mocks } = loadRecommendNonceModule();
+    mocks.mockFindChain.mockReturnValue({
+      id: 999,
+      serverId: 'tempo',
+    });
+    mocks.mockIsTempoChain.mockReturnValue(true);
+    mocks.mockRequestReadOnlyETHRpc.mockResolvedValue('0x8');
+    mocks.mockGetNonceByChain.mockResolvedValue(3);
+
+    await expect(
+      getRecommendNonce({
+        account: null,
+        chainId: 999,
+        from: '0xabc',
+        nonceKey: 0n,
+      }),
+    ).resolves.toBe('0x8');
+
+    expect(mocks.mockEncodeFunctionData).not.toHaveBeenCalled();
+    expect(mocks.mockRequestReadOnlyETHRpc).toHaveBeenCalledWith(
+      {
+        method: 'eth_getTransactionCount',
+        params: ['0xabc', 'latest'],
+      },
+      'tempo',
+      null,
+    );
+    expect(mocks.mockGetNonceByChain).toHaveBeenCalledWith('0xabc', 999);
+  });
+});


### PR DESCRIPTION
## Summary
- add read-only RPC tests for cache hits, custom RPC routing, default RPC fallback, and custom testnet clients
- add recommended nonce tests for invalid chains, standard nonce max selection, and Tempo keyed nonce eth_call behavior

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/core/apis/readOnlyRpc.test.ts src/core/apis/recommendNonce.test.ts
- corepack yarn workspace rabby-mobile eslint src/core/apis/readOnlyRpc.test.ts src/core/apis/recommendNonce.test.ts --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached
