### PR TITLE
test: cover persisted utility services

### DIFF
--- a/apps/mobile/src/core/services/browserHistoryService.test.ts
+++ b/apps/mobile/src/core/services/browserHistoryService.test.ts
@@ -1,0 +1,125 @@
+type BrowserHistoryStore = {
+  browserHistory: Record<
+    string,
+    {
+      createdAt: number;
+      origin: string;
+    }
+  >;
+};
+
+function loadBrowserHistoryModule(initialStore?: BrowserHistoryStore) {
+  jest.resetModules();
+
+  class MockStoreServiceBase {
+    store: BrowserHistoryStore;
+
+    constructor(
+      _name: string,
+      template: BrowserHistoryStore,
+      options: {
+        storageAdapter?: {
+          store?: BrowserHistoryStore;
+        };
+      },
+    ) {
+      this.store = options.storageAdapter?.store || template;
+    }
+  }
+
+  jest.doMock('@rabby-wallet/persist-store', () => ({
+    StoreServiceBase: MockStoreServiceBase,
+  }));
+  jest.doMock('../storage/storeConstant', () => ({
+    APP_STORE_NAMES: {
+      browserHistory: 'browserHistory',
+    },
+  }));
+
+  const { BrowserHistoryService } =
+    require('./browserHistoryService') as typeof import('./browserHistoryService');
+
+  return {
+    BrowserHistoryService,
+    storageAdapter: {
+      store: initialStore,
+    },
+  };
+}
+
+describe('core/services/browserHistoryService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('lowercases recent persisted origins and drops entries older than 30 days', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_000_000_000_000);
+    const recentCreatedAt = 1_000_000_000_000 - 24 * 60 * 60 * 1000;
+    const oldCreatedAt = 1_000_000_000_000 - 31 * 24 * 60 * 60 * 1000;
+    const { BrowserHistoryService, storageAdapter } = loadBrowserHistoryModule({
+      browserHistory: {
+        'HTTPS://OLD.EXAMPLE': {
+          createdAt: oldCreatedAt,
+          origin: 'HTTPS://OLD.EXAMPLE',
+        },
+        'HTTPS://RECENT.EXAMPLE': {
+          createdAt: recentCreatedAt,
+          origin: 'HTTPS://RECENT.EXAMPLE',
+        },
+      },
+    });
+
+    const service = new BrowserHistoryService({
+      storageAdapter: storageAdapter as never,
+    });
+
+    expect(service.store.browserHistory).toEqual({
+      'https://recent.example': {
+        createdAt: recentCreatedAt,
+        origin: 'HTTPS://RECENT.EXAMPLE',
+      },
+    });
+  });
+
+  it('stores, lists, queries, and removes browser history by normalized origin', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_000);
+    const { BrowserHistoryService } = loadBrowserHistoryModule();
+    const service = new BrowserHistoryService();
+
+    service.setHistory({
+      createdAt: 10,
+      origin: 'HTTPS://FIRST.EXAMPLE',
+    });
+    service.setHistory({
+      createdAt: 20,
+      origin: 'https://second.example',
+    });
+
+    expect(service.hasHistory('https://FIRST.example')).toBe(true);
+    expect(service.getHistory('https://first.example')).toEqual({
+      createdAt: 10,
+      origin: 'https://first.example',
+    });
+    expect(service.getHistoryList()).toEqual([
+      {
+        createdAt: 20,
+        origin: 'https://second.example',
+      },
+      {
+        createdAt: 10,
+        origin: 'https://first.example',
+      },
+    ]);
+
+    service.removeHistory('HTTPS://FIRST.EXAMPLE');
+
+    expect(service.hasHistory('https://first.example')).toBe(false);
+    expect(service.getHistoryList()).toEqual([
+      {
+        createdAt: 20,
+        origin: 'https://second.example',
+      },
+    ]);
+  });
+});

--- a/apps/mobile/src/core/services/openapiStore.test.ts
+++ b/apps/mobile/src/core/services/openapiStore.test.ts
@@ -1,0 +1,136 @@
+type OpenApiStoreState = {
+  api: {
+    host: string;
+  };
+  apiKey: string | null;
+  apiTime: number | null;
+};
+
+function createState(
+  state: Partial<OpenApiStoreState> = {},
+): OpenApiStoreState {
+  return {
+    api: {
+      host: 'https://initial.example',
+      ...state.api,
+    },
+    apiKey: null,
+    apiTime: null,
+    ...state,
+  };
+}
+
+function loadOpenApiStoreModule(storesForConstructors: OpenApiStoreState[]) {
+  jest.resetModules();
+
+  const stores = [
+    createState({
+      apiKey: 'singleton-key',
+      apiTime: 1,
+    }),
+    ...storesForConstructors,
+  ];
+  const mockCreatePersistStore = jest.fn(() => stores.shift());
+  const mockUuidV4 = jest.fn(() => 'generated-api-key');
+
+  jest.doMock('@/constant', () => ({
+    INITIAL_OPENAPI_URL: 'https://api.rabby.test',
+  }));
+  jest.doMock('@rabby-wallet/persist-store', () => ({
+    __esModule: true,
+    default: (...args: unknown[]) => mockCreatePersistStore(...args),
+  }));
+  jest.doMock('../storage/mmkv', () => ({
+    appStorage: {
+      name: 'mock-storage',
+    },
+  }));
+  jest.doMock('../storage/storeConstant', () => ({
+    APP_STORE_NAMES: {
+      notificationOpenapi: 'notificationOpenapi',
+      openapi: 'openapi',
+    },
+  }));
+  jest.doMock('uuid', () => ({
+    v4: (...args: unknown[]) => mockUuidV4(...args),
+  }));
+
+  const { OpenApiStore } =
+    require('./openapiStore') as typeof import('./openapiStore');
+
+  return {
+    OpenApiStore,
+    mocks: {
+      mockCreatePersistStore,
+      mockUuidV4,
+    },
+  };
+}
+
+describe('core/services/openapiStore', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('generates an API key and timestamp when the persisted store has no key', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(12_345_000);
+    const storeState = createState({
+      apiKey: null,
+      apiTime: null,
+    });
+    const { OpenApiStore, mocks } = loadOpenApiStoreModule([storeState]);
+
+    const store = new OpenApiStore({
+      name: 'notificationOpenapi' as never,
+    });
+
+    expect(store.apiKey).toBe('generated-api-key');
+    expect(store.apiTime).toBe(12_345);
+    expect(mocks.mockCreatePersistStore).toHaveBeenLastCalledWith(
+      {
+        name: 'notificationOpenapi',
+        template: {
+          api: {
+            host: 'https://api.rabby.test',
+          },
+          apiKey: null,
+          apiTime: null,
+        },
+      },
+      {
+        storage: undefined,
+      },
+    );
+  });
+
+  it('preserves existing store values and exposes host, key, and time setters', () => {
+    const storeState = createState({
+      api: {
+        host: 'https://persisted.example',
+      },
+      apiKey: 'persisted-key',
+      apiTime: 10,
+    });
+    const { OpenApiStore, mocks } = loadOpenApiStoreModule([storeState]);
+
+    const store = new OpenApiStore();
+
+    expect(store.host).toBe('https://persisted.example');
+    expect(store.apiKey).toBe('persisted-key');
+    expect(store.apiTime).toBe(10);
+    expect(mocks.mockUuidV4).not.toHaveBeenCalled();
+
+    store.host = 'https://next.example';
+    store.apiKey = 'next-key';
+    store.apiTime = 20;
+
+    expect(store.store).toEqual({
+      api: {
+        host: 'https://next.example',
+      },
+      apiKey: 'next-key',
+      apiTime: 20,
+    });
+  });
+});

--- a/apps/mobile/src/core/services/rabbyPoints.test.ts
+++ b/apps/mobile/src/core/services/rabbyPoints.test.ts
@@ -1,0 +1,70 @@
+function loadRabbyPointsModule(
+  persistedStore:
+    | {
+        signatures: Record<string, string>;
+      }
+    | undefined = undefined,
+) {
+  jest.resetModules();
+
+  const mockCreatePersistStore = jest.fn(() => persistedStore);
+
+  jest.doMock('@rabby-wallet/persist-store', () => ({
+    __esModule: true,
+    default: (...args: unknown[]) => mockCreatePersistStore(...args),
+  }));
+  jest.doMock('@/core/storage/storeConstant', () => ({
+    APP_STORE_NAMES: {
+      RabbyPoints: 'RabbyPoints',
+    },
+  }));
+
+  const { RabbyPointsService } =
+    require('./rabbyPoints') as typeof import('./rabbyPoints');
+
+  return {
+    RabbyPointsService,
+    mocks: {
+      mockCreatePersistStore,
+    },
+  };
+}
+
+describe('core/services/rabbyPoints', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('stores, reads, and clears signatures case-insensitively by address', () => {
+    const { RabbyPointsService } = loadRabbyPointsModule();
+    const service = new RabbyPointsService();
+
+    service.setSignature('0xABC', 'signature');
+
+    expect(service.store.signatures).toEqual({
+      '0xabc': 'signature',
+    });
+    expect(service.getSignature('0xAbC')).toBe('signature');
+
+    service.clearSignatureByAddr('0xABC');
+
+    expect(service.getSignature('0xabc')).toBeUndefined();
+    expect(service.store.signatures).toEqual({});
+  });
+
+  it('uses persisted signatures when storage returns an existing store and can clear all', () => {
+    const persistedStore = {
+      signatures: {
+        '0xabc': 'signature',
+      },
+    };
+    const { RabbyPointsService } = loadRabbyPointsModule(persistedStore);
+    const service = new RabbyPointsService();
+
+    expect(service.getSignature('0xABC')).toBe('signature');
+
+    service.clearSignature();
+
+    expect(service.store.signatures).toEqual({});
+  });
+});

--- a/apps/mobile/src/core/services/rabbyPoints.ts
+++ b/apps/mobile/src/core/services/rabbyPoints.ts
@@ -39,7 +39,7 @@ export class RabbyPointsService {
     return this.store.signatures[addr.toLowerCase()];
   };
   clearSignatureByAddr = (addr: string) => {
-    delete this.store.signatures[addr];
+    delete this.store.signatures[addr.toLowerCase()];
     this.store.signatures = {
       ...this.store.signatures,
     };


### PR DESCRIPTION
## Summary
- add RabbyPoints service tests for case-insensitive signature storage, lookup, and clearing; fix clear-by-address to normalize before deletion
- add OpenApiStore tests for API key generation/timestamps and host/key/time setters
- add BrowserHistoryService tests for stale-entry pruning, origin normalization, sorted listing, and removal

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/core/services/rabbyPoints.test.ts src/core/services/openapiStore.test.ts src/core/services/browserHistoryService.test.ts
- corepack yarn workspace rabby-mobile eslint src/core/services/rabbyPoints.ts src/core/services/rabbyPoints.test.ts src/core/services/openapiStore.test.ts src/core/services/browserHistoryService.test.ts --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached
