### PR TITLE
test: cover auto lock and device api utilities

### DIFF
--- a/apps/mobile/src/core/apis/autoLock.test.ts
+++ b/apps/mobile/src/core/apis/autoLock.test.ts
@@ -1,0 +1,132 @@
+type PreferenceStore = Record<string, unknown>;
+
+function loadAutoLockModule({
+  isUnlocked = true,
+  preferences = {},
+}: {
+  isUnlocked?: boolean;
+  preferences?: PreferenceStore;
+} = {}) {
+  jest.resetModules();
+
+  const store: PreferenceStore = {
+    ...preferences,
+  };
+  const mockGetPreference = jest.fn((key: string) => store[key]);
+  const mockSetPreference = jest.fn((value: PreferenceStore) => {
+    Object.assign(store, value);
+  });
+  const mockIsUnlocked = jest.fn(() => isUnlocked);
+
+  jest.doMock('react-native', () => ({
+    AppState: {
+      addEventListener: jest.fn(),
+      currentState: 'active',
+      isAvailable: true,
+    },
+  }));
+  jest.doMock('@/constant/autoLock', () => ({
+    DEFAULT_AUTO_LOCK_MINUTES: 5,
+  }));
+  jest.doMock('../services', () => ({
+    keyringService: {
+      isUnlocked: mockIsUnlocked,
+    },
+    preferenceService: {
+      getPreference: (...args: unknown[]) => mockGetPreference(...args),
+      setPreference: (...args: unknown[]) => mockSetPreference(...args),
+    },
+  }));
+
+  const autoLockModule = require('./autoLock') as typeof import('./autoLock');
+
+  return {
+    ...autoLockModule,
+    mocks: {
+      mockGetPreference,
+      mockIsUnlocked,
+      mockSetPreference,
+      store,
+    },
+  };
+}
+
+describe('core/apis/autoLock', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('normalizes auto-lock timeout values to whole-second millisecond durations', () => {
+    const { coerceAutoLockTimeout, isValidAutoLockTime } = loadAutoLockModule();
+
+    expect(isValidAutoLockTime(1)).toBe(true);
+    expect(isValidAutoLockTime(0)).toBe(false);
+    expect(coerceAutoLockTimeout(0)).toEqual({
+      minutes: -1,
+      timeoutMs: -1,
+    });
+    expect(coerceAutoLockTimeout(90_500)).toEqual({
+      minutes: 1.51,
+      timeoutMs: 90_000,
+    });
+  });
+
+  it('derives persisted auto-lock expire time from the stored minute preference', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(10_000);
+    const { getPersistedAutoLockTimes } = loadAutoLockModule({
+      preferences: {
+        autoLockTime: 1.5,
+      },
+    });
+
+    expect(getPersistedAutoLockTimes()).toEqual({
+      expireTime: 100_000,
+      minutes: 1.5,
+      timeoutMs: 90_000,
+    });
+  });
+
+  it('derives unlock-session expiry from explicit preference or last unlock time', () => {
+    const explicit = loadAutoLockModule({
+      preferences: {
+        unlockSessionExpireTime: -1,
+      },
+    });
+    expect(explicit.getPersistedUnlockSessionExpireTime()).toBe(-1);
+
+    const fromLastUnlock = loadAutoLockModule({
+      preferences: {
+        autoLockTime: 2,
+        lastUnlockTime: 5_000,
+      },
+    });
+    expect(fromLastUnlock.getPersistedUnlockSessionExpireTime()).toBe(125_000);
+  });
+
+  it('refreshes foreground and persisted unlock-session expiry when the wallet session can be extended', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(20_000);
+    const { autoLockEvent, refreshAutolockTimeout, mocks } = loadAutoLockModule(
+      {
+        isUnlocked: true,
+        preferences: {
+          autoLockTime: 1,
+          lastUnlockTime: 10_000,
+        },
+      },
+    );
+    const changes: number[] = [];
+    autoLockEvent.on('change', expireTime => {
+      changes.push(expireTime);
+    });
+
+    expect(refreshAutolockTimeout()).toBe(80_000);
+    expect(mocks.store.unlockSessionExpireTime).toBe(80_000);
+    expect(mocks.mockSetPreference).toHaveBeenCalledWith({
+      unlockSessionExpireTime: 80_000,
+    });
+
+    expect(refreshAutolockTimeout('clear')).toBe(-1);
+    expect(changes).toEqual([80_000, -1]);
+  });
+});

--- a/apps/mobile/src/core/apis/device.test.ts
+++ b/apps/mobile/src/core/apis/device.test.ts
@@ -1,0 +1,127 @@
+function loadDeviceModule({
+  existingUUID,
+  platform = 'android',
+}: {
+  existingUUID?: string | null;
+  platform?: 'android' | 'ios';
+} = {}) {
+  jest.resetModules();
+
+  let storedUUID = existingUUID ?? null;
+  const mockGetItem = jest.fn(() => storedUUID);
+  const mockSetItem = jest.fn((_key: string, value: string) => {
+    storedUUID = value;
+  });
+  const mockUuidV4 = jest.fn(() => 'generated-uuid');
+  const mockGetUniqueIdSync = jest.fn(() => 'device-unique-id');
+  const mockGetSystemName = jest.fn(() => 'Android');
+  const mockGetSystemVersion = jest.fn(() => '15');
+
+  jest.doMock('react-native', () => ({
+    Platform: {
+      OS: platform,
+    },
+  }));
+  jest.doMock('react-native-device-info', () => ({
+    __esModule: true,
+    default: {
+      getSystemName: (...args: unknown[]) => mockGetSystemName(...args),
+      getSystemVersion: (...args: unknown[]) => mockGetSystemVersion(...args),
+      getUniqueIdSync: (...args: unknown[]) => mockGetUniqueIdSync(...args),
+    },
+  }));
+  jest.doMock('uuid', () => ({
+    v4: (...args: unknown[]) => mockUuidV4(...args),
+  }));
+  jest.doMock('@/constant', () => ({
+    APPLICATION_ID: 'com.rabby.mobile.test',
+    APP_VERSIONS: {
+      buildNumber: '99',
+      fromNative: '1.2.3',
+    },
+  }));
+  jest.doMock('@/constant/env', () => ({
+    BUILD_GIT_INFO: {
+      BUILD_GIT_HASH: 'abcdef0',
+    },
+  }));
+  jest.doMock('../storage/mmkv', () => ({
+    appJsonStore: {
+      getItem: (...args: unknown[]) => mockGetItem(...args),
+      setItem: (...args: unknown[]) => mockSetItem(...args),
+    },
+  }));
+
+  const deviceModule = require('./device') as typeof import('./device');
+
+  return {
+    ...deviceModule,
+    mocks: {
+      mockGetItem,
+      mockGetSystemName,
+      mockGetSystemVersion,
+      mockGetUniqueIdSync,
+      mockSetItem,
+      mockUuidV4,
+    },
+  };
+}
+
+describe('core/apis/device', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('returns an existing persisted UUID without generating a new one', () => {
+    const { ensureDeviceUUID, mocks } = loadDeviceModule({
+      existingUUID: 'persisted-uuid',
+    });
+
+    expect(ensureDeviceUUID()).toBe('persisted-uuid');
+    expect(mocks.mockGetItem).toHaveBeenCalledWith('rabbymobile_uuid', null);
+    expect(mocks.mockUuidV4).not.toHaveBeenCalled();
+    expect(mocks.mockSetItem).not.toHaveBeenCalled();
+  });
+
+  it('generates and persists a UUID when no device UUID exists', () => {
+    const { ensureDeviceUUID, mocks } = loadDeviceModule();
+
+    expect(ensureDeviceUUID()).toBe('generated-uuid');
+    expect(mocks.mockSetItem).toHaveBeenCalledWith(
+      'rabbymobile_uuid',
+      'generated-uuid',
+    );
+  });
+
+  it('combines persisted app UUID, platform, and hardware unique id', () => {
+    const { makeDeviceUUID } = loadDeviceModule({
+      existingUUID: 'persisted-uuid',
+      platform: 'ios',
+    });
+
+    expect(makeDeviceUUID()).toEqual({
+      deviceUUID: 'persisted-uuid-ios-device-unique-id',
+      uniqId: 'device-unique-id',
+    });
+  });
+
+  it('builds the mobile client push info payload from app and device metadata', () => {
+    const { makeMobileClientPushInfo } = loadDeviceModule({
+      existingUUID: 'persisted-uuid',
+      platform: 'ios',
+    });
+
+    expect(makeMobileClientPushInfo('push-token', true)).toEqual({
+      appBuildNumber: '99',
+      appBuildRevision: 'abcdef0',
+      appVersion: '1.2.3',
+      deviceUUID: 'persisted-uuid-ios-device-unique-id',
+      enabledNotifications: true,
+      packageName: 'com.rabby.mobile.test',
+      platform: 'ios',
+      pushToken: 'push-token',
+      systemName: 'Android',
+      systemVersion: '15',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add auto-lock API tests for timeout normalization, persisted expiry derivation, unlock-session expiry, and refresh/clear events
- add device API tests for persisted UUID generation, device UUID composition, and mobile push-info payload construction

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/core/apis/autoLock.test.ts src/core/apis/device.test.ts
- corepack yarn workspace rabby-mobile eslint src/core/apis/autoLock.test.ts src/core/apis/device.test.ts --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached
