### PR TITLE
test: cover analytics and debug log utilities

### DIFF
--- a/apps/mobile/src/core/apis/analytics.test.ts
+++ b/apps/mobile/src/core/apis/analytics.test.ts
@@ -1,0 +1,122 @@
+function loadAnalyticsModule() {
+  jest.resetModules();
+
+  const mockGetAddressValueMap = jest.fn();
+  const mockGetAllVisibleAccountsArray = jest.fn();
+  const mockGetSendLogTime = jest.fn();
+  const mockMatomoRequestEvent = jest.fn();
+  const mockUpdateSendLogTime = jest.fn();
+
+  jest.doMock('@/utils/analytics', () => ({
+    matomoRequestEvent: (...args: unknown[]) => mockMatomoRequestEvent(...args),
+  }));
+  jest.doMock('@/store/balance', () => ({
+    __esModule: true,
+    default: {
+      getAddressValueMap: (...args: unknown[]) =>
+        mockGetAddressValueMap(...args),
+    },
+  }));
+  jest.doMock('@rabby-wallet/keyring-utils', () => ({
+    KEYRING_CATEGORY_MAP: {
+      SimpleKeyring: 'private-key',
+      WatchAddressKeyring: 'watch',
+    },
+  }));
+  jest.doMock('../services/shared', () => ({
+    keyringService: {
+      getAllVisibleAccountsArray: (...args: unknown[]) =>
+        mockGetAllVisibleAccountsArray(...args),
+    },
+    preferenceService: {
+      getSendLogTime: (...args: unknown[]) => mockGetSendLogTime(...args),
+      updateSendLogTime: (...args: unknown[]) => mockUpdateSendLogTime(...args),
+    },
+  }));
+
+  const analyticsModule =
+    require('./analytics') as typeof import('./analytics');
+
+  return {
+    ...analyticsModule,
+    mocks: {
+      mockGetAddressValueMap,
+      mockGetAllVisibleAccountsArray,
+      mockGetSendLogTime,
+      mockMatomoRequestEvent,
+      mockUpdateSendLogTime,
+    },
+  };
+}
+
+describe('core/apis/analytics', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetModules();
+  });
+
+  it('skips user-address analytics when the send log time is already today', async () => {
+    const now = new Date('2026-05-31T12:00:00Z');
+    jest.useFakeTimers().setSystemTime(now);
+    const { sendUserAddressEvent, mocks } = loadAnalyticsModule();
+    mocks.mockGetSendLogTime.mockReturnValue(
+      new Date('2026-05-31T01:00:00Z').getTime(),
+    );
+
+    await sendUserAddressEvent();
+
+    expect(mocks.mockGetAllVisibleAccountsArray).not.toHaveBeenCalled();
+    expect(mocks.mockMatomoRequestEvent).not.toHaveBeenCalled();
+    expect(mocks.mockUpdateSendLogTime).not.toHaveBeenCalled();
+  });
+
+  it('groups visible accounts by keyring category, brand, and empty-balance state', async () => {
+    const now = new Date('2026-05-31T12:00:00Z');
+    jest.useFakeTimers().setSystemTime(now);
+    const { sendUserAddressEvent, mocks } = loadAnalyticsModule();
+    mocks.mockGetSendLogTime.mockReturnValue(
+      new Date('2026-05-30T12:00:00Z').getTime(),
+    );
+    mocks.mockGetAddressValueMap.mockReturnValue({
+      '0xaaa': {
+        totalBalance: 10,
+      },
+      '0xbbb': {
+        totalBalance: 20,
+      },
+    });
+    mocks.mockGetAllVisibleAccountsArray.mockResolvedValue([
+      {
+        address: '0xAAA',
+        brandName: 'Rabby',
+        type: 'SimpleKeyring',
+      },
+      {
+        address: '0xBBB',
+        brandName: 'Rabby',
+        type: 'SimpleKeyring',
+      },
+      {
+        address: '0xCCC',
+        brandName: 'Watch',
+        type: 'WatchAddressKeyring',
+      },
+    ]);
+
+    await sendUserAddressEvent();
+
+    expect(mocks.mockMatomoRequestEvent).toHaveBeenCalledWith({
+      action: 'private-key',
+      category: 'UserAddress',
+      label: 'Rabby|notEmpty|2',
+      value: 2,
+    });
+    expect(mocks.mockMatomoRequestEvent).toHaveBeenCalledWith({
+      action: 'watch',
+      category: 'UserAddress',
+      label: 'Watch|empty|1',
+      value: 1,
+    });
+    expect(mocks.mockUpdateSendLogTime).toHaveBeenCalledWith(now.getTime());
+  });
+});

--- a/apps/mobile/src/core/apis/analytics.ts
+++ b/apps/mobile/src/core/apis/analytics.ts
@@ -2,8 +2,11 @@ import { matomoRequestEvent } from '@/utils/analytics';
 import addressBalanceStore from '@/store/balance';
 import { KEYRING_CATEGORY_MAP } from '@rabby-wallet/keyring-utils';
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 import groupBy from 'lodash/groupBy';
 import { keyringService, preferenceService } from '../services/shared';
+
+dayjs.extend(utc);
 
 export const sendUserAddressEvent = async () => {
   const time = preferenceService.getSendLogTime();

--- a/apps/mobile/src/core/services/debugLogService.test.ts
+++ b/apps/mobile/src/core/services/debugLogService.test.ts
@@ -1,0 +1,76 @@
+function loadDebugLogService() {
+  jest.resetModules();
+
+  const service = require('./debugLogService')
+    .default as typeof import('./debugLogService').default;
+  service.clearLogs();
+
+  return service;
+}
+
+describe('core/services/debugLogService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    loadDebugLogService().clearLogs();
+  });
+
+  it('adds newest logs first and notifies active subscribers only', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(123);
+    const service = loadDebugLogService();
+    const listener = jest.fn();
+    const unsubscribe = service.subscribe(listener);
+
+    service.info('first', {
+      value: 1,
+    });
+    service.warn('second');
+    unsubscribe();
+    service.error('third');
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(service.getLogs()).toEqual([
+      {
+        data: undefined,
+        level: 'error',
+        message: 'third',
+        timestamp: 123,
+      },
+      {
+        data: undefined,
+        level: 'warn',
+        message: 'second',
+        timestamp: 123,
+      },
+      {
+        data: {
+          value: 1,
+        },
+        level: 'info',
+        message: 'first',
+        timestamp: 123,
+      },
+    ]);
+  });
+
+  it('keeps only the latest 500 log entries and clears logs with notification', () => {
+    const service = loadDebugLogService();
+    const listener = jest.fn();
+    service.subscribe(listener);
+
+    for (let index = 0; index < 505; index += 1) {
+      jest.spyOn(Date, 'now').mockReturnValue(index);
+      service.debug(`log-${index}`);
+      jest.restoreAllMocks();
+    }
+
+    const logs = service.getLogs();
+    expect(service.getLogsCount()).toBe(500);
+    expect(logs[0].message).toBe('log-504');
+    expect(logs[499].message).toBe('log-5');
+
+    service.clearLogs();
+
+    expect(service.getLogs()).toEqual([]);
+    expect(listener).toHaveBeenCalledTimes(506);
+  });
+});


### PR DESCRIPTION
## Summary
- add analytics API tests for daily send-log skipping and grouped user-address Matomo events
- register the dayjs utc plugin inside analytics.ts so sendUserAddressEvent does not depend on unrelated module load order
- add debug log service tests for subscriber notifications, newest-first ordering, max log retention, and clearing

## Test plan
- NODE_ENV=test BABEL_ENV=test corepack yarn workspace rabby-mobile test --runInBand src/core/apis/analytics.test.ts src/core/services/debugLogService.test.ts
- corepack yarn workspace rabby-mobile eslint src/core/apis/analytics.ts src/core/apis/analytics.test.ts src/core/services/debugLogService.test.ts --ext .ts,.tsx --max-warnings=0
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- git diff --check --cached
