### PR TITLE
test: cover network preference services

### DIFF
--- a/apps/mobile/src/core/services/currencyService.test.ts
+++ b/apps/mobile/src/core/services/currencyService.test.ts
@@ -1,0 +1,130 @@
+type CurrencyStore = {
+  data: {
+    currency: string;
+    currencyList: unknown[];
+    updatedAt: number;
+  };
+};
+
+let activeCurrencyTimers: Array<ReturnType<typeof setInterval> | null> = [];
+
+function loadCurrencyServiceModule(initialStore?: CurrencyStore) {
+  jest.resetModules();
+
+  const mockGetCurrencyList = jest.fn();
+
+  class MockStoreServiceBase {
+    store: CurrencyStore;
+
+    constructor(
+      _name: string,
+      template: CurrencyStore,
+      options: {
+        storageAdapter?: {
+          store?: CurrencyStore;
+        };
+      },
+    ) {
+      this.store = options.storageAdapter?.store || template;
+    }
+  }
+
+  jest.doMock('@rabby-wallet/persist-store', () => ({
+    StoreServiceBase: MockStoreServiceBase,
+  }));
+  jest.doMock('@/core/storage/storeConstant', () => ({
+    APP_STORE_NAMES: {
+      currency: 'currency',
+    },
+  }));
+  jest.doMock('../request', () => ({
+    openapi: {
+      getCurrencyList: (...args: unknown[]) => mockGetCurrencyList(...args),
+    },
+  }));
+
+  const { CurrencyService } =
+    require('./currencyService') as typeof import('./currencyService');
+
+  return {
+    CurrencyService,
+    mocks: {
+      mockGetCurrencyList,
+    },
+    storageAdapter: {
+      store: initialStore,
+    },
+  };
+}
+
+describe('core/services/currencyService', () => {
+  afterEach(() => {
+    activeCurrencyTimers.forEach(timer => {
+      if (timer) {
+        clearInterval(timer);
+      }
+    });
+    activeCurrencyTimers = [];
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('skips non-forced currency refreshes inside the cooldown window', async () => {
+    const now = 1_000_000;
+    jest.useFakeTimers().setSystemTime(new Date(now));
+    const { CurrencyService, mocks, storageAdapter } =
+      loadCurrencyServiceModule({
+        data: {
+          currency: 'USD',
+          currencyList: [],
+          updatedAt: now,
+        },
+      });
+    mocks.mockGetCurrencyList.mockResolvedValue([]);
+
+    const service = new CurrencyService({
+      storageAdapter: storageAdapter as never,
+    });
+    activeCurrencyTimers.push(service.timer);
+    await Promise.resolve();
+    mocks.mockGetCurrencyList.mockClear();
+
+    await service.syncCurrencyList();
+
+    expect(mocks.mockGetCurrencyList).not.toHaveBeenCalled();
+  });
+
+  it('force refreshes the currency list and updates the timestamp', async () => {
+    const now = 2_000_000;
+    jest.useFakeTimers().setSystemTime(new Date(now));
+    const { CurrencyService, mocks, storageAdapter } =
+      loadCurrencyServiceModule({
+        data: {
+          currency: 'USD',
+          currencyList: [],
+          updatedAt: now,
+        },
+      });
+    mocks.mockGetCurrencyList.mockResolvedValue([
+      {
+        code: 'USD',
+        symbol: '$',
+      },
+    ]);
+
+    const service = new CurrencyService({
+      storageAdapter: storageAdapter as never,
+    });
+    activeCurrencyTimers.push(service.timer);
+    await Promise.resolve();
+
+    expect(service.store.data.currencyList).toEqual([
+      {
+        code: 'USD',
+        symbol: '$',
+      },
+    ]);
+    expect(service.store.data.updatedAt).toBe(now);
+  });
+});

--- a/apps/mobile/src/core/services/metamaskModeService.test.ts
+++ b/apps/mobile/src/core/services/metamaskModeService.test.ts
@@ -1,0 +1,122 @@
+type MetamaskModeStore = {
+  data: {
+    sites: string[];
+    updatedAt: number;
+  };
+};
+
+let activeMetamaskTimers: Array<ReturnType<typeof setInterval> | null> = [];
+
+function loadMetamaskModeServiceModule(initialStore?: MetamaskModeStore) {
+  jest.resetModules();
+
+  const mockAxiosGet = jest.fn();
+
+  class MockStoreServiceBase {
+    store: MetamaskModeStore;
+
+    constructor(
+      _name: string,
+      template: MetamaskModeStore,
+      options: {
+        storageAdapter?: {
+          store?: MetamaskModeStore;
+        };
+      },
+    ) {
+      this.store = options.storageAdapter?.store || template;
+    }
+  }
+
+  jest.doMock('@rabby-wallet/persist-store', () => ({
+    StoreServiceBase: MockStoreServiceBase,
+  }));
+  jest.doMock('@/core/storage/storeConstant', () => ({
+    APP_STORE_NAMES: {
+      metamaskMode: 'metamaskMode',
+    },
+  }));
+  jest.doMock('axios', () => ({
+    get: (...args: unknown[]) => mockAxiosGet(...args),
+  }));
+
+  const { MetamaskModeService } =
+    require('./metamaskModeService') as typeof import('./metamaskModeService');
+
+  return {
+    MetamaskModeService,
+    mocks: {
+      mockAxiosGet,
+    },
+    storageAdapter: {
+      store: initialStore,
+    },
+  };
+}
+
+describe('core/services/metamaskModeService', () => {
+  afterEach(() => {
+    activeMetamaskTimers.forEach(timer => {
+      if (timer) {
+        clearInterval(timer);
+      }
+    });
+    activeMetamaskTimers = [];
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('skips remote refreshes inside the cooldown window and matches origins without protocol', async () => {
+    const now = 3_000_000;
+    jest.useFakeTimers().setSystemTime(new Date(now));
+    const { MetamaskModeService, mocks, storageAdapter } =
+      loadMetamaskModeServiceModule({
+        data: {
+          sites: ['fake.example'],
+          updatedAt: now,
+        },
+      });
+
+    const service = new MetamaskModeService({
+      storageAdapter: storageAdapter as never,
+    });
+    activeMetamaskTimers.push(service.timer);
+    await service.syncMetamaskModeList();
+
+    expect(mocks.mockAxiosGet).not.toHaveBeenCalled();
+    expect(service.checkIsMetamaskMode('https://fake.example')).toBe(true);
+    expect(service.checkIsMetamaskMode('http://fake.example')).toBe(true);
+    expect(service.checkIsMetamaskMode('https://other.example')).toBe(false);
+  });
+
+  it('refreshes the metamask-mode site list after the cooldown expires', async () => {
+    const now = 4_000_000;
+    jest.useFakeTimers().setSystemTime(new Date(now));
+    const { MetamaskModeService, mocks, storageAdapter } =
+      loadMetamaskModeServiceModule({
+        data: {
+          sites: [],
+          updatedAt: now,
+        },
+      });
+    mocks.mockAxiosGet.mockResolvedValue({
+      data: ['next.example'],
+    });
+    const service = new MetamaskModeService({
+      storageAdapter: storageAdapter as never,
+    });
+    activeMetamaskTimers.push(service.timer);
+    service.store.data.updatedAt = 0;
+
+    await service.syncMetamaskModeList();
+
+    expect(mocks.mockAxiosGet).toHaveBeenCalledWith(
+      'https://static.debank.com/fake_mm_dapps.json',
+    );
+    expect(service.store.data).toEqual({
+      sites: ['next.example'],
+      updatedAt: now,
+    });
+  });
+});

--- a/apps/mobile/src/core/services/offlineChain.test.ts
+++ b/apps/mobile/src/core/services/offlineChain.test.ts
@@ -1,0 +1,82 @@
+function loadOfflineChainModule({
+  isNonPublicProductionEnv,
+  persistedStore,
+}: {
+  isNonPublicProductionEnv: boolean;
+  persistedStore?: {
+    closeTipsChains: string[];
+  };
+}) {
+  jest.resetModules();
+
+  const mockCreatePersistStore = jest.fn(() => persistedStore);
+
+  jest.doMock('@rabby-wallet/persist-store', () => ({
+    __esModule: true,
+    default: (...args: unknown[]) => mockCreatePersistStore(...args),
+  }));
+  jest.doMock('@/core/storage/storeConstant', () => ({
+    APP_STORE_NAMES: {
+      offlineChain: 'offlineChain',
+    },
+  }));
+  jest.doMock('@/constant', () => ({
+    isNonPublicProductionEnv,
+  }));
+
+  const { OfflineChainService } =
+    require('./offlineChain') as typeof import('./offlineChain');
+
+  return {
+    OfflineChainService,
+    mocks: {
+      mockCreatePersistStore,
+    },
+  };
+}
+
+describe('core/services/offlineChain', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('appends closed-tip chains to the persisted list', () => {
+    const { OfflineChainService } = loadOfflineChainModule({
+      isNonPublicProductionEnv: false,
+      persistedStore: {
+        closeTipsChains: ['eth'],
+      },
+    });
+    const service = new OfflineChainService();
+
+    service.setCloseTipsChains(['arb', 'base']);
+
+    expect(service.getCloseTipsChains()).toEqual(['eth', 'arb', 'base']);
+  });
+
+  it('only allows mock clearing closed-tip chains in non-public production environments', () => {
+    const publicEnv = loadOfflineChainModule({
+      isNonPublicProductionEnv: false,
+      persistedStore: {
+        closeTipsChains: ['eth'],
+      },
+    });
+    const publicService = new publicEnv.OfflineChainService();
+
+    publicService.mockClearCloseTipsChains();
+
+    expect(publicService.getCloseTipsChains()).toEqual(['eth']);
+
+    const nonPublicEnv = loadOfflineChainModule({
+      isNonPublicProductionEnv: true,
+      persistedStore: {
+        closeTipsChains: ['eth'],
+      },
+    });
+    const nonPublicService = new nonPublicEnv.OfflineChainService();
+
+    nonPublicService.mockClearCloseTipsChains();
+
+    expect(nonPublicService.getCloseTipsChains()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add currency service tests for cooldown-skipped refreshes and forced list updates
- add metamask-mode service tests for cooldown behavior, remote list refresh, and protocol-stripped origin matching
- add offline-chain tests for close-tip chain persistence and non-public-env mock clearing

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/core/services/currencyService.test.ts src/core/services/metamaskModeService.test.ts src/core/services/offlineChain.test.ts
- corepack yarn workspace rabby-mobile eslint src/core/services/currencyService.test.ts src/core/services/metamaskModeService.test.ts src/core/services/offlineChain.test.ts --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached
