### PR TITLE
test: cover core api and service baseline

### DIFF
--- a/apps/mobile/src/core/apis/address.test.ts
+++ b/apps/mobile/src/core/apis/address.test.ts
@@ -1,0 +1,331 @@
+const KEYRING_TYPE = {
+  WatchAddressKeyring: 'WatchAddressKeyring',
+  GnosisKeyring: 'GnosisKeyring',
+  WalletConnectKeyring: 'WalletConnectKeyring',
+  SimpleKeyring: 'SimpleKeyring',
+  HdKeyring: 'HdKeyring',
+} as const;
+
+type Account = {
+  address: string;
+  type: string;
+  brandName: string;
+};
+
+function createAccount(account: Partial<Account> = {}): Account {
+  return {
+    address: '0xabc',
+    type: KEYRING_TYPE.SimpleKeyring,
+    brandName: 'rabby',
+    ...account,
+  };
+}
+
+function loadAddressModule({
+  allAccounts = [],
+  currentAccount = null,
+  dapps = {},
+  hasAddress = false,
+  isUnlocked = true,
+}: {
+  allAccounts?: Account[];
+  currentAccount?: Account | null;
+  dapps?: Record<string, Record<string, unknown>>;
+  hasAddress?: boolean;
+  isUnlocked?: boolean;
+} = {}) {
+  jest.resetModules();
+
+  let fallbackAccount = currentAccount;
+  const mockWatchKeyring = {
+    setAccountToAdd: jest.fn(),
+  };
+  const mockGetKeyring = jest.fn().mockResolvedValue(mockWatchKeyring);
+  const mockAddNewAccount = jest.fn().mockResolvedValue({
+    address: '0xwatch',
+  });
+  const mockRemoveAccount = jest.fn().mockResolvedValue(undefined);
+  const mockHasAddress = jest.fn().mockResolvedValue(hasAddress);
+  const mockGetAllVisibleAccountsArray = jest
+    .fn()
+    .mockResolvedValue(allAccounts);
+  const mockSetCurrentAccount = jest.fn((account: Account | null) => {
+    fallbackAccount = account;
+  });
+  const mockGetFallbackAccount = jest.fn(() => fallbackAccount);
+  const mockRemoveAddressAvatar = jest.fn();
+  const mockRemovePinAddress = jest.fn();
+  const mockInitCurrentAccount = jest.fn();
+  const mockRemoveAlias = jest.fn();
+  const mockRemoveWhitelist = jest.fn();
+  const mockRemoveList = jest.fn();
+  const mockRemoveAgentWallet = jest.fn();
+  const mockGetDapps = jest.fn(() => dapps);
+  const mockUpdateDapp = jest.fn();
+  const mockBroadcastEvent = jest.fn();
+  const mockRemoveTestnetAddressBalanceCache = jest.fn();
+  const mockIsUnlocked = jest.fn(() => isUnlocked);
+
+  jest.doMock('@rabby-wallet/base-utils', () => ({
+    addressUtils: {
+      isSameAddress: (left?: string, right?: string) =>
+        (left || '').toLowerCase() === (right || '').toLowerCase(),
+    },
+  }));
+  jest.doMock('@rabby-wallet/keyring-utils', () => ({
+    KEYRING_TYPE,
+  }));
+  jest.doMock('@rabby-wallet/eth-keyring-watch', () => jest.fn());
+  jest.doMock('@/core/apis/lock', () => ({
+    isUnlocked: (...args: unknown[]) => mockIsUnlocked(...args),
+  }));
+  jest.doMock('@/constant/event', () => ({
+    BroadcastEvent: {
+      accountsChanged: 'accountsChanged',
+    },
+  }));
+  jest.doMock('@/utils/testnetAddressBalanceCache', () => ({
+    removeTestnetAddressBalanceCache: (...args: unknown[]) =>
+      mockRemoveTestnetAddressBalanceCache(...args),
+  }));
+  jest.doMock('./keyring', () => ({
+    getKeyring: (...args: unknown[]) => mockGetKeyring(...args),
+  }));
+  jest.doMock('../services', () => ({
+    contactService: {
+      removeAlias: mockRemoveAlias,
+    },
+    dappService: {
+      getDapps: mockGetDapps,
+      updateDapp: mockUpdateDapp,
+    },
+    keyringService: {
+      addNewAccount: mockAddNewAccount,
+      getAllVisibleAccountsArray: mockGetAllVisibleAccountsArray,
+      hasAddress: mockHasAddress,
+      removeAccount: mockRemoveAccount,
+    },
+    perpsService: {
+      removeAgentWallet: mockRemoveAgentWallet,
+    },
+    preferenceService: {
+      getFallbackAccount: mockGetFallbackAccount,
+      initCurrentAccount: mockInitCurrentAccount,
+      removeAddressAvatar: mockRemoveAddressAvatar,
+      removePinAddress: mockRemovePinAddress,
+      setCurrentAccount: mockSetCurrentAccount,
+    },
+    sessionService: {
+      broadcastEvent: mockBroadcastEvent,
+    },
+    transactionHistoryService: {
+      removeList: mockRemoveList,
+    },
+    whitelistService: {
+      removeWhitelist: mockRemoveWhitelist,
+    },
+  }));
+
+  const addressModule = require('./address') as typeof import('./address');
+
+  return {
+    ...addressModule,
+    mocks: {
+      mockAddNewAccount,
+      mockBroadcastEvent,
+      mockGetAllVisibleAccountsArray,
+      mockGetDapps,
+      mockGetFallbackAccount,
+      mockGetKeyring,
+      mockHasAddress,
+      mockInitCurrentAccount,
+      mockIsUnlocked,
+      mockRemoveAccount,
+      mockRemoveAddressAvatar,
+      mockRemoveAgentWallet,
+      mockRemoveAlias,
+      mockRemoveList,
+      mockRemovePinAddress,
+      mockRemoveTestnetAddressBalanceCache,
+      mockRemoveWhitelist,
+      mockSetCurrentAccount,
+      mockUpdateDapp,
+      mockWatchKeyring,
+    },
+  };
+}
+
+describe('core/apis/address', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('adds a watch address through the watch keyring and initializes current account', async () => {
+    const { addWatchAddress, mocks } = loadAddressModule();
+
+    await expect(addWatchAddress('0xwatch')).resolves.toEqual({
+      address: '0xwatch',
+    });
+
+    expect(mocks.mockGetKeyring).toHaveBeenCalledWith(
+      KEYRING_TYPE.WatchAddressKeyring,
+    );
+    expect(mocks.mockWatchKeyring.setAccountToAdd).toHaveBeenCalledWith(
+      '0xwatch',
+    );
+    expect(mocks.mockAddNewAccount).toHaveBeenCalledWith(
+      mocks.mockWatchKeyring,
+    );
+    expect(mocks.mockInitCurrentAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it('filters reportable accounts into callable and uncallable groups', async () => {
+    const simple = createAccount({
+      address: '0xsimple',
+      type: KEYRING_TYPE.SimpleKeyring,
+    });
+    const hd = createAccount({
+      address: '0xhd',
+      type: KEYRING_TYPE.HdKeyring,
+    });
+    const watch = createAccount({
+      address: '0xwatch',
+      type: KEYRING_TYPE.WatchAddressKeyring,
+    });
+    const gnosis = createAccount({
+      address: '0xgnosis',
+      type: KEYRING_TYPE.GnosisKeyring,
+    });
+    const { getAllMyAccount, getAddressesForReport, mocks } = loadAddressModule(
+      {
+        allAccounts: [simple, watch, gnosis, hd],
+      },
+    );
+
+    await expect(getAllMyAccount()).resolves.toEqual([simple, hd]);
+    await expect(getAddressesForReport()).resolves.toEqual({
+      myCallableAddresses: ['0xsimple', '0xhd'],
+      myCallableAddressCount: 2,
+      myUncallableAddresses: ['0xwatch', '0xgnosis'],
+      myUncallableAddressCount: 2,
+    });
+    expect(mocks.mockGetAllVisibleAccountsArray).toHaveBeenCalledTimes(2);
+  });
+
+  it('fully cleans up the last removed address and moves connected dapps to the next current account', async () => {
+    const removedAccount = createAccount({
+      address: '0xABC',
+      type: KEYRING_TYPE.SimpleKeyring,
+    });
+    const nextAccount = createAccount({
+      address: '0xdef',
+      type: KEYRING_TYPE.HdKeyring,
+    });
+    const matchingDapp = {
+      currentAccount: {
+        address: '0xabc',
+        type: KEYRING_TYPE.SimpleKeyring,
+        brandName: 'rabby',
+      },
+      isConnected: true,
+      name: 'matching dapp',
+    };
+    const otherDapp = {
+      currentAccount: createAccount({
+        address: '0x999',
+      }),
+      isConnected: true,
+      name: 'other dapp',
+    };
+    const { removeAddress, mocks } = loadAddressModule({
+      allAccounts: [nextAccount],
+      currentAccount: removedAccount,
+      dapps: {
+        'https://app.example': matchingDapp,
+        'https://other.example': otherDapp,
+      },
+      hasAddress: false,
+      isUnlocked: true,
+    });
+
+    await removeAddress(removedAccount);
+
+    expect(mocks.mockIsUnlocked).toHaveBeenCalledTimes(1);
+    expect(mocks.mockRemoveAccount).toHaveBeenCalledWith(
+      '0xABC',
+      KEYRING_TYPE.SimpleKeyring,
+      'rabby',
+      true,
+    );
+    expect(mocks.mockHasAddress).toHaveBeenCalledWith('0xABC');
+    expect(mocks.mockRemoveTestnetAddressBalanceCache).toHaveBeenCalledWith(
+      '0xABC',
+    );
+    expect(mocks.mockRemoveAddressAvatar).toHaveBeenCalledWith('0xABC');
+    expect(mocks.mockRemoveAlias).toHaveBeenCalledWith('0xABC');
+    expect(mocks.mockRemoveWhitelist).toHaveBeenCalledWith('0xABC');
+    expect(mocks.mockRemoveList).toHaveBeenCalledWith('0xABC');
+    expect(mocks.mockRemoveAgentWallet).toHaveBeenCalledWith('0xABC');
+    expect(mocks.mockRemovePinAddress).toHaveBeenCalledWith(removedAccount);
+    expect(mocks.mockSetCurrentAccount).toHaveBeenCalledWith(nextAccount);
+    expect(mocks.mockUpdateDapp).toHaveBeenCalledTimes(1);
+    expect(mocks.mockUpdateDapp).toHaveBeenCalledWith({
+      ...matchingDapp,
+      origin: 'https://app.example',
+      currentAccount: nextAccount,
+    });
+    expect(mocks.mockBroadcastEvent).toHaveBeenCalledWith(
+      'accountsChanged',
+      ['0xdef'],
+      'https://app.example',
+    );
+  });
+
+  it('keeps address-scoped data when another keyring still owns the same address', async () => {
+    const walletConnectAccount = createAccount({
+      address: '0xwalletconnect',
+      type: KEYRING_TYPE.WalletConnectKeyring,
+    });
+    const otherCurrentAccount = createAccount({
+      address: '0xother',
+    });
+    const { removeAddress, mocks } = loadAddressModule({
+      currentAccount: otherCurrentAccount,
+      hasAddress: true,
+      isUnlocked: true,
+    });
+
+    await removeAddress(walletConnectAccount);
+
+    expect(mocks.mockIsUnlocked).not.toHaveBeenCalled();
+    expect(mocks.mockRemoveAccount).toHaveBeenCalledWith(
+      '0xwalletconnect',
+      KEYRING_TYPE.WalletConnectKeyring,
+      'rabby',
+      false,
+    );
+    expect(mocks.mockRemoveTestnetAddressBalanceCache).not.toHaveBeenCalled();
+    expect(mocks.mockRemoveAddressAvatar).not.toHaveBeenCalled();
+    expect(mocks.mockRemoveAlias).not.toHaveBeenCalled();
+    expect(mocks.mockRemoveWhitelist).not.toHaveBeenCalled();
+    expect(mocks.mockRemoveList).not.toHaveBeenCalled();
+    expect(mocks.mockRemoveAgentWallet).not.toHaveBeenCalled();
+    expect(mocks.mockSetCurrentAccount).not.toHaveBeenCalled();
+  });
+
+  it('requires an unlocked wallet before removing sensitive keyring accounts', async () => {
+    const { removeAddress, mocks } = loadAddressModule({
+      isUnlocked: false,
+    });
+
+    await expect(
+      removeAddress(
+        createAccount({
+          type: KEYRING_TYPE.SimpleKeyring,
+        }),
+      ),
+    ).rejects.toThrow('background.error.unlock');
+
+    expect(mocks.mockRemoveAccount).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/core/apis/approvals.test.ts
+++ b/apps/mobile/src/core/apis/approvals.test.ts
@@ -1,0 +1,353 @@
+const mockFindChain = jest.fn();
+const mockSendRequest = jest.fn();
+const mockEncodeFunctionCall = jest.fn();
+const mockTranslate = jest.fn((key: string) => `translated:${key}`);
+const mockRequestETHRpc = jest.fn();
+const mockDecodeAbiParameters = jest.fn();
+const mockToChecksumAddress = jest.fn(
+  (address: string) => `checksum:${address}`,
+);
+
+jest.mock('i18next', () => ({
+  t: (...args: unknown[]) => mockTranslate(...args),
+}));
+
+jest.mock('@/constant', () => ({
+  INTERNAL_REQUEST_SESSION: 'internal-request-session',
+}));
+
+jest.mock('./sendRequest', () => ({
+  sendRequest: (...args: unknown[]) => mockSendRequest(...args),
+  abiCoder: {
+    encodeFunctionCall: (...args: unknown[]) => mockEncodeFunctionCall(...args),
+  },
+}));
+
+jest.mock('../services', () => ({
+  preferenceService: {},
+}));
+
+jest.mock('@/utils/chain', () => ({
+  findChain: (...args: unknown[]) => mockFindChain(...args),
+}));
+
+jest.mock('./provider', () => ({
+  requestETHRpc: (...args: unknown[]) => mockRequestETHRpc(...args),
+}));
+
+jest.mock('@ethereumjs/util', () => ({
+  isZeroAddress: jest.fn(),
+  toChecksumAddress: (...args: unknown[]) => mockToChecksumAddress(...args),
+}));
+
+jest.mock('viem', () => ({
+  decodeAbiParameters: (...args: unknown[]) => mockDecodeAbiParameters(...args),
+}));
+
+jest.mock('@rabby-wallet/biz-utils', () => ({
+  approvalUtils: {
+    summarizeRevoke: jest.fn(),
+  },
+  permit2Utils: {
+    decodePermit2GroupKey: jest.fn(),
+  },
+}));
+
+import {
+  approveToken,
+  getErc721Approved,
+  getNFTApprovedForAll,
+  lockdownPermit2,
+  revokeNFTApprove,
+} from './approvals';
+
+const account = {
+  address: '0xabc',
+  type: 'SimpleKeyring',
+  brandName: 'SimpleKeyring',
+};
+
+describe('core/apis/approvals', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindChain.mockReturnValue({
+      id: 1,
+      serverId: 'eth',
+    });
+    mockEncodeFunctionCall.mockReturnValue('0xencodedCall');
+    mockSendRequest.mockResolvedValue('0xtx');
+    mockRequestETHRpc.mockResolvedValue('0xrpc');
+    mockDecodeAbiParameters.mockReturnValue([true]);
+  });
+
+  it('rejects approveToken without account or known chain', async () => {
+    await expect(
+      approveToken({
+        chainServerId: 'eth',
+        id: '0xtoken',
+        spender: '0xspender',
+        amount: 1,
+        account: null as never,
+      }),
+    ).rejects.toThrow('translated:background.error.noCurrentAccount');
+
+    mockFindChain.mockReturnValue(undefined);
+    await expect(
+      approveToken({
+        chainServerId: 'unknown',
+        id: '0xtoken',
+        spender: '0xspender',
+        amount: 1,
+        account: account as never,
+      }),
+    ).rejects.toThrow('translated:background.error.invalidChainId');
+
+    expect(mockSendRequest).not.toHaveBeenCalled();
+  });
+
+  it('builds token approve transactions with gas price and extra metadata', async () => {
+    const ctx = { ga: { source: 'test' } };
+
+    await expect(
+      approveToken({
+        chainServerId: 'eth',
+        id: '0xtoken',
+        spender: '0xspender',
+        amount: '100',
+        gasPrice: 123,
+        extra: {
+          isSwap: true,
+          swapPreferMEVGuarded: true,
+        },
+        $ctx: ctx,
+        isBuild: true,
+        account: account as never,
+      }),
+    ).resolves.toBe('0xtx');
+
+    expect(mockEncodeFunctionCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'approve',
+      }),
+      ['checksum:0xspender', '100'],
+    );
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      {
+        data: {
+          $ctx: ctx,
+          method: 'eth_sendTransaction',
+          params: [
+            {
+              from: '0xabc',
+              to: '0xtoken',
+              chainId: 1,
+              data: '0xencodedCall',
+              gasPrice: 123,
+              isSwap: true,
+              swapPreferMEVGuarded: true,
+            },
+          ],
+        },
+        session: 'internal-request-session',
+        account,
+      },
+      true,
+    );
+  });
+
+  it('reads NFT approval-for-all and ERC721 approved operator through eth_call', async () => {
+    await expect(
+      getNFTApprovedForAll({
+        chainServerId: 'eth',
+        contractAddress: '0xnft',
+        address: '0xowner',
+        spender: '0xspender',
+        account: account as never,
+      }),
+    ).resolves.toBe(true);
+
+    expect(mockEncodeFunctionCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'isApprovedForAll',
+      }),
+      ['checksum:0xowner', 'checksum:0xspender'],
+    );
+    expect(mockRequestETHRpc).toHaveBeenCalledWith(
+      {
+        method: 'eth_call',
+        params: [{ to: '0xnft', data: '0xencodedCall' }, 'latest'],
+      },
+      'eth',
+      account,
+    );
+
+    mockDecodeAbiParameters.mockReturnValue(['0xapproved']);
+    await expect(
+      getErc721Approved({
+        chainServerId: 'eth',
+        contractAddress: '0xnft',
+        nftTokenId: '7',
+        account: account as never,
+      }),
+    ).resolves.toBe('0xapproved');
+    expect(mockEncodeFunctionCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'getApproved',
+      }),
+      ['7'],
+    );
+  });
+
+  it('builds ERC721 revoke transactions for approved-for-all and token-specific approvals', async () => {
+    await revokeNFTApprove(
+      {
+        chainServerId: 'eth',
+        contractId: '0xnft',
+        spender: '0xspender',
+        abi: 'ERC721',
+        nftTokenId: '7',
+        isApprovedForAll: true,
+        account: account as never,
+      },
+      { ga: { source: 'nft-all' } },
+      true,
+    );
+
+    expect(mockEncodeFunctionCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'setApprovalForAll',
+      }),
+      ['checksum:0xspender', false],
+    );
+    expect(mockSendRequest).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          params: [
+            expect.objectContaining({
+              from: '0xabc',
+              to: '0xnft',
+              chainId: 1,
+              data: '0xencodedCall',
+            }),
+          ],
+        }),
+      }),
+      true,
+    );
+
+    await revokeNFTApprove(
+      {
+        chainServerId: 'eth',
+        contractId: '0xnft',
+        spender: '0xspender',
+        abi: 'ERC721',
+        nftTokenId: '7',
+        isApprovedForAll: false,
+        account: account as never,
+      },
+      undefined,
+      false,
+    );
+
+    expect(mockEncodeFunctionCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'approve',
+      }),
+      ['0x0000000000000000000000000000000000000000', '7'],
+    );
+  });
+
+  it('builds ERC1155 revoke transactions and rejects unknown NFT ABI variants', async () => {
+    await expect(
+      revokeNFTApprove({
+        chainServerId: 'eth',
+        contractId: '0xnft',
+        spender: '0xspender',
+        abi: 'ERC1155',
+        isApprovedForAll: true,
+        account: account as never,
+      }),
+    ).resolves.toBe('0xtx');
+
+    expect(mockEncodeFunctionCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'setApprovalForAll',
+      }),
+      ['checksum:0xspender', false],
+    );
+
+    await expect(
+      revokeNFTApprove({
+        chainServerId: 'eth',
+        contractId: '0xnft',
+        spender: '0xspender',
+        abi: '',
+        isApprovedForAll: true,
+        account: account as never,
+      }),
+    ).rejects.toThrow('translated:background.error.unknownAbi');
+  });
+
+  it('normalizes Permit2 token spender pairs before lockdown transaction construction', async () => {
+    const tokenSpenders = [
+      {
+        token: '0xtoken',
+        spender: '0xspender',
+      },
+    ];
+
+    await expect(
+      lockdownPermit2(
+        {
+          id: '0xpermit2',
+          chainServerId: 'eth',
+          tokenSpenders,
+          gasPrice: 456,
+          $ctx: { ga: { source: 'permit2' } },
+          account: account as never,
+        },
+        true,
+      ),
+    ).resolves.toBe('0xtx');
+
+    expect(tokenSpenders).toEqual([
+      {
+        token: '0xtoken',
+        spender: '0xspender',
+      },
+    ]);
+    expect(mockEncodeFunctionCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'lockdown',
+      }),
+      [
+        [
+          {
+            token: 'checksum:0xtoken',
+            spender: 'checksum:0xspender',
+          },
+        ],
+      ],
+    );
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      {
+        data: {
+          $ctx: { ga: { source: 'permit2' } },
+          method: 'eth_sendTransaction',
+          params: [
+            {
+              from: '0xabc',
+              to: '0xpermit2',
+              chainId: 1,
+              data: '0xencodedCall',
+              gasPrice: 456,
+            },
+          ],
+        },
+        session: 'internal-request-session',
+        account,
+      },
+      true,
+    );
+  });
+});

--- a/apps/mobile/src/core/apis/autoLock.test.ts
+++ b/apps/mobile/src/core/apis/autoLock.test.ts
@@ -1,0 +1,132 @@
+type PreferenceStore = Record<string, unknown>;
+
+function loadAutoLockModule({
+  isUnlocked = true,
+  preferences = {},
+}: {
+  isUnlocked?: boolean;
+  preferences?: PreferenceStore;
+} = {}) {
+  jest.resetModules();
+
+  const store: PreferenceStore = {
+    ...preferences,
+  };
+  const mockGetPreference = jest.fn((key: string) => store[key]);
+  const mockSetPreference = jest.fn((value: PreferenceStore) => {
+    Object.assign(store, value);
+  });
+  const mockIsUnlocked = jest.fn(() => isUnlocked);
+
+  jest.doMock('react-native', () => ({
+    AppState: {
+      addEventListener: jest.fn(),
+      currentState: 'active',
+      isAvailable: true,
+    },
+  }));
+  jest.doMock('@/constant/autoLock', () => ({
+    DEFAULT_AUTO_LOCK_MINUTES: 5,
+  }));
+  jest.doMock('../services', () => ({
+    keyringService: {
+      isUnlocked: mockIsUnlocked,
+    },
+    preferenceService: {
+      getPreference: (...args: unknown[]) => mockGetPreference(...args),
+      setPreference: (...args: unknown[]) => mockSetPreference(...args),
+    },
+  }));
+
+  const autoLockModule = require('./autoLock') as typeof import('./autoLock');
+
+  return {
+    ...autoLockModule,
+    mocks: {
+      mockGetPreference,
+      mockIsUnlocked,
+      mockSetPreference,
+      store,
+    },
+  };
+}
+
+describe('core/apis/autoLock', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('normalizes auto-lock timeout values to whole-second millisecond durations', () => {
+    const { coerceAutoLockTimeout, isValidAutoLockTime } = loadAutoLockModule();
+
+    expect(isValidAutoLockTime(1)).toBe(true);
+    expect(isValidAutoLockTime(0)).toBe(false);
+    expect(coerceAutoLockTimeout(0)).toEqual({
+      minutes: -1,
+      timeoutMs: -1,
+    });
+    expect(coerceAutoLockTimeout(90_500)).toEqual({
+      minutes: 1.51,
+      timeoutMs: 90_000,
+    });
+  });
+
+  it('derives persisted auto-lock expire time from the stored minute preference', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(10_000);
+    const { getPersistedAutoLockTimes } = loadAutoLockModule({
+      preferences: {
+        autoLockTime: 1.5,
+      },
+    });
+
+    expect(getPersistedAutoLockTimes()).toEqual({
+      expireTime: 100_000,
+      minutes: 1.5,
+      timeoutMs: 90_000,
+    });
+  });
+
+  it('derives unlock-session expiry from explicit preference or last unlock time', () => {
+    const explicit = loadAutoLockModule({
+      preferences: {
+        unlockSessionExpireTime: -1,
+      },
+    });
+    expect(explicit.getPersistedUnlockSessionExpireTime()).toBe(-1);
+
+    const fromLastUnlock = loadAutoLockModule({
+      preferences: {
+        autoLockTime: 2,
+        lastUnlockTime: 5_000,
+      },
+    });
+    expect(fromLastUnlock.getPersistedUnlockSessionExpireTime()).toBe(125_000);
+  });
+
+  it('refreshes foreground and persisted unlock-session expiry when the wallet session can be extended', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(20_000);
+    const { autoLockEvent, refreshAutolockTimeout, mocks } = loadAutoLockModule(
+      {
+        isUnlocked: true,
+        preferences: {
+          autoLockTime: 1,
+          lastUnlockTime: 10_000,
+        },
+      },
+    );
+    const changes: number[] = [];
+    autoLockEvent.on('change', expireTime => {
+      changes.push(expireTime);
+    });
+
+    expect(refreshAutolockTimeout()).toBe(80_000);
+    expect(mocks.store.unlockSessionExpireTime).toBe(80_000);
+    expect(mocks.mockSetPreference).toHaveBeenCalledWith({
+      unlockSessionExpireTime: 80_000,
+    });
+
+    expect(refreshAutolockTimeout('clear')).toBe(-1);
+    expect(changes).toEqual([80_000, -1]);
+  });
+});

--- a/apps/mobile/src/core/apis/customRPC.test.ts
+++ b/apps/mobile/src/core/apis/customRPC.test.ts
@@ -1,0 +1,88 @@
+function loadCustomRPCModule() {
+  jest.resetModules();
+
+  const mockFindChain = jest.fn();
+  const mockPing = jest.fn();
+  const mockRequest = jest.fn();
+
+  jest.doMock('@/utils/chain', () => ({
+    findChain: (...args: unknown[]) => mockFindChain(...args),
+  }));
+  jest.doMock('../services/shared', () => ({
+    customRPCService: {
+      getAllRPC: jest.fn(),
+      getRPCByChain: jest.fn(),
+      hasCustomRPC: jest.fn(),
+      ping: mockPing,
+      removeCustomRPC: jest.fn(),
+      request: mockRequest,
+      setRPC: jest.fn(),
+      setRPCEnable: jest.fn(),
+    },
+  }));
+
+  const { apiCustomRPC } =
+    require('./customRPC') as typeof import('./customRPC');
+
+  return {
+    apiCustomRPC,
+    mocks: {
+      mockFindChain,
+      mockPing,
+      mockRequest,
+    },
+  };
+}
+
+describe('core/apis/customRPC', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('rejects RPC validation for unsupported chain ids before making network calls', async () => {
+    const { apiCustomRPC, mocks } = loadCustomRPCModule();
+    mocks.mockFindChain.mockReturnValue(null);
+
+    await expect(
+      apiCustomRPC.validateRPC('https://rpc.example', 12345),
+    ).rejects.toThrow('ChainId 12345 is not supported');
+
+    expect(mocks.mockPing).not.toHaveBeenCalled();
+    expect(mocks.mockRequest).not.toHaveBeenCalled();
+  });
+
+  it('pings the built-in chain and validates the candidate RPC eth_chainId', async () => {
+    const { apiCustomRPC, mocks } = loadCustomRPCModule();
+    mocks.mockFindChain.mockReturnValue({
+      enum: 'eth',
+      id: 1,
+    });
+    mocks.mockPing.mockResolvedValue(undefined);
+    mocks.mockRequest.mockResolvedValue('0x1');
+
+    await expect(
+      apiCustomRPC.validateRPC('https://rpc.example', 1),
+    ).resolves.toBe(true);
+
+    expect(mocks.mockPing).toHaveBeenCalledWith('eth');
+    expect(mocks.mockRequest).toHaveBeenCalledWith(
+      'https://rpc.example',
+      'eth_chainId',
+      [],
+    );
+  });
+
+  it('returns false when the candidate RPC reports a different chain id', async () => {
+    const { apiCustomRPC, mocks } = loadCustomRPCModule();
+    mocks.mockFindChain.mockReturnValue({
+      enum: 'eth',
+      id: 1,
+    });
+    mocks.mockPing.mockResolvedValue(undefined);
+    mocks.mockRequest.mockResolvedValue('0x2');
+
+    await expect(
+      apiCustomRPC.validateRPC('https://rpc.example', 1),
+    ).resolves.toBe(false);
+  });
+});

--- a/apps/mobile/src/core/apis/customTestnet.test.ts
+++ b/apps/mobile/src/core/apis/customTestnet.test.ts
@@ -1,0 +1,188 @@
+function loadCustomTestnetModule() {
+  jest.resetModules();
+
+  const mockAdd = jest.fn();
+  const mockGetTransactionCount = jest.fn();
+  const mockGetNonceByChain = jest.fn();
+  const mockGetChainListByIds = jest.fn();
+  const mockMatomoRequestEvent = jest.fn();
+  const mockFindChain = jest.fn();
+
+  const transactionHistoryService = {
+    getNonceByChain: mockGetNonceByChain,
+    store: {
+      transactions: {},
+    },
+  };
+
+  jest.doMock('@/utils/analytics', () => ({
+    matomoRequestEvent: (...args: unknown[]) => mockMatomoRequestEvent(...args),
+  }));
+  jest.doMock('@/utils/chain', () => ({
+    findChain: (...args: unknown[]) => mockFindChain(...args),
+  }));
+  jest.doMock('../request', () => ({
+    openapi: {
+      getChainListByIds: (...args: unknown[]) => mockGetChainListByIds(...args),
+    },
+  }));
+  jest.doMock('../services/shared', () => ({
+    customTestnetService: {
+      add: mockAdd,
+      addToken: jest.fn(),
+      estimateGas: jest.fn(),
+      getGasMarket: jest.fn(),
+      getGasPrice: jest.fn(),
+      getList: jest.fn(),
+      getToken: jest.fn(),
+      getTokenList: jest.fn(),
+      getTransactionCount: mockGetTransactionCount,
+      getTransactionReceipt: jest.fn(),
+      getTx: jest.fn(),
+      hasToken: jest.fn(),
+      remove: jest.fn(),
+      removeToken: jest.fn(),
+      update: jest.fn(),
+    },
+    transactionHistoryService,
+  }));
+
+  const { apiCustomTestnet } =
+    require('./customTestnet') as typeof import('./customTestnet');
+
+  return {
+    apiCustomTestnet,
+    mocks: {
+      mockAdd,
+      mockFindChain,
+      mockGetChainListByIds,
+      mockGetNonceByChain,
+      mockGetTransactionCount,
+      mockMatomoRequestEvent,
+      transactionHistoryService,
+    },
+  };
+}
+
+describe('core/apis/customTestnet', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('records the successful add-network analytics event with the request source', async () => {
+    const { apiCustomTestnet, mocks } = loadCustomTestnetModule();
+    mocks.mockAdd.mockResolvedValue({
+      id: 9001,
+      name: 'Local Testnet',
+    });
+
+    await expect(
+      apiCustomTestnet.addCustomTestnet(
+        {
+          id: 9001,
+          name: 'Local Testnet',
+        } as never,
+        {
+          ga: {
+            source: 'dapp',
+          },
+        },
+      ),
+    ).resolves.toEqual({
+      id: 9001,
+      name: 'Local Testnet',
+    });
+
+    expect(mocks.mockMatomoRequestEvent).toHaveBeenCalledWith({
+      action: 'Success Add Network',
+      category: 'Custom Network',
+      label: 'dapp_9001',
+    });
+  });
+
+  it('does not record the success analytics event when add returns an error payload', async () => {
+    const { apiCustomTestnet, mocks } = loadCustomTestnetModule();
+    mocks.mockAdd.mockResolvedValue({
+      error: 'invalid rpc',
+    });
+
+    await expect(
+      apiCustomTestnet.addCustomTestnet({
+        id: 9001,
+      } as never),
+    ).resolves.toEqual({
+      error: 'invalid rpc',
+    });
+
+    expect(mocks.mockMatomoRequestEvent).not.toHaveBeenCalled();
+  });
+
+  it('uses the larger value between on-chain and local custom-testnet nonce', async () => {
+    const { apiCustomTestnet, mocks } = loadCustomTestnetModule();
+    mocks.mockGetTransactionCount.mockResolvedValue(3);
+    mocks.mockGetNonceByChain.mockResolvedValue(8);
+
+    await expect(
+      apiCustomTestnet.getCustomTestnetNonce({
+        address: '0xabc',
+        chainId: 9001,
+      }),
+    ).resolves.toBe(8);
+
+    expect(mocks.mockGetTransactionCount).toHaveBeenCalledWith({
+      address: '0xabc',
+      blockTag: 'latest',
+      chainId: 9001,
+    });
+    expect(mocks.mockGetNonceByChain).toHaveBeenCalledWith('0xabc', 9001);
+  });
+
+  it('loads only transaction-history chain ids that are not already built-in chains', async () => {
+    const { apiCustomTestnet, mocks } = loadCustomTestnetModule();
+    mocks.transactionHistoryService.store.transactions = {
+      builtin: {
+        chainId: 1,
+      },
+      customA: {
+        chainId: 9001,
+      },
+      customADuplicate: {
+        chainId: 9001,
+      },
+      customB: {
+        chainId: 9002,
+      },
+    };
+    mocks.mockFindChain.mockImplementation(({ id }) =>
+      id === 1
+        ? {
+            enum: 'eth',
+            id: 1,
+          }
+        : null,
+    );
+    mocks.mockGetChainListByIds.mockResolvedValue([
+      {
+        id: 9001,
+      },
+      {
+        id: 9002,
+      },
+    ]);
+
+    await expect(
+      apiCustomTestnet.getUsedCustomTestnetChainList(),
+    ).resolves.toEqual([
+      {
+        id: 9001,
+      },
+      {
+        id: 9002,
+      },
+    ]);
+
+    expect(mocks.mockGetChainListByIds).toHaveBeenCalledWith({
+      ids: '9001,9002',
+    });
+  });
+});

--- a/apps/mobile/src/core/apis/device.test.ts
+++ b/apps/mobile/src/core/apis/device.test.ts
@@ -1,0 +1,127 @@
+function loadDeviceModule({
+  existingUUID,
+  platform = 'android',
+}: {
+  existingUUID?: string | null;
+  platform?: 'android' | 'ios';
+} = {}) {
+  jest.resetModules();
+
+  let storedUUID = existingUUID ?? null;
+  const mockGetItem = jest.fn(() => storedUUID);
+  const mockSetItem = jest.fn((_key: string, value: string) => {
+    storedUUID = value;
+  });
+  const mockUuidV4 = jest.fn(() => 'generated-uuid');
+  const mockGetUniqueIdSync = jest.fn(() => 'device-unique-id');
+  const mockGetSystemName = jest.fn(() => 'Android');
+  const mockGetSystemVersion = jest.fn(() => '15');
+
+  jest.doMock('react-native', () => ({
+    Platform: {
+      OS: platform,
+    },
+  }));
+  jest.doMock('react-native-device-info', () => ({
+    __esModule: true,
+    default: {
+      getSystemName: (...args: unknown[]) => mockGetSystemName(...args),
+      getSystemVersion: (...args: unknown[]) => mockGetSystemVersion(...args),
+      getUniqueIdSync: (...args: unknown[]) => mockGetUniqueIdSync(...args),
+    },
+  }));
+  jest.doMock('uuid', () => ({
+    v4: (...args: unknown[]) => mockUuidV4(...args),
+  }));
+  jest.doMock('@/constant', () => ({
+    APPLICATION_ID: 'com.rabby.mobile.test',
+    APP_VERSIONS: {
+      buildNumber: '99',
+      fromNative: '1.2.3',
+    },
+  }));
+  jest.doMock('@/constant/env', () => ({
+    BUILD_GIT_INFO: {
+      BUILD_GIT_HASH: 'abcdef0',
+    },
+  }));
+  jest.doMock('../storage/mmkv', () => ({
+    appJsonStore: {
+      getItem: (...args: unknown[]) => mockGetItem(...args),
+      setItem: (...args: unknown[]) => mockSetItem(...args),
+    },
+  }));
+
+  const deviceModule = require('./device') as typeof import('./device');
+
+  return {
+    ...deviceModule,
+    mocks: {
+      mockGetItem,
+      mockGetSystemName,
+      mockGetSystemVersion,
+      mockGetUniqueIdSync,
+      mockSetItem,
+      mockUuidV4,
+    },
+  };
+}
+
+describe('core/apis/device', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('returns an existing persisted UUID without generating a new one', () => {
+    const { ensureDeviceUUID, mocks } = loadDeviceModule({
+      existingUUID: 'persisted-uuid',
+    });
+
+    expect(ensureDeviceUUID()).toBe('persisted-uuid');
+    expect(mocks.mockGetItem).toHaveBeenCalledWith('rabbymobile_uuid', null);
+    expect(mocks.mockUuidV4).not.toHaveBeenCalled();
+    expect(mocks.mockSetItem).not.toHaveBeenCalled();
+  });
+
+  it('generates and persists a UUID when no device UUID exists', () => {
+    const { ensureDeviceUUID, mocks } = loadDeviceModule();
+
+    expect(ensureDeviceUUID()).toBe('generated-uuid');
+    expect(mocks.mockSetItem).toHaveBeenCalledWith(
+      'rabbymobile_uuid',
+      'generated-uuid',
+    );
+  });
+
+  it('combines persisted app UUID, platform, and hardware unique id', () => {
+    const { makeDeviceUUID } = loadDeviceModule({
+      existingUUID: 'persisted-uuid',
+      platform: 'ios',
+    });
+
+    expect(makeDeviceUUID()).toEqual({
+      deviceUUID: 'persisted-uuid-ios-device-unique-id',
+      uniqId: 'device-unique-id',
+    });
+  });
+
+  it('builds the mobile client push info payload from app and device metadata', () => {
+    const { makeMobileClientPushInfo } = loadDeviceModule({
+      existingUUID: 'persisted-uuid',
+      platform: 'ios',
+    });
+
+    expect(makeMobileClientPushInfo('push-token', true)).toEqual({
+      appBuildNumber: '99',
+      appBuildRevision: 'abcdef0',
+      appVersion: '1.2.3',
+      deviceUUID: 'persisted-uuid-ios-device-unique-id',
+      enabledNotifications: true,
+      packageName: 'com.rabby.mobile.test',
+      platform: 'ios',
+      pushToken: 'push-token',
+      systemName: 'Android',
+      systemVersion: '15',
+    });
+  });
+});

--- a/apps/mobile/src/core/apis/lock.test.ts
+++ b/apps/mobile/src/core/apis/lock.test.ts
@@ -1,0 +1,425 @@
+const mockVerifyPassword = jest.fn();
+const mockUpdatePassword = jest.fn();
+const mockResetPassword = jest.fn();
+const mockDangerouslyResetPasswordAndKeyrings = jest.fn();
+const mockGetCountOfAccountsInKeyring = jest.fn();
+const mockIsUnlocked = jest.fn();
+const mockSubmitPassword = jest.fn();
+const mockSetLocked = jest.fn();
+const mockHasPublicAccountSnapshot = jest.fn();
+const mockKeyringOn = jest.fn();
+const mockKeyringOff = jest.fn();
+const mockRefreshMemStoreKeyrings = jest.fn();
+const mockGetPreference = jest.fn();
+const mockSetPreference = jest.fn();
+const mockInitCurrentAccount = jest.fn();
+const mockBroadcastEvent = jest.fn();
+const mockCheckMultipleFailed = jest.fn();
+const mockResetMultipleFailed = jest.fn();
+const mockShouldRejectUnlockDueToMultipleFailed = jest.fn();
+const mockRefreshAutolockTimeout = jest.fn();
+const mockGetPersistedUnlockSessionExpireTime = jest.fn();
+const mockPerfEmit = jest.fn();
+
+const createEventClass = () =>
+  class EventEmitter {
+    private listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+
+    on(event: string, listener: (...args: unknown[]) => void) {
+      this.listeners[event] = [...(this.listeners[event] || []), listener];
+      return this;
+    }
+
+    emit(event: string, ...args: unknown[]) {
+      (this.listeners[event] || []).forEach(listener => listener(...args));
+      return true;
+    }
+  };
+
+const keyringService = {
+  verifyPassword: (...args: unknown[]) => mockVerifyPassword(...args),
+  updatePassword: (...args: unknown[]) => mockUpdatePassword(...args),
+  resetPassword: (...args: unknown[]) => mockResetPassword(...args),
+  dangerouslyResetPasswordAndKeyrings: (...args: unknown[]) =>
+    mockDangerouslyResetPasswordAndKeyrings(...args),
+  getCountOfAccountsInKeyring: (...args: unknown[]) =>
+    mockGetCountOfAccountsInKeyring(...args),
+  isUnlocked: (...args: unknown[]) => mockIsUnlocked(...args),
+  submitPassword: (...args: unknown[]) => mockSubmitPassword(...args),
+  setLocked: (...args: unknown[]) => mockSetLocked(...args),
+  hasPublicAccountSnapshot: (...args: unknown[]) =>
+    mockHasPublicAccountSnapshot(...args),
+  on: (...args: unknown[]) => mockKeyringOn(...args),
+  off: (...args: unknown[]) => mockKeyringOff(...args),
+  refreshMemStoreKeyrings: (...args: unknown[]) =>
+    mockRefreshMemStoreKeyrings(...args),
+};
+
+const preferenceService = {
+  getPreference: (...args: unknown[]) => mockGetPreference(...args),
+  setPreference: (...args: unknown[]) => mockSetPreference(...args),
+  initCurrentAccount: (...args: unknown[]) => mockInitCurrentAccount(...args),
+};
+
+const sessionService = {
+  broadcastEvent: (...args: unknown[]) => mockBroadcastEvent(...args),
+};
+
+const loadLockModule = () => {
+  jest.resetModules();
+
+  jest.doMock('react-native', () => ({
+    Platform: {
+      OS: 'ios',
+    },
+  }));
+
+  jest.doMock('@/constant/encryptor', () => ({
+    RABBY_MOBILE_KR_PWD: 'built-in-password',
+  }));
+
+  jest.doMock('@/constant/event', () => ({
+    BroadcastEvent: {
+      accountsChanged: 'accountsChanged',
+      lock: 'lock',
+      unlock: 'unlock',
+    },
+  }));
+
+  jest.doMock('../services', () => ({
+    keyringService,
+    preferenceService,
+    sessionService,
+  }));
+
+  jest.doMock('./event', () => ({
+    makeEEClass: () => ({
+      EventEmitter: createEventClass(),
+    }),
+  }));
+
+  jest.doMock('@/utils/time', () => ({
+    formatTimeReadable: (seconds: number) => `${seconds}s`,
+  }));
+
+  jest.doMock('../utils/unlockRateLimit', () => ({
+    resetMultipleFailed: (...args: unknown[]) =>
+      mockResetMultipleFailed(...args),
+    checkMultipleFailed: (...args: unknown[]) =>
+      mockCheckMultipleFailed(...args),
+    shouldRejectUnlockDueToMultipleFailed: (...args: unknown[]) =>
+      mockShouldRejectUnlockDueToMultipleFailed(...args),
+  }));
+
+  jest.doMock('../utils/store', () => ({
+    runIIFEFunc: (fn: () => unknown) => fn(),
+  }));
+
+  jest.doMock('../utils/perf', () => ({
+    perfEvents: {
+      emit: (...args: unknown[]) => mockPerfEmit(...args),
+    },
+  }));
+
+  jest.doMock('./autoLock', () => ({
+    getPersistedUnlockSessionExpireTime: (...args: unknown[]) =>
+      mockGetPersistedUnlockSessionExpireTime(...args),
+    refreshAutolockTimeout: (...args: unknown[]) =>
+      mockRefreshAutolockTimeout(...args),
+  }));
+
+  jest.doMock('@/utils/logger', () => ({
+    logger: {
+      info: jest.fn(),
+    },
+  }));
+
+  return require('./lock') as typeof import('./lock');
+};
+
+describe('core/apis/lock password and session utilities', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-31T12:00:00.000Z'));
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+    mockVerifyPassword.mockResolvedValue(undefined);
+    mockUpdatePassword.mockResolvedValue(undefined);
+    mockResetPassword.mockResolvedValue(undefined);
+    mockDangerouslyResetPasswordAndKeyrings.mockResolvedValue(undefined);
+    mockGetCountOfAccountsInKeyring.mockResolvedValue(0);
+    mockIsUnlocked.mockReturnValue(false);
+    mockSubmitPassword.mockResolvedValue(undefined);
+    mockSetLocked.mockResolvedValue(undefined);
+    mockHasPublicAccountSnapshot.mockReturnValue(true);
+    mockGetPreference.mockReturnValue(0);
+    mockShouldRejectUnlockDueToMultipleFailed.mockReturnValue({
+      reject: false,
+      timeDiff: 0,
+    });
+    mockGetPersistedUnlockSessionExpireTime.mockReturnValue(Date.now() + 1_000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('parses custom validation behavior while providing default handlers', () => {
+    const { parseValidationBehavior } = loadLockModule();
+    const validationHandler = jest.fn();
+    const onFinished = jest.fn();
+
+    expect(
+      parseValidationBehavior({
+        validationHandler,
+        onFinished,
+      }),
+    ).toEqual({
+      validationHandler,
+      onFinished,
+    });
+
+    const defaults = parseValidationBehavior();
+    expect(defaults.validationHandler).toBeInstanceOf(Function);
+    expect(defaults.onFinished).toBeInstanceOf(Function);
+  });
+
+  it('sets wallet password only after verifying the built-in password', async () => {
+    const { setupWalletPassword } = loadLockModule();
+
+    await expect(setupWalletPassword('new-password')).resolves.toEqual({
+      error: '',
+    });
+
+    expect(mockVerifyPassword).toHaveBeenCalledWith('built-in-password');
+    expect(mockUpdatePassword).toHaveBeenCalledWith(
+      'built-in-password',
+      'new-password',
+    );
+  });
+
+  it('rejects invalid initial password setup inputs and verification failures', async () => {
+    const { setupWalletPassword } = loadLockModule();
+
+    await expect(setupWalletPassword('built-in-password')).resolves.toEqual({
+      error: 'Incorret Password',
+    });
+    await expect(setupWalletPassword('')).resolves.toEqual({
+      error: 'Password cannot be empty',
+    });
+
+    mockVerifyPassword.mockRejectedValue(new Error('bad built-in password'));
+    await expect(setupWalletPassword('new-password')).resolves.toEqual({
+      error: 'Current password is incorrect',
+    });
+    expect(mockUpdatePassword).not.toHaveBeenCalled();
+  });
+
+  it('updates or clears custom passwords only after current-password verification', async () => {
+    const { clearCustomPassword, updateWalletPassword } = loadLockModule();
+
+    await expect(
+      updateWalletPassword('old-password', 'new-password'),
+    ).resolves.toEqual({
+      error: '',
+    });
+    expect(mockUpdatePassword).toHaveBeenCalledWith(
+      'old-password',
+      'new-password',
+    );
+
+    await expect(clearCustomPassword('current-password')).resolves.toEqual({
+      error: '',
+    });
+    expect(mockUpdatePassword).toHaveBeenCalledWith(
+      'current-password',
+      'built-in-password',
+    );
+
+    mockVerifyPassword.mockRejectedValue(new Error('bad current password'));
+    await expect(
+      updateWalletPassword('bad-old-password', 'new-password'),
+    ).resolves.toEqual({
+      error: 'Current password is incorrect',
+    });
+  });
+
+  it('decides whether setup password should be asked from lock info and account count', async () => {
+    const { shouldAskSetPassword } = loadLockModule();
+
+    mockVerifyPassword.mockResolvedValue(undefined);
+    await expect(shouldAskSetPassword()).resolves.toBe(true);
+
+    mockVerifyPassword.mockRejectedValue(new Error('custom password'));
+    mockGetCountOfAccountsInKeyring.mockResolvedValue(0);
+    await expect(shouldAskSetPassword()).resolves.toBe(true);
+
+    mockGetCountOfAccountsInKeyring.mockResolvedValue(1);
+    await expect(shouldAskSetPassword()).resolves.toBe(false);
+  });
+
+  it('resets password by setup path for built-in password accounts and reset path for empty keyring', async () => {
+    const { resetPasswordOnUI } = loadLockModule();
+
+    mockGetCountOfAccountsInKeyring.mockResolvedValue(1);
+    mockVerifyPassword.mockResolvedValue(undefined);
+    await expect(resetPasswordOnUI('new-password')).resolves.toEqual({
+      error: '',
+    });
+    expect(mockUpdatePassword).toHaveBeenCalledWith(
+      'built-in-password',
+      'new-password',
+    );
+    expect(mockResetPassword).not.toHaveBeenCalled();
+
+    jest.clearAllMocks();
+    mockGetCountOfAccountsInKeyring.mockResolvedValue(0);
+    mockVerifyPassword.mockResolvedValue(undefined);
+    await expect(resetPasswordOnUI('empty-keyring-password')).resolves.toEqual({
+      error: '',
+    });
+    expect(mockResetPassword).toHaveBeenCalledWith('empty-keyring-password');
+  });
+
+  it('fails reset when accounts exist under a custom password', async () => {
+    const { resetPasswordOnUI } = loadLockModule();
+
+    mockGetCountOfAccountsInKeyring.mockResolvedValue(1);
+    mockVerifyPassword.mockRejectedValue(new Error('custom password'));
+
+    await expect(resetPasswordOnUI('new-password')).resolves.toEqual({
+      error: 'Failed to reset password',
+    });
+    expect(mockUpdatePassword).not.toHaveBeenCalled();
+    expect(mockResetPassword).not.toHaveBeenCalled();
+  });
+
+  it('wraps dangerous password reset with a stable error result', async () => {
+    const { dangerouslyResetPasswordAndKeyrings } = loadLockModule();
+
+    await expect(
+      dangerouslyResetPasswordAndKeyrings('old-password', 'new-password'),
+    ).resolves.toEqual({
+      error: '',
+    });
+    expect(mockDangerouslyResetPasswordAndKeyrings).toHaveBeenCalledWith(
+      'old-password',
+      'new-password',
+    );
+
+    mockDangerouslyResetPasswordAndKeyrings.mockRejectedValue(
+      new Error('reset failed'),
+    );
+    await expect(
+      dangerouslyResetPasswordAndKeyrings('old-password'),
+    ).resolves.toEqual({
+      error: 'Failed to reset password an clear keyrings',
+    });
+  });
+
+  it('locks wallet, clears unlock time, and broadcasts account and lock events', async () => {
+    const { getUnlockTime, lockWallet } = loadLockModule();
+
+    await lockWallet();
+
+    expect(mockSetLocked).toHaveBeenCalled();
+    expect(getUnlockTime()).toBe(0);
+    expect(mockSetPreference).toHaveBeenCalledWith({
+      lastUnlockTime: 0,
+      unlockSessionExpireTime: 0,
+    });
+    expect(mockBroadcastEvent).toHaveBeenCalledWith('accountsChanged', []);
+    expect(mockBroadcastEvent).toHaveBeenCalledWith('lock');
+  });
+
+  it('updates unlock time and checks persisted unlock-session validity', async () => {
+    const {
+      clearUnlockTime,
+      getUnlockTime,
+      isUnlockSessionValid,
+      unlockTimeEvent,
+      updateUnlockTime,
+    } = loadLockModule();
+    const updates: number[] = [];
+    unlockTimeEvent.on('updated', time => updates.push(time as number));
+
+    await updateUnlockTime();
+
+    expect(getUnlockTime()).toBe(Date.now());
+    expect(mockSetPreference).toHaveBeenCalledWith({
+      lastUnlockTime: Date.now(),
+    });
+    expect(mockRefreshAutolockTimeout).toHaveBeenCalled();
+    expect(updates).toEqual([Date.now()]);
+    expect(isUnlockSessionValid()).toBe(true);
+
+    mockGetPersistedUnlockSessionExpireTime.mockReturnValue(Date.now() - 1);
+    expect(isUnlockSessionValid()).toBe(false);
+
+    mockGetPersistedUnlockSessionExpireTime.mockReturnValue(-1);
+    mockIsUnlocked.mockReturnValue(false);
+    mockHasPublicAccountSnapshot.mockReturnValue(false);
+    expect(isUnlockSessionValid()).toBe(false);
+
+    clearUnlockTime();
+    expect(updates).toEqual([Date.now(), 0]);
+    expect(getUnlockTime()).toBe(0);
+  });
+
+  it('unlocks through submitPassword and refreshes unlock time only on success', async () => {
+    const { unlockWalletWithUpdateUnlockTime } = loadLockModule();
+
+    await expect(unlockWalletWithUpdateUnlockTime('password')).resolves.toEqual(
+      {
+        error: '',
+        formFieldError: '',
+        toastError: '',
+      },
+    );
+    expect(mockSubmitPassword).toHaveBeenCalledWith('password', {
+      trustedPassword: undefined,
+      trustedVaultKeyString: undefined,
+      onTrustedVaultKeyString: undefined,
+      deferMemStoreKeyringsUpdate: undefined,
+    });
+    expect(mockResetMultipleFailed).toHaveBeenCalled();
+    expect(mockInitCurrentAccount).toHaveBeenCalled();
+    expect(mockBroadcastEvent).toHaveBeenCalledWith('unlock');
+    expect(mockSetPreference).toHaveBeenCalledWith({
+      lastUnlockTime: Date.now(),
+    });
+
+    jest.clearAllMocks();
+    mockSubmitPassword.mockRejectedValue(new Error('bad password'));
+    await expect(unlockWalletWithUpdateUnlockTime('bad')).resolves.toEqual({
+      error: 'Incorrect password',
+      formFieldError: '',
+      toastError: '',
+    });
+    expect(mockCheckMultipleFailed).toHaveBeenCalled();
+    expect(mockSetPreference).not.toHaveBeenCalledWith({
+      lastUnlockTime: Date.now(),
+    });
+  });
+
+  it('returns rate-limit unlock errors before submitting password', async () => {
+    const { unlockWalletWithUpdateUnlockTime } = loadLockModule();
+    mockShouldRejectUnlockDueToMultipleFailed.mockReturnValue({
+      reject: true,
+      timeDiff: 61_000,
+    });
+
+    await expect(unlockWalletWithUpdateUnlockTime('password')).resolves.toEqual(
+      {
+        error: 'Incorrect password',
+        formFieldError: 'Too many failed attempts',
+        toastError: 'Too many failed attempts, please try again after 61s',
+      },
+    );
+
+    expect(mockSubmitPassword).not.toHaveBeenCalled();
+    expect(mockSetPreference).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/core/apis/perps.test.ts
+++ b/apps/mobile/src/core/apis/perps.test.ts
@@ -1,0 +1,164 @@
+function loadPerpsModule({ isUnlocked = true }: { isUnlocked?: boolean } = {}) {
+  jest.resetModules();
+
+  const mockCreateAgentWallet = jest.fn();
+  const mockDisconnect = jest.fn();
+  const mockGetAgentWallet = jest.fn();
+  const mockGetAgentWalletPreference = jest.fn();
+  const mockGetCurrentAccount = jest.fn();
+  const mockGetHasClosedLearnMoreCard = jest.fn();
+  const mockGetHasDoneNewUserProcess = jest.fn();
+  const mockGetHasShownPerpsGuidePopup = jest.fn();
+  const mockGetLastUsedAccount = jest.fn();
+  const mockGetSelectedKlineInterval = jest.fn();
+  const mockGetSendApproveAfterDeposit = jest.fn();
+  const mockHyperliquidSDK = jest.fn().mockImplementation(params => ({
+    params,
+    ws: {
+      disconnect: mockDisconnect,
+    },
+  }));
+  const mockIsUnlocked = jest.fn(() => isUnlocked);
+  const mockSetCurrentAccount = jest.fn();
+  const mockSetHasClosedLearnMoreCard = jest.fn();
+  const mockSetHasDoneNewUserProcess = jest.fn();
+  const mockSetHasShownPerpsGuidePopup = jest.fn();
+  const mockSetSelectedKlineInterval = jest.fn();
+  const mockSetSendApproveAfterDeposit = jest.fn();
+  const mockUpdateAgentWalletPreference = jest.fn();
+
+  jest.doMock('@rabby-wallet/hyperliquid-sdk', () => ({
+    HyperliquidSDK: mockHyperliquidSDK,
+  }));
+  jest.doMock('@/core/apis/lock', () => ({
+    isUnlocked: (...args: unknown[]) => mockIsUnlocked(...args),
+  }));
+  jest.doMock('../services', () => ({
+    perpsService: {
+      createAgentWallet: mockCreateAgentWallet,
+      getAgentWallet: mockGetAgentWallet,
+      getAgentWalletPreference: mockGetAgentWalletPreference,
+      getCurrentAccount: mockGetCurrentAccount,
+      getHasClosedLearnMoreCard: mockGetHasClosedLearnMoreCard,
+      getHasDoneNewUserProcess: mockGetHasDoneNewUserProcess,
+      getHasShownPerpsGuidePopup: mockGetHasShownPerpsGuidePopup,
+      getLastUsedAccount: mockGetLastUsedAccount,
+      getSelectedKlineInterval: mockGetSelectedKlineInterval,
+      getSendApproveAfterDeposit: mockGetSendApproveAfterDeposit,
+      setCurrentAccount: mockSetCurrentAccount,
+      setHasClosedLearnMoreCard: mockSetHasClosedLearnMoreCard,
+      setHasDoneNewUserProcess: mockSetHasDoneNewUserProcess,
+      setHasShownPerpsGuidePopup: mockSetHasShownPerpsGuidePopup,
+      setSelectedKlineInterval: mockSetSelectedKlineInterval,
+      setSendApproveAfterDeposit: mockSetSendApproveAfterDeposit,
+      updateAgentWalletPreference: mockUpdateAgentWalletPreference,
+    },
+  }));
+
+  const { apisPerps } = require('./perps') as typeof import('./perps');
+
+  return {
+    apisPerps,
+    mocks: {
+      mockCreateAgentWallet,
+      mockDisconnect,
+      mockGetAgentWallet,
+      mockHyperliquidSDK,
+      mockIsUnlocked,
+    },
+  };
+}
+
+describe('core/apis/perps', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('lazily creates, reuses, and destroys the Hyperliquid SDK singleton', () => {
+    const { apisPerps, mocks } = loadPerpsModule();
+
+    const firstSDK = apisPerps.getPerpsSDK();
+    const secondSDK = apisPerps.getPerpsSDK();
+
+    expect(secondSDK).toBe(firstSDK);
+    expect(mocks.mockHyperliquidSDK).toHaveBeenCalledTimes(1);
+    expect(mocks.mockHyperliquidSDK).toHaveBeenCalledWith({
+      isTestnet: false,
+      timeout: 10000,
+    });
+
+    apisPerps.destroyPerpsSDK();
+    expect(mocks.mockDisconnect).toHaveBeenCalledTimes(1);
+
+    const recreatedSDK = apisPerps.getPerpsSDK();
+    expect(recreatedSDK).not.toBe(firstSDK);
+    expect(mocks.mockHyperliquidSDK).toHaveBeenCalledTimes(2);
+  });
+
+  it('requires an unlocked wallet before creating an agent wallet', async () => {
+    const unlocked = loadPerpsModule({
+      isUnlocked: true,
+    });
+    unlocked.mocks.mockCreateAgentWallet.mockResolvedValue({
+      agentAddress: '0xagent',
+      vault: '0xvault',
+    });
+
+    await expect(
+      unlocked.apisPerps.createPerpsAgentWallet('0xmaster'),
+    ).resolves.toEqual({
+      agentAddress: '0xagent',
+      vault: '0xvault',
+    });
+    expect(unlocked.mocks.mockCreateAgentWallet).toHaveBeenCalledWith(
+      '0xmaster',
+    );
+
+    const locked = loadPerpsModule({
+      isUnlocked: false,
+    });
+    await expect(
+      locked.apisPerps.createPerpsAgentWallet('0xmaster'),
+    ).rejects.toThrow('background.error.unlock');
+    expect(locked.mocks.mockCreateAgentWallet).not.toHaveBeenCalled();
+  });
+
+  it('returns an existing agent wallet preference without creating a new wallet', async () => {
+    const { apisPerps, mocks } = loadPerpsModule();
+    mocks.mockGetAgentWallet.mockResolvedValue({
+      preference: {
+        agentAddress: '0xexisting-agent',
+      },
+      vault: '0xexisting-vault',
+    });
+
+    await expect(
+      apisPerps.getOrCreatePerpsAgentWallet('0xmaster'),
+    ).resolves.toEqual({
+      agentAddress: '0xexisting-agent',
+      vault: '0xexisting-vault',
+    });
+
+    expect(mocks.mockGetAgentWallet).toHaveBeenCalledWith('0xmaster');
+    expect(mocks.mockCreateAgentWallet).not.toHaveBeenCalled();
+  });
+
+  it('creates an agent wallet when no existing perps wallet is stored', async () => {
+    const { apisPerps, mocks } = loadPerpsModule();
+    mocks.mockGetAgentWallet.mockResolvedValue(null);
+    mocks.mockCreateAgentWallet.mockResolvedValue({
+      agentAddress: '0xnew-agent',
+      vault: '0xnew-vault',
+    });
+
+    await expect(
+      apisPerps.getOrCreatePerpsAgentWallet('0xmaster'),
+    ).resolves.toEqual({
+      agentAddress: '0xnew-agent',
+      vault: '0xnew-vault',
+    });
+
+    expect(mocks.mockGetAgentWallet).toHaveBeenCalledWith('0xmaster');
+    expect(mocks.mockCreateAgentWallet).toHaveBeenCalledWith('0xmaster');
+  });
+});

--- a/apps/mobile/src/core/apis/portfolio.test.ts
+++ b/apps/mobile/src/core/apis/portfolio.test.ts
@@ -1,0 +1,132 @@
+const mockOpenapiGetComplexProtocolList = jest.fn();
+const mockTestOpenapiGetComplexProtocolList = jest.fn();
+const mockOpenapiGetProtocol = jest.fn();
+const mockTestOpenapiGetProtocol = jest.fn();
+const mockPQueueAdd = jest.fn((fn: () => unknown) => fn());
+
+jest.mock('@/core/request', () => ({
+  openapi: {
+    getComplexProtocolList: (...args: unknown[]) =>
+      mockOpenapiGetComplexProtocolList(...args),
+    getProtocol: (...args: unknown[]) => mockOpenapiGetProtocol(...args),
+  },
+  testOpenapi: {
+    getComplexProtocolList: (...args: unknown[]) =>
+      mockTestOpenapiGetComplexProtocolList(...args),
+    getProtocol: (...args: unknown[]) => mockTestOpenapiGetProtocol(...args),
+  },
+}));
+
+jest.mock('@/core/utils/concurrency', () => ({
+  makeSWRKeyAsyncFunc: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
+jest.mock('@/utils/requestQueue', () => ({
+  pQueue: {
+    add: (...args: unknown[]) => mockPQueueAdd(...args),
+  },
+}));
+
+import {
+  batchLoadProjects,
+  loadPortfolioSnapshot,
+  loadTestnetPortfolioSnapshot,
+} from './portfolio';
+
+describe('core/apis/portfolio', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockOpenapiGetComplexProtocolList.mockResolvedValue(['mainnet-snapshot']);
+    mockTestOpenapiGetComplexProtocolList.mockResolvedValue([
+      'testnet-snapshot',
+    ]);
+    mockOpenapiGetProtocol.mockImplementation(({ id }) =>
+      Promise.resolve({ id, network: 'mainnet' }),
+    );
+    mockTestOpenapiGetProtocol.mockImplementation(({ id }) =>
+      Promise.resolve({ id, network: 'testnet' }),
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('loads mainnet and testnet portfolio snapshots through the shared queue', async () => {
+    await expect(loadPortfolioSnapshot('0xabc')).resolves.toEqual([
+      'mainnet-snapshot',
+    ]);
+    await expect(loadTestnetPortfolioSnapshot('0xabc')).resolves.toEqual([
+      'testnet-snapshot',
+    ]);
+
+    expect(mockPQueueAdd).toHaveBeenCalledTimes(2);
+    expect(mockOpenapiGetComplexProtocolList).toHaveBeenCalledWith('0xabc');
+    expect(mockTestOpenapiGetComplexProtocolList).toHaveBeenCalledWith('0xabc');
+  });
+
+  it('loads mainnet project details in queue order', async () => {
+    await expect(
+      batchLoadProjects('0xabc', ['aave', 'curve']),
+    ).resolves.toEqual([
+      {
+        id: 'aave',
+        network: 'mainnet',
+      },
+      {
+        id: 'curve',
+        network: 'mainnet',
+      },
+    ]);
+
+    expect(mockOpenapiGetProtocol).toHaveBeenCalledWith({
+      addr: '0xabc',
+      id: 'aave',
+    });
+    expect(mockOpenapiGetProtocol).toHaveBeenCalledWith({
+      addr: '0xabc',
+      id: 'curve',
+    });
+    expect(mockTestOpenapiGetProtocol).not.toHaveBeenCalled();
+  });
+
+  it('loads testnet project details when requested', async () => {
+    await expect(
+      batchLoadProjects('0xabc', ['test-protocol'], true),
+    ).resolves.toEqual([
+      {
+        id: 'test-protocol',
+        network: 'testnet',
+      },
+    ]);
+
+    expect(mockTestOpenapiGetProtocol).toHaveBeenCalledWith({
+      addr: '0xabc',
+      id: 'test-protocol',
+    });
+  });
+
+  it('returns null for failed single project loads only when ignoreSingleError is enabled', async () => {
+    mockOpenapiGetProtocol.mockImplementation(({ id }) => {
+      if (id === 'bad') {
+        return Promise.reject(new Error('bad project'));
+      }
+      return Promise.resolve({ id, network: 'mainnet' });
+    });
+
+    await expect(
+      batchLoadProjects('0xabc', ['good', 'bad'], false, true),
+    ).resolves.toEqual([
+      {
+        id: 'good',
+        network: 'mainnet',
+      },
+      null,
+    ]);
+
+    await expect(
+      batchLoadProjects('0xabc', ['bad'], false, false),
+    ).rejects.toThrow('bad project');
+  });
+});

--- a/apps/mobile/src/core/apis/readOnlyRpc.test.ts
+++ b/apps/mobile/src/core/apis/readOnlyRpc.test.ts
@@ -1,0 +1,218 @@
+function loadReadOnlyRpcModule() {
+  jest.resetModules();
+
+  const mockFindChain = jest.fn();
+  const mockRpcCacheGet = jest.fn();
+  const mockRpcCacheSet = jest.fn();
+  const mockHasCustomRPC = jest.fn();
+  const mockRequestCustomRPC = jest.fn();
+  const mockDefaultEthRPC = jest.fn();
+  const mockGetClient = jest.fn();
+  const mockClientRequest = jest.fn();
+
+  jest.doMock('@/constant', () => ({
+    INTERNAL_REQUEST_SESSION: {
+      origin: 'internal://rabby',
+    },
+  }));
+  jest.doMock('@/constant/chains', () => ({
+    CHAINS_ENUM: {
+      ETH: 'eth',
+    },
+  }));
+  jest.doMock('@/utils/chain', () => ({
+    findChain: (...args: unknown[]) => mockFindChain(...args),
+  }));
+  jest.doMock('@/core/services/customRPCService', () => ({
+    customRPCService: {
+      defaultEthRPC: (...args: unknown[]) => mockDefaultEthRPC(...args),
+      hasCustomRPC: (...args: unknown[]) => mockHasCustomRPC(...args),
+      requestCustomRPC: (...args: unknown[]) => mockRequestCustomRPC(...args),
+    },
+  }));
+  jest.doMock('@/core/services/customTestnetService', () => ({
+    customTestnetService: {
+      getClient: (...args: unknown[]) => mockGetClient(...args),
+    },
+  }));
+  jest.doMock('@/core/services/rpcCache', () => ({
+    __esModule: true,
+    default: {
+      get: (...args: unknown[]) => mockRpcCacheGet(...args),
+      set: (...args: unknown[]) => mockRpcCacheSet(...args),
+    },
+  }));
+
+  mockGetClient.mockReturnValue({
+    request: mockClientRequest,
+  });
+
+  const { requestReadOnlyETHRpc } =
+    require('./readOnlyRpc') as typeof import('./readOnlyRpc');
+
+  return {
+    requestReadOnlyETHRpc,
+    mocks: {
+      mockClientRequest,
+      mockDefaultEthRPC,
+      mockFindChain,
+      mockGetClient,
+      mockHasCustomRPC,
+      mockRequestCustomRPC,
+      mockRpcCacheGet,
+      mockRpcCacheSet,
+    },
+  };
+}
+
+describe('core/apis/readOnlyRpc', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('returns an account-scoped cached RPC result without touching services', async () => {
+    const { requestReadOnlyETHRpc, mocks } = loadReadOnlyRpcModule();
+    mocks.mockRpcCacheGet.mockReturnValue('cached-result');
+
+    await expect(
+      requestReadOnlyETHRpc(
+        {
+          method: 'eth_call',
+          params: [
+            {
+              to: '0xcontract',
+            },
+            'latest',
+          ],
+        },
+        'eth',
+        {
+          address: '0xABC',
+        } as never,
+      ),
+    ).resolves.toBe('cached-result');
+
+    expect(mocks.mockRpcCacheGet).toHaveBeenCalledWith('0xabc', {
+      chainId: 'eth',
+      method: 'eth_call',
+      params: [
+        {
+          to: '0xcontract',
+        },
+        'latest',
+      ],
+    });
+    expect(mocks.mockFindChain).not.toHaveBeenCalled();
+    expect(mocks.mockRequestCustomRPC).not.toHaveBeenCalled();
+    expect(mocks.mockDefaultEthRPC).not.toHaveBeenCalled();
+    expect(mocks.mockClientRequest).not.toHaveBeenCalled();
+  });
+
+  it('routes mainnet requests through a configured custom RPC and caches the pending promise and final result', async () => {
+    const { requestReadOnlyETHRpc, mocks } = loadReadOnlyRpcModule();
+    mocks.mockRpcCacheGet.mockReturnValue(undefined);
+    mocks.mockFindChain.mockReturnValue({
+      enum: 'eth',
+      id: 1,
+      isTestnet: false,
+      serverId: 'eth',
+    });
+    mocks.mockHasCustomRPC.mockReturnValue(true);
+    mocks.mockRequestCustomRPC.mockResolvedValue('0x123');
+
+    await expect(
+      requestReadOnlyETHRpc(
+        {
+          method: 'eth_getBalance',
+          params: ['0xabc', 'latest'],
+        },
+        'eth',
+        {
+          address: '0xabc',
+        } as never,
+      ),
+    ).resolves.toBe('0x123');
+
+    expect(mocks.mockRequestCustomRPC).toHaveBeenCalledWith(
+      'eth',
+      'eth_getBalance',
+      ['0xabc', 'latest'],
+    );
+    expect(mocks.mockRpcCacheSet).toHaveBeenNthCalledWith(1, '0xabc', {
+      chainId: 'eth',
+      method: 'eth_getBalance',
+      params: ['0xabc', 'latest'],
+      result: expect.any(Promise),
+    });
+    expect(mocks.mockRpcCacheSet).toHaveBeenNthCalledWith(2, '0xabc', {
+      chainId: 'eth',
+      method: 'eth_getBalance',
+      params: ['0xabc', 'latest'],
+      result: '0x123',
+    });
+  });
+
+  it('falls back to the default ETH RPC when no chain-specific custom RPC exists', async () => {
+    const { requestReadOnlyETHRpc, mocks } = loadReadOnlyRpcModule();
+    mocks.mockRpcCacheGet.mockReturnValue(undefined);
+    mocks.mockFindChain.mockImplementation(({ enum: chainEnum }) =>
+      chainEnum === 'eth'
+        ? {
+            enum: 'eth',
+            id: 1,
+            isTestnet: false,
+            serverId: 'eth',
+          }
+        : null,
+    );
+    mocks.mockHasCustomRPC.mockReturnValue(false);
+    mocks.mockDefaultEthRPC.mockResolvedValue('0x456');
+
+    await expect(
+      requestReadOnlyETHRpc(
+        {
+          method: 'eth_blockNumber',
+          params: [],
+        },
+        'unknown',
+        null,
+      ),
+    ).resolves.toBe('0x456');
+
+    expect(mocks.mockDefaultEthRPC).toHaveBeenCalledWith({
+      chainServerId: 'unknown',
+      method: 'eth_blockNumber',
+      origin: 'internal://rabby',
+      params: [],
+    });
+  });
+
+  it('routes testnet requests through the custom testnet client', async () => {
+    const { requestReadOnlyETHRpc, mocks } = loadReadOnlyRpcModule();
+    mocks.mockRpcCacheGet.mockReturnValue(undefined);
+    mocks.mockFindChain.mockReturnValue({
+      enum: 'custom9001',
+      id: 9001,
+      isTestnet: true,
+      serverId: 'custom9001',
+    });
+    mocks.mockClientRequest.mockResolvedValue('0xtestnet');
+
+    await expect(
+      requestReadOnlyETHRpc(
+        {
+          method: 'eth_getTransactionCount',
+          params: ['0xabc', 'latest'],
+        },
+        'custom9001',
+        undefined,
+      ),
+    ).resolves.toBe('0xtestnet');
+
+    expect(mocks.mockGetClient).toHaveBeenCalledWith(9001);
+    expect(mocks.mockClientRequest).toHaveBeenCalledWith({
+      method: 'eth_getTransactionCount',
+      params: ['0xabc', 'latest'],
+    });
+  });
+});

--- a/apps/mobile/src/core/apis/recommendNonce.test.ts
+++ b/apps/mobile/src/core/apis/recommendNonce.test.ts
@@ -1,0 +1,192 @@
+function loadRecommendNonceModule() {
+  jest.resetModules();
+
+  const mockDecodeFunctionResult = jest.fn();
+  const mockEncodeFunctionData = jest.fn();
+  const mockFindChain = jest.fn();
+  const mockGetNonceByChain = jest.fn();
+  const mockIsTempoChain = jest.fn();
+  const mockRequestReadOnlyETHRpc = jest.fn();
+
+  jest.doMock('i18next', () => ({
+    t: (key: string) => key,
+  }));
+  jest.doMock('viem', () => ({
+    decodeFunctionResult: (...args: unknown[]) =>
+      mockDecodeFunctionResult(...args),
+    encodeFunctionData: (...args: unknown[]) => mockEncodeFunctionData(...args),
+  }));
+  jest.doMock('viem/tempo', () => ({
+    Abis: {
+      nonce: ['nonce-abi'],
+    },
+    Addresses: {
+      nonceManager: '0xnonce',
+    },
+  }));
+  jest.doMock('@/core/services', () => ({
+    transactionHistoryService: {
+      getNonceByChain: (...args: unknown[]) => mockGetNonceByChain(...args),
+    },
+  }));
+  jest.doMock('@/utils/chain', () => ({
+    findChain: (...args: unknown[]) => mockFindChain(...args),
+  }));
+  jest.doMock('@/utils/tempoChain', () => ({
+    isTempoChain: (...args: unknown[]) => mockIsTempoChain(...args),
+  }));
+  jest.doMock('./readOnlyRpc', () => ({
+    requestReadOnlyETHRpc: (...args: unknown[]) =>
+      mockRequestReadOnlyETHRpc(...args),
+  }));
+
+  const { getRecommendNonce } =
+    require('./recommendNonce') as typeof import('./recommendNonce');
+
+  return {
+    getRecommendNonce,
+    mocks: {
+      mockDecodeFunctionResult,
+      mockEncodeFunctionData,
+      mockFindChain,
+      mockGetNonceByChain,
+      mockIsTempoChain,
+      mockRequestReadOnlyETHRpc,
+    },
+  };
+}
+
+describe('core/apis/recommendNonce', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('rejects unsupported chain ids before reading local or remote nonce', async () => {
+    const { getRecommendNonce, mocks } = loadRecommendNonceModule();
+    mocks.mockFindChain.mockReturnValue(null);
+
+    await expect(
+      getRecommendNonce({
+        account: null,
+        chainId: 12345,
+        from: '0xabc',
+      }),
+    ).rejects.toThrow('background.error.invalidChainId');
+
+    expect(mocks.mockRequestReadOnlyETHRpc).not.toHaveBeenCalled();
+    expect(mocks.mockGetNonceByChain).not.toHaveBeenCalled();
+  });
+
+  it('uses the larger value between standard on-chain and local transaction-history nonce', async () => {
+    const { getRecommendNonce, mocks } = loadRecommendNonceModule();
+    const account = {
+      address: '0xabc',
+    };
+    mocks.mockFindChain.mockReturnValue({
+      id: 1,
+      serverId: 'eth',
+    });
+    mocks.mockIsTempoChain.mockReturnValue(false);
+    mocks.mockRequestReadOnlyETHRpc.mockResolvedValue('0x5');
+    mocks.mockGetNonceByChain.mockResolvedValue(7);
+
+    await expect(
+      getRecommendNonce({
+        account: account as never,
+        chainId: 1,
+        from: '0xabc',
+      }),
+    ).resolves.toBe('0x7');
+
+    expect(mocks.mockRequestReadOnlyETHRpc).toHaveBeenCalledWith(
+      {
+        method: 'eth_getTransactionCount',
+        params: ['0xabc', 'latest'],
+      },
+      'eth',
+      account,
+    );
+    expect(mocks.mockGetNonceByChain).toHaveBeenCalledWith('0xabc', 1);
+  });
+
+  it('reads Tempo keyed nonce with eth_call when a positive nonce key is provided', async () => {
+    const { getRecommendNonce, mocks } = loadRecommendNonceModule();
+    const account = {
+      address: '0xabc',
+    };
+    mocks.mockFindChain.mockReturnValue({
+      id: 999,
+      serverId: 'tempo',
+    });
+    mocks.mockIsTempoChain.mockReturnValue(true);
+    mocks.mockEncodeFunctionData.mockReturnValue('0xencoded');
+    mocks.mockRequestReadOnlyETHRpc.mockResolvedValue('0xresult');
+    mocks.mockDecodeFunctionResult.mockReturnValue(10n);
+
+    await expect(
+      getRecommendNonce({
+        account: account as never,
+        chainId: 999,
+        from: '0xabc',
+        nonceKey: ' 0x2 ',
+      }),
+    ).resolves.toBe('0xa');
+
+    expect(mocks.mockEncodeFunctionData).toHaveBeenCalledWith({
+      abi: ['nonce-abi'],
+      args: ['0xabc', 2n],
+      functionName: 'getNonce',
+    });
+    expect(mocks.mockRequestReadOnlyETHRpc).toHaveBeenCalledWith(
+      {
+        method: 'eth_call',
+        params: [
+          {
+            data: '0xencoded',
+            to: '0xnonce',
+          },
+          'latest',
+        ],
+      },
+      'tempo',
+      account,
+    );
+    expect(mocks.mockDecodeFunctionResult).toHaveBeenCalledWith({
+      abi: ['nonce-abi'],
+      data: '0xresult',
+      functionName: 'getNonce',
+    });
+    expect(mocks.mockGetNonceByChain).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the standard nonce path for Tempo chains when the nonce key is empty or non-positive', async () => {
+    const { getRecommendNonce, mocks } = loadRecommendNonceModule();
+    mocks.mockFindChain.mockReturnValue({
+      id: 999,
+      serverId: 'tempo',
+    });
+    mocks.mockIsTempoChain.mockReturnValue(true);
+    mocks.mockRequestReadOnlyETHRpc.mockResolvedValue('0x8');
+    mocks.mockGetNonceByChain.mockResolvedValue(3);
+
+    await expect(
+      getRecommendNonce({
+        account: null,
+        chainId: 999,
+        from: '0xabc',
+        nonceKey: 0n,
+      }),
+    ).resolves.toBe('0x8');
+
+    expect(mocks.mockEncodeFunctionData).not.toHaveBeenCalled();
+    expect(mocks.mockRequestReadOnlyETHRpc).toHaveBeenCalledWith(
+      {
+        method: 'eth_getTransactionCount',
+        params: ['0xabc', 'latest'],
+      },
+      'tempo',
+      null,
+    );
+    expect(mocks.mockGetNonceByChain).toHaveBeenCalledWith('0xabc', 999);
+  });
+});

--- a/apps/mobile/src/core/apis/token.test.ts
+++ b/apps/mobile/src/core/apis/token.test.ts
@@ -1,0 +1,339 @@
+function loadTokenModule() {
+  jest.resetModules();
+
+  const mockAddHexPrefix = jest.fn((value: string) => `hex:${value}`);
+  const mockEncodeFunctionCall = jest.fn();
+  const mockEncodeParameter = jest.fn();
+  const mockFindChain = jest.fn();
+  const mockFindChainByServerID = jest.fn();
+  const mockSendRequest = jest.fn();
+  const mockToChecksumAddress = jest.fn(
+    (address: string) => `checksum:${address}`,
+  );
+  const mockUnpadHexString = jest.fn((value: string) => `unpad:${value}`);
+
+  jest.doMock('i18next', () => ({
+    t: (key: string) => key,
+  }));
+  jest.doMock('@/constant', () => ({
+    INTERNAL_REQUEST_SESSION: {
+      icon: 'rabby-icon',
+      name: 'Rabby',
+      origin: 'internal://rabby',
+    },
+  }));
+  jest.doMock('@/utils/chain', () => ({
+    findChain: (...args: unknown[]) => mockFindChain(...args),
+    findChainByServerID: (...args: unknown[]) =>
+      mockFindChainByServerID(...args),
+  }));
+  jest.doMock('@ethereumjs/util', () => ({
+    toChecksumAddress: (...args: unknown[]) => mockToChecksumAddress(...args),
+  }));
+  jest.doMock('ethereumjs-util', () => ({
+    addHexPrefix: (...args: unknown[]) => mockAddHexPrefix(...args),
+    unpadHexString: (...args: unknown[]) => mockUnpadHexString(...args),
+  }));
+  jest.doMock('./sendRequest', () => ({
+    abiCoder: {
+      encodeFunctionCall: (...args: unknown[]) =>
+        mockEncodeFunctionCall(...args),
+      encodeParameter: (...args: unknown[]) => mockEncodeParameter(...args),
+    },
+    sendRequest: (...args: unknown[]) => mockSendRequest(...args),
+  }));
+
+  mockSendRequest.mockResolvedValue({
+    hash: '0xtx',
+  });
+
+  const tokenModule = require('./token') as typeof import('./token');
+
+  return {
+    ...tokenModule,
+    mocks: {
+      mockAddHexPrefix,
+      mockEncodeFunctionCall,
+      mockEncodeParameter,
+      mockFindChain,
+      mockFindChainByServerID,
+      mockSendRequest,
+      mockToChecksumAddress,
+      mockUnpadHexString,
+    },
+  };
+}
+
+describe('core/apis/token', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('rejects sendToken without an account or supported chain', async () => {
+    const { sendToken, mocks } = loadTokenModule();
+
+    await expect(
+      sendToken({
+        account: null as never,
+        chainServerId: 'eth',
+        rawAmount: '1',
+        to: '0xto',
+        tokenId: '0xtoken',
+      }),
+    ).rejects.toThrow('background.error.noCurrentAccount');
+
+    mocks.mockFindChainByServerID.mockReturnValue(null);
+    await expect(
+      sendToken({
+        account: {
+          address: '0xsender',
+        } as never,
+        chainServerId: 'unknown',
+        rawAmount: '1',
+        to: '0xto',
+        tokenId: '0xtoken',
+      }),
+    ).rejects.toThrow('background.error.invalidChainId');
+    expect(mocks.mockSendRequest).not.toHaveBeenCalled();
+  });
+
+  it('builds an ERC20 transfer transaction through sendRequest', async () => {
+    const { sendToken, mocks } = loadTokenModule();
+    const account = {
+      address: '0xsender',
+    };
+    mocks.mockFindChainByServerID.mockReturnValue({
+      id: 1,
+      nativeTokenAddress: '0xeeee',
+    });
+    mocks.mockEncodeFunctionCall.mockReturnValue('0xtransferdata');
+
+    await expect(
+      sendToken({
+        $ctx: {
+          source: 'send-token',
+        },
+        account: account as never,
+        chainServerId: 'eth',
+        isBuild: true,
+        rawAmount: '123',
+        to: '0xrecipient',
+        tokenId: '0xtoken',
+      }),
+    ).resolves.toEqual({
+      hash: '0xtx',
+    });
+
+    expect(mocks.mockEncodeFunctionCall).toHaveBeenCalledWith(
+      {
+        inputs: [
+          {
+            name: 'to',
+            type: 'address',
+          },
+          {
+            name: 'value',
+            type: 'uint256',
+          },
+        ],
+        name: 'transfer',
+        type: 'function',
+      },
+      ['checksum:0xrecipient', '123'],
+    );
+    expect(mocks.mockSendRequest).toHaveBeenCalledWith(
+      {
+        account,
+        data: {
+          $ctx: {
+            source: 'send-token',
+          },
+          method: 'eth_sendTransaction',
+          params: [
+            {
+              chainId: 1,
+              data: '0xtransferdata',
+              from: '0xsender',
+              isSend: true,
+              to: '0xtoken',
+              value: '0x0',
+            },
+          ],
+        },
+        session: {
+          icon: 'rabby-icon',
+          name: 'Rabby',
+          origin: 'internal://rabby',
+        },
+      },
+      true,
+    );
+  });
+
+  it('builds a native token transfer by converting raw amount into transaction value', async () => {
+    const { sendToken, mocks } = loadTokenModule();
+    const account = {
+      address: '0xsender',
+    };
+    mocks.mockFindChainByServerID.mockReturnValue({
+      id: 1,
+      nativeTokenAddress: '0xeeee',
+    });
+    mocks.mockEncodeFunctionCall.mockReturnValue('unused-erc20-data');
+    mocks.mockEncodeParameter.mockReturnValue('000f');
+
+    await sendToken({
+      account: account as never,
+      chainServerId: 'eth',
+      rawAmount: '15',
+      to: '0xrecipient',
+      tokenId: '0xeeee',
+    });
+
+    expect(mocks.mockEncodeParameter).toHaveBeenCalledWith('uint256', '15');
+    expect(mocks.mockUnpadHexString).toHaveBeenCalledWith('000f');
+    expect(mocks.mockAddHexPrefix).toHaveBeenCalledWith('unpad:000f');
+    expect(mocks.mockSendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          params: [
+            expect.not.objectContaining({
+              data: expect.anything(),
+            }),
+          ],
+        }),
+      }),
+      undefined,
+    );
+    expect(mocks.mockSendRequest.mock.calls[0][0].data.params[0]).toEqual({
+      chainId: 1,
+      from: '0xsender',
+      isSend: true,
+      to: '0xrecipient',
+      value: 'hex:unpad:000f',
+    });
+  });
+
+  it('builds an ERC721 safeTransferFrom transaction with build metadata', async () => {
+    const { transferNFT, mocks } = loadTokenModule();
+    const account = {
+      address: '0xsender',
+    };
+    mocks.mockFindChain.mockReturnValue({
+      id: 1,
+    });
+    mocks.mockEncodeFunctionCall.mockReturnValue('0xerc721data');
+
+    await transferNFT(
+      {
+        abi: 'ERC721',
+        account: account as never,
+        chainServerId: 'eth',
+        contractId: '0xnft',
+        to: '0xrecipient',
+        tokenId: '42',
+      },
+      {
+        $ctx: {
+          source: 'nft',
+        },
+        isBuild: true,
+      },
+    );
+
+    expect(mocks.mockEncodeFunctionCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'safeTransferFrom',
+      }),
+      ['checksum:0xsender', 'checksum:0xrecipient', '42'],
+    );
+    expect(mocks.mockSendRequest).toHaveBeenCalledWith(
+      {
+        account,
+        data: {
+          $ctx: {
+            source: 'nft',
+          },
+          chainId: 1,
+          from: '0xsender',
+          method: 'eth_sendTransaction',
+          params: [
+            {
+              chainId: 1,
+              data: '0xerc721data',
+              from: '0xsender',
+              to: '0xnft',
+            },
+          ],
+          to: '0xnft',
+        },
+        session: {
+          icon: 'rabby-icon',
+          name: 'Rabby',
+          origin: 'internal://rabby',
+        },
+      },
+      true,
+    );
+  });
+
+  it('builds an ERC1155 transfer with amount and rejects unknown NFT ABI', async () => {
+    const { transferNFT, mocks } = loadTokenModule();
+    const account = {
+      address: '0xsender',
+    };
+    mocks.mockFindChain.mockReturnValue({
+      id: 1,
+    });
+    mocks.mockEncodeFunctionCall.mockReturnValue('0xerc1155data');
+
+    await transferNFT(
+      {
+        abi: 'ERC1155',
+        account: account as never,
+        amount: 3,
+        chainServerId: 'eth',
+        contractId: '0xnft',
+        to: '0xrecipient',
+        tokenId: '42',
+      },
+      {},
+    );
+
+    expect(mocks.mockEncodeFunctionCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'safeTransferFrom',
+      }),
+      ['checksum:0xsender', 'checksum:0xrecipient', '42', 3, []],
+    );
+    expect(mocks.mockSendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          params: [
+            {
+              chainId: 1,
+              data: '0xerc1155data',
+              from: '0xsender',
+              to: '0xnft',
+            },
+          ],
+        }),
+      }),
+      false,
+    );
+
+    await expect(
+      transferNFT(
+        {
+          abi: 'ERC777' as never,
+          account: account as never,
+          chainServerId: 'eth',
+          contractId: '0xnft',
+          to: '0xrecipient',
+          tokenId: '42',
+        },
+        {},
+      ),
+    ).rejects.toThrow('background.error.unknownAbi');
+  });
+});

--- a/apps/mobile/src/core/apis/transactions.test.ts
+++ b/apps/mobile/src/core/apis/transactions.test.ts
@@ -1,0 +1,338 @@
+const mockRequestETHRpc = jest.fn();
+const mockFetchEstimatedL1Fee = jest.fn();
+const mockFindChain = jest.fn();
+const mockIntToHex = jest.fn((value: number) => `0x${value.toString(16)}`);
+const mockIsTempoChain = jest.fn();
+const mockGetTempoFeeTokenInfo = jest.fn();
+
+jest.mock('@/constant/gas', () => ({
+  CAN_ESTIMATE_L1_FEE_CHAINS: ['op'],
+  DEFAULT_GAS_LIMIT_BUFFER: 0.95,
+  DEFAULT_GAS_LIMIT_RATIO: 1.5,
+  SAFE_GAS_LIMIT_BUFFER: {
+    1: 0.9,
+  },
+  SAFE_GAS_LIMIT_RATIO: {
+    1: 1.2,
+  },
+}));
+
+jest.mock('@/core/apis/provider', () => ({
+  requestETHRpc: (...args: unknown[]) => mockRequestETHRpc(...args),
+  fetchEstimatedL1Fee: (...args: unknown[]) => mockFetchEstimatedL1Fee(...args),
+}));
+
+jest.mock('@/utils/chain', () => ({
+  findChain: (...args: unknown[]) => mockFindChain(...args),
+}));
+
+jest.mock('@/utils/number', () => ({
+  intToHex: (...args: unknown[]) => mockIntToHex(...args),
+}));
+
+jest.mock('@/constant/txGasLimit', () => ({
+  TX_GAS_LIMIT_CHAIN_MAPPING: {
+    LIMITED: 50_000,
+  },
+}));
+
+jest.mock('@/utils/tempo', () => ({
+  getTempoFeeTokenInfo: (...args: unknown[]) =>
+    mockGetTempoFeeTokenInfo(...args),
+  isTempoChain: (...args: unknown[]) => mockIsTempoChain(...args),
+}));
+
+import BigNumber from 'bignumber.js';
+import {
+  calcGasLimit,
+  explainGas,
+  getGasTokenBalance,
+  getNativeTokenBalance,
+} from './transactions';
+
+const account = {
+  address: '0xabc',
+  type: 'SimpleKeyring',
+  brandName: 'SimpleKeyring',
+};
+
+const mainnetChain = {
+  id: 1,
+  enum: 'ETH',
+  serverId: 'eth',
+  nativeTokenAddress: '0xeeee',
+  nativeTokenSymbol: 'ETH',
+  nativeTokenDecimals: 18,
+  nativeTokenLogo: 'eth.png',
+};
+
+describe('core/apis/transactions gas utilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequestETHRpc.mockResolvedValue('0x10');
+    mockFetchEstimatedL1Fee.mockResolvedValue('0');
+    mockFindChain.mockReturnValue(mainnetChain);
+    mockIsTempoChain.mockReturnValue(false);
+    mockGetTempoFeeTokenInfo.mockResolvedValue({
+      rawBalanceHex: '0x20',
+      tokenId: '0xfee',
+      symbol: 'FEE',
+      decimals: 18,
+      logoUrl: 'fee.png',
+    });
+  });
+
+  it('calculates gas limit with chain-specific ratio and clamps to block gas limit buffer', async () => {
+    await expect(
+      calcGasLimit({
+        chain: mainnetChain as never,
+        tx: {
+          gas: '0x5208',
+          value: '0',
+        } as never,
+        gas: new BigNumber(100_000),
+        selectedGas: {
+          price: 1,
+        } as never,
+        nativeTokenBalance: '100000000000000000000',
+        explainTx: {
+          gas: {
+            gas_ratio: 2,
+          },
+        } as never,
+        needRatio: true,
+        account: account as never,
+        preparedBlock: {
+          gasLimit: '110000',
+        } as never,
+      }),
+    ).resolves.toEqual({
+      gasLimit: '0x182b8',
+      recommendGasLimitRatio: 1.2,
+    });
+
+    expect(mockIntToHex).toHaveBeenCalledWith(99_000);
+    expect(mockRequestETHRpc).not.toHaveBeenCalled();
+  });
+
+  it('uses explain gas ratio when estimated cost would exceed available balance', async () => {
+    await expect(
+      calcGasLimit({
+        chain: mainnetChain as never,
+        tx: {
+          gas: '0x0',
+          value: '0',
+        } as never,
+        gas: new BigNumber(100),
+        selectedGas: {
+          price: 10,
+        } as never,
+        nativeTokenBalance: '1',
+        explainTx: {
+          gas: {
+            gas_ratio: 3,
+          },
+        } as never,
+        needRatio: true,
+        account: account as never,
+        preparedBlock: null,
+      }),
+    ).resolves.toEqual({
+      gasLimit: '0x12c',
+      recommendGasLimitRatio: 3,
+    });
+
+    expect(mockRequestETHRpc).toHaveBeenCalledWith(
+      {
+        method: 'eth_getBlockByNumber',
+        params: ['latest', false],
+      },
+      'eth',
+      account,
+    );
+  });
+
+  it('uses mapped single transaction gas limit as an upper bound', async () => {
+    const limitedChain = {
+      ...mainnetChain,
+      enum: 'LIMITED',
+      id: 999,
+    };
+
+    await expect(
+      calcGasLimit({
+        chain: limitedChain as never,
+        tx: {
+          gas: '0x0',
+          value: '0',
+        } as never,
+        gas: new BigNumber(100_000),
+        selectedGas: null,
+        nativeTokenBalance: '100000000000',
+        explainTx: {
+          gas: {
+            gas_ratio: 2,
+          },
+        } as never,
+        needRatio: false,
+        account: account as never,
+      }),
+    ).resolves.toEqual({
+      gasLimit: '0xc350',
+      recommendGasLimitRatio: 1,
+    });
+  });
+
+  it('loads native token gas balance through read-only RPC', async () => {
+    mockRequestETHRpc.mockResolvedValue('0x10');
+
+    await expect(
+      getGasTokenBalance({
+        address: '0xabc',
+        chainId: 1,
+        account: account as never,
+      }),
+    ).resolves.toEqual({
+      rawBalance: '16',
+      token: {
+        tokenId: '0xeeee',
+        symbol: 'ETH',
+        decimals: 18,
+        logoUrl: 'eth.png',
+      },
+    });
+
+    expect(mockRequestETHRpc).toHaveBeenCalledWith(
+      {
+        method: 'eth_getBalance',
+        params: ['0xabc', 'latest'],
+      },
+      'eth',
+      account,
+    );
+    await expect(
+      getNativeTokenBalance({
+        address: '0xabc',
+        chainId: 1,
+        account: account as never,
+      }),
+    ).resolves.toBe('16');
+  });
+
+  it('loads Tempo fee-token gas balance when the chain uses Tempo gas tokens', async () => {
+    mockFindChain.mockReturnValue({
+      ...mainnetChain,
+      serverId: 'tempo',
+    });
+    mockIsTempoChain.mockReturnValue(true);
+
+    await expect(
+      getGasTokenBalance({
+        address: '0xabc',
+        chainId: 1,
+        account: account as never,
+      }),
+    ).resolves.toEqual({
+      rawBalance: '32',
+      token: {
+        tokenId: '0xfee',
+        symbol: 'FEE',
+        decimals: 18,
+        logoUrl: 'fee.png',
+      },
+    });
+
+    expect(mockGetTempoFeeTokenInfo).toHaveBeenCalledWith({
+      account,
+      userAddress: '0xabc',
+      chainServerId: 'tempo',
+    });
+    expect(mockRequestETHRpc).not.toHaveBeenCalled();
+  });
+
+  it('explains gas with prepared L1 fee and token decimal conversion', async () => {
+    mockFindChain.mockReturnValue({
+      ...mainnetChain,
+      enum: 'op',
+      serverId: 'op',
+    });
+
+    const result = await explainGas({
+      gasUsed: 21_000,
+      gasPrice: 1_000_000_000,
+      chainId: 1,
+      nativeTokenPrice: 2,
+      tx: {
+        from: '0xabc',
+      } as never,
+      gasLimit: '30000',
+      account: account as never,
+      preparedL1Fee: '1000000000000000000',
+      gasTokenDecimals: 6,
+    });
+
+    expect(result.gasCostUsd.toFixed()).toBe('2.000042');
+    expect(result.gasCostAmount.toFixed()).toBe('1.000021');
+    expect(result.maxGasCostAmount.toFixed()).toBe('1.00003');
+    expect(result.gasCostRawAmount.toFixed()).toBe('1000021');
+    expect(result.maxGasCostRawAmount.toFixed()).toBe('1000030');
+    expect(mockFetchEstimatedL1Fee).not.toHaveBeenCalled();
+  });
+
+  it('fetches L1 fee when needed and prices Tempo gas at unit price', async () => {
+    mockFindChain.mockReturnValue({
+      ...mainnetChain,
+      enum: 'op',
+      serverId: 'tempo',
+    });
+    mockIsTempoChain.mockReturnValue(true);
+    mockFetchEstimatedL1Fee.mockResolvedValue('1000000000000000000');
+
+    const result = await explainGas({
+      gasUsed: 1,
+      gasPrice: 1_000_000_000,
+      chainId: 1,
+      nativeTokenPrice: 999,
+      tx: {
+        from: '0xabc',
+      } as never,
+      gasLimit: '2',
+      account: account as never,
+    });
+
+    expect(result.gasCostUsd.toFixed()).toBe('1.000000001');
+    expect(mockFetchEstimatedL1Fee).toHaveBeenCalledWith(
+      {
+        txParams: {
+          from: '0xabc',
+        },
+        account,
+      },
+      'op',
+    );
+  });
+
+  it('throws when gas balance or gas explanation chain is not supported', async () => {
+    mockFindChain.mockReturnValue(undefined);
+
+    await expect(
+      getGasTokenBalance({
+        address: '0xabc',
+        chainId: 999,
+        account: account as never,
+      }),
+    ).rejects.toThrow('chain not found');
+
+    await expect(
+      explainGas({
+        gasUsed: 1,
+        gasPrice: 1,
+        chainId: 999,
+        nativeTokenPrice: 1,
+        tx: {} as never,
+        gasLimit: '1',
+        account: account as never,
+      }),
+    ).rejects.toThrow('999 is not found in supported chains');
+  });
+});

--- a/apps/mobile/src/core/services/browserService.test.ts
+++ b/apps/mobile/src/core/services/browserService.test.ts
@@ -1,0 +1,323 @@
+type BrowserStore = {
+  browserBookmarks: {
+    entities: Record<string, Record<string, unknown>>;
+    ids: string[];
+  };
+  browserHistory: {
+    entities: Record<string, Record<string, unknown>>;
+    ids: string[];
+  };
+  browserTabs: {
+    activeTabId: string;
+    tabs: Array<Record<string, unknown>>;
+  };
+  config: {
+    isMigrated?: boolean;
+  };
+};
+
+function createBrowserStore(
+  overrides: Partial<BrowserStore> = {},
+): BrowserStore {
+  return {
+    browserBookmarks: {
+      entities: {},
+      ids: [],
+    },
+    browserHistory: {
+      entities: {},
+      ids: [],
+    },
+    browserTabs: {
+      activeTabId: '',
+      tabs: [],
+    },
+    config: {
+      isMigrated: true,
+    },
+    ...overrides,
+  };
+}
+
+function loadBrowserServiceModule({
+  initialStore = createBrowserStore(),
+  legacyStores = {},
+}: {
+  initialStore?: BrowserStore;
+  legacyStores?: Record<string, unknown>;
+} = {}) {
+  jest.resetModules();
+
+  const mockCaptureException = jest.fn();
+  const mockCopyFile = jest.fn();
+  const mockExists = jest.fn();
+  const mockGetItem = jest.fn((key: string) => legacyStores[key]);
+  const mockGetViewShotFilePath = jest.fn((name: string) => `/doc/${name}`);
+  const mockUnlink = jest.fn();
+
+  class MockStoreServiceBase {
+    store: BrowserStore;
+
+    constructor(
+      _name: string,
+      template: BrowserStore,
+      options: {
+        storageAdapter?: {
+          store?: BrowserStore;
+        };
+      },
+    ) {
+      this.store = options.storageAdapter?.store || template;
+    }
+  }
+
+  jest.doMock('@rabby-wallet/persist-store', () => ({
+    StoreServiceBase: MockStoreServiceBase,
+  }));
+  jest.doMock('@sentry/react-native', () => ({
+    captureException: (...args: unknown[]) => mockCaptureException(...args),
+  }));
+  jest.doMock('@rabby-wallet/base-utils/dist/isomorphic/url', () => ({
+    safeGetOrigin: (url: string) => {
+      try {
+        return new URL(url).origin;
+      } catch {
+        return url;
+      }
+    },
+    safeParseURL: (url: string) => {
+      try {
+        return new URL(url);
+      } catch {
+        return null;
+      }
+    },
+  }));
+  jest.doMock('react-native-fs', () => ({
+    DocumentDirectoryPath: '/doc',
+    copyFile: (...args: unknown[]) => mockCopyFile(...args),
+    exists: (...args: unknown[]) => mockExists(...args),
+    unlink: (...args: unknown[]) => mockUnlink(...args),
+  }));
+  jest.doMock('@/utils/browser', () => ({
+    getViewShotFilePath: (...args: unknown[]) =>
+      mockGetViewShotFilePath(...args),
+  }));
+  jest.doMock('../storage/storeConstant', () => ({
+    APP_STORE_NAMES: {
+      browser: 'browser',
+      browserHistory: 'browserHistory',
+      dapps: 'dapps',
+    },
+  }));
+
+  const { BrowserService } =
+    require('./browserService') as typeof import('./browserService');
+
+  return {
+    BrowserService,
+    mocks: {
+      mockCaptureException,
+      mockCopyFile,
+      mockExists,
+      mockGetItem,
+      mockGetViewShotFilePath,
+      mockUnlink,
+    },
+    storageAdapter: {
+      getItem: mockGetItem,
+      store: initialStore,
+    },
+  };
+}
+
+describe('core/services/browserService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('migrates legacy dapp favorites/history and sanitizes restored tabs', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(2_000_000_000);
+    const { BrowserService, storageAdapter } = loadBrowserServiceModule({
+      initialStore: createBrowserStore({
+        browserTabs: {
+          activeTabId: 'missing-tab',
+          tabs: [
+            {
+              id: 'valid-tab',
+              initialUrl: '',
+              openTime: 1,
+              url: 'https://valid.example/path',
+            },
+            {
+              id: 'invalid-tab',
+              initialUrl: '',
+              openTime: 2,
+              url: 'about:blank',
+            },
+          ],
+        },
+        config: {
+          isMigrated: false,
+        },
+      }),
+      legacyStores: {
+        browserHistory: {
+          browserHistory: {
+            'https://fav.example': {
+              createdAt: 1_999_999_000,
+              origin: 'https://fav.example',
+            },
+          },
+        },
+        dapps: {
+          dapps: {
+            'https://fav.example': {
+              favoriteAt: 1_999_998_000,
+              isFavorite: true,
+              name: 'Favorite',
+              origin: 'https://fav.example',
+            },
+          },
+        },
+      },
+    });
+
+    const service = new BrowserService({
+      storageAdapter: storageAdapter as never,
+    });
+
+    expect(service.store.config.isMigrated).toBe(true);
+    expect(service.store.browserBookmarks).toEqual({
+      entities: {
+        'https://fav.example/': {
+          createdAt: 1_999_998_000,
+          name: 'Favorite',
+          url: 'https://fav.example/',
+        },
+      },
+      ids: ['https://fav.example/'],
+    });
+    expect(service.store.browserHistory).toEqual({
+      entities: {
+        'https://fav.example': {
+          createdAt: 1_999_999_000,
+          name: 'Favorite',
+          url: 'https://fav.example',
+        },
+      },
+      ids: ['https://fav.example'],
+    });
+    expect(service.store.browserTabs).toEqual({
+      activeTabId: 'valid-tab',
+      tabs: [
+        {
+          id: 'valid-tab',
+          initialUrl: 'https://valid.example/path',
+          isTerminate: true,
+          openTime: 1,
+          url: 'https://valid.example/path',
+        },
+      ],
+    });
+  });
+
+  it('keeps bookmark/history entity tools sorted and clearBrowserData resets history and tabs', () => {
+    const { BrowserService } = loadBrowserServiceModule();
+    const service = new BrowserService();
+
+    service.bookmark.addMany([
+      {
+        createdAt: 10,
+        url: 'https://old.example',
+      },
+      {
+        createdAt: 20,
+        url: 'https://new.example',
+      },
+    ]);
+    service.history.addMany([
+      {
+        createdAt: 30,
+        url: 'https://history.example',
+      },
+    ]);
+    service.updateBrowserTabs({
+      activeTabId: 'tab-1',
+      tabs: [
+        {
+          id: 'tab-1',
+          initialUrl: 'https://tab.example',
+          openTime: 1,
+          url: 'https://tab.example',
+        },
+      ],
+    });
+
+    expect(service.store.browserBookmarks.ids).toEqual([
+      'https://new.example',
+      'https://old.example',
+    ]);
+    expect(service.store.browserHistory.ids).toEqual([
+      'https://history.example',
+    ]);
+
+    service.clearBrowserData();
+
+    expect(service.store.browserBookmarks.ids).toEqual([
+      'https://new.example',
+      'https://old.example',
+    ]);
+    expect(service.store.browserHistory).toEqual({
+      entities: {},
+      ids: [],
+    });
+    expect(service.store.browserTabs).toEqual({
+      activeTabId: '',
+      tabs: [],
+    });
+  });
+
+  it('replaces tab screenshots by deleting old files and copying the new one', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(123);
+    const { BrowserService, mocks, storageAdapter } = loadBrowserServiceModule({
+      initialStore: createBrowserStore({
+        browserTabs: {
+          activeTabId: 'tab-1',
+          tabs: [
+            {
+              id: 'tab-1',
+              initialUrl: 'https://tab.example',
+              openTime: 1,
+              url: 'https://tab.example',
+              viewShot: 'old-shot.jpg',
+            },
+          ],
+        },
+      }),
+    });
+    mocks.mockExists.mockImplementation((path: string) =>
+      Promise.resolve(path === '/doc/old-shot.jpg'),
+    );
+    mocks.mockUnlink.mockResolvedValue(undefined);
+    mocks.mockCopyFile.mockResolvedValue(undefined);
+    const service = new BrowserService({
+      storageAdapter: storageAdapter as never,
+    });
+
+    await expect(
+      service.saveScreenshot({
+        tabId: 'tab-1',
+        tempUri: '/tmp/new.jpg',
+      }),
+    ).resolves.toBe('screenshot-tab-1-123.jpg');
+
+    expect(mocks.mockGetViewShotFilePath).toHaveBeenCalledWith('old-shot.jpg');
+    expect(mocks.mockUnlink).toHaveBeenCalledWith('/doc/old-shot.jpg');
+    expect(mocks.mockCopyFile).toHaveBeenCalledWith(
+      '/tmp/new.jpg',
+      '/doc/screenshot-tab-1-123.jpg',
+    );
+  });
+});

--- a/apps/mobile/src/core/services/currencyService.test.ts
+++ b/apps/mobile/src/core/services/currencyService.test.ts
@@ -1,0 +1,130 @@
+type CurrencyStore = {
+  data: {
+    currency: string;
+    currencyList: unknown[];
+    updatedAt: number;
+  };
+};
+
+let activeCurrencyTimers: Array<ReturnType<typeof setInterval> | null> = [];
+
+function loadCurrencyServiceModule(initialStore?: CurrencyStore) {
+  jest.resetModules();
+
+  const mockGetCurrencyList = jest.fn();
+
+  class MockStoreServiceBase {
+    store: CurrencyStore;
+
+    constructor(
+      _name: string,
+      template: CurrencyStore,
+      options: {
+        storageAdapter?: {
+          store?: CurrencyStore;
+        };
+      },
+    ) {
+      this.store = options.storageAdapter?.store || template;
+    }
+  }
+
+  jest.doMock('@rabby-wallet/persist-store', () => ({
+    StoreServiceBase: MockStoreServiceBase,
+  }));
+  jest.doMock('@/core/storage/storeConstant', () => ({
+    APP_STORE_NAMES: {
+      currency: 'currency',
+    },
+  }));
+  jest.doMock('../request', () => ({
+    openapi: {
+      getCurrencyList: (...args: unknown[]) => mockGetCurrencyList(...args),
+    },
+  }));
+
+  const { CurrencyService } =
+    require('./currencyService') as typeof import('./currencyService');
+
+  return {
+    CurrencyService,
+    mocks: {
+      mockGetCurrencyList,
+    },
+    storageAdapter: {
+      store: initialStore,
+    },
+  };
+}
+
+describe('core/services/currencyService', () => {
+  afterEach(() => {
+    activeCurrencyTimers.forEach(timer => {
+      if (timer) {
+        clearInterval(timer);
+      }
+    });
+    activeCurrencyTimers = [];
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('skips non-forced currency refreshes inside the cooldown window', async () => {
+    const now = 1_000_000;
+    jest.useFakeTimers().setSystemTime(new Date(now));
+    const { CurrencyService, mocks, storageAdapter } =
+      loadCurrencyServiceModule({
+        data: {
+          currency: 'USD',
+          currencyList: [],
+          updatedAt: now,
+        },
+      });
+    mocks.mockGetCurrencyList.mockResolvedValue([]);
+
+    const service = new CurrencyService({
+      storageAdapter: storageAdapter as never,
+    });
+    activeCurrencyTimers.push(service.timer);
+    await Promise.resolve();
+    mocks.mockGetCurrencyList.mockClear();
+
+    await service.syncCurrencyList();
+
+    expect(mocks.mockGetCurrencyList).not.toHaveBeenCalled();
+  });
+
+  it('force refreshes the currency list and updates the timestamp', async () => {
+    const now = 2_000_000;
+    jest.useFakeTimers().setSystemTime(new Date(now));
+    const { CurrencyService, mocks, storageAdapter } =
+      loadCurrencyServiceModule({
+        data: {
+          currency: 'USD',
+          currencyList: [],
+          updatedAt: now,
+        },
+      });
+    mocks.mockGetCurrencyList.mockResolvedValue([
+      {
+        code: 'USD',
+        symbol: '$',
+      },
+    ]);
+
+    const service = new CurrencyService({
+      storageAdapter: storageAdapter as never,
+    });
+    activeCurrencyTimers.push(service.timer);
+    await Promise.resolve();
+
+    expect(service.store.data.currencyList).toEqual([
+      {
+        code: 'USD',
+        symbol: '$',
+      },
+    ]);
+    expect(service.store.data.updatedAt).toBe(now);
+  });
+});

--- a/apps/mobile/src/core/services/dappService.test.ts
+++ b/apps/mobile/src/core/services/dappService.test.ts
@@ -1,0 +1,195 @@
+type DappStore = {
+  dapps: Record<string, Record<string, unknown>>;
+};
+
+const INTERNAL_REQUEST_ORIGIN =
+  'chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch';
+
+function loadDappServiceModule(initialStore?: DappStore) {
+  jest.resetModules();
+
+  const mockCaptureException = jest.fn();
+  const mockSafeGetOrigin = jest.fn((url: string) => {
+    try {
+      return new URL(url).origin;
+    } catch {
+      return url;
+    }
+  });
+
+  class MockStoreServiceBase {
+    store: DappStore;
+
+    constructor(
+      _name: string,
+      template: DappStore,
+      options: {
+        storageAdapter?: {
+          store?: DappStore;
+        };
+      },
+    ) {
+      this.store = options.storageAdapter?.store || template;
+    }
+  }
+
+  jest.doMock('@rabby-wallet/persist-store', () => ({
+    StoreServiceBase: MockStoreServiceBase,
+  }));
+  jest.doMock('@sentry/react-native', () => ({
+    captureException: (...args: unknown[]) => mockCaptureException(...args),
+  }));
+  jest.doMock('@rabby-wallet/base-utils/dist/isomorphic/url', () => ({
+    safeGetOrigin: (...args: unknown[]) => mockSafeGetOrigin(...args),
+  }));
+  jest.doMock('@/constant', () => ({
+    INTERNAL_REQUEST_ORIGIN,
+  }));
+  jest.doMock('../storage/storeConstant', () => ({
+    APP_STORE_NAMES: {
+      dapps: 'dapps',
+    },
+  }));
+
+  const { DappService } =
+    require('./dappService') as typeof import('./dappService');
+
+  return {
+    DappService,
+    mocks: {
+      mockCaptureException,
+      mockSafeGetOrigin,
+    },
+    storageAdapter: {
+      store: initialStore,
+    },
+  };
+}
+
+describe('core/services/dappService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('migrates missing or invalid persisted origins and patches known non-dapp sites', () => {
+    const { DappService, storageAdapter } = loadDappServiceModule({
+      dapps: {
+        'https://legacy.example': {
+          chainId: 'eth',
+          name: 'Legacy',
+          origin: 'legacy.example',
+        },
+      },
+    });
+
+    const service = new DappService({
+      storageAdapter: storageAdapter as never,
+    });
+
+    expect(service.getDapp('https://legacy.example')).toEqual({
+      chainId: 'eth',
+      name: 'Legacy',
+      origin: 'https://legacy.example',
+    });
+    expect(service.getDapp('https://www.google.com')?.isDapp).toBe(false);
+    expect(service.getDapp('https://x.com')?.isDapp).toBe(false);
+    expect(service.getDapp('https://github.com')?.isDapp).toBe(false);
+  });
+
+  it('adds, updates, removes, and rejects malformed dapp origins', () => {
+    const { DappService, mocks } = loadDappServiceModule();
+    const service = new DappService();
+
+    service.addDapp([
+      {
+        chainId: 'eth',
+        isConnected: true,
+        name: 'App',
+        origin: 'https://app.example',
+      },
+      {
+        chainId: 'eth',
+        name: 'Other',
+        origin: 'https://other.example',
+      },
+    ] as never);
+    service.updateDapp({
+      chainId: 'arb',
+      icon: 'next-icon',
+      name: 'Updated App',
+      origin: 'https://app.example',
+    } as never);
+
+    expect(service.getDapp('https://app.example')).toEqual({
+      chainId: 'arb',
+      icon: 'next-icon',
+      isConnected: true,
+      name: 'Updated App',
+      origin: 'https://app.example',
+    });
+
+    service.updateDapp({
+      chainId: 'eth',
+      name: 'Bad',
+      origin: 'app.example',
+    } as never);
+    expect(mocks.mockCaptureException).toHaveBeenCalledWith(expect.any(Error), {
+      extra: {
+        dapp: {
+          chainId: 'eth',
+          name: 'Bad',
+          origin: 'app.example',
+        },
+      },
+      tags: {
+        scene: 'dappService',
+      },
+    });
+    expect(service.getDapp('app.example')).toBeUndefined();
+
+    service.removeDapp('https://other.example');
+    expect(service.getDapp('https://other.example')).toBeUndefined();
+  });
+
+  it('tracks favorites, connected dapps, disconnects, and permission checks by safe origin', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(123);
+    const { DappService, mocks } = loadDappServiceModule();
+    const service = new DappService();
+
+    service.addDapp({
+      chainId: 'eth',
+      isConnected: true,
+      name: 'App',
+      origin: 'https://app.example',
+    } as never);
+    service.updateFavorite('https://app.example', true);
+
+    expect(service.getFavoriteDapps()).toEqual([
+      expect.objectContaining({
+        favoriteAt: 123,
+        isFavorite: true,
+        origin: 'https://app.example',
+      }),
+    ]);
+    expect(service.getConnectedDapp('https://app.example')).toEqual(
+      expect.objectContaining({
+        isConnected: true,
+      }),
+    );
+    expect(service.hasPermission(INTERNAL_REQUEST_ORIGIN)).toBe(true);
+    expect(service.hasPermission('https://app.example/swap?chain=eth')).toBe(
+      true,
+    );
+    expect(mocks.mockSafeGetOrigin).toHaveBeenCalledWith(
+      'https://app.example/swap?chain=eth',
+    );
+
+    service.disconnect('https://app.example');
+
+    expect(service.getConnectedDapp('https://app.example')).toBeNull();
+    expect(service.hasPermission('https://app.example/swap?chain=eth')).toBe(
+      false,
+    );
+  });
+});

--- a/apps/mobile/src/core/services/metamaskModeService.test.ts
+++ b/apps/mobile/src/core/services/metamaskModeService.test.ts
@@ -1,0 +1,122 @@
+type MetamaskModeStore = {
+  data: {
+    sites: string[];
+    updatedAt: number;
+  };
+};
+
+let activeMetamaskTimers: Array<ReturnType<typeof setInterval> | null> = [];
+
+function loadMetamaskModeServiceModule(initialStore?: MetamaskModeStore) {
+  jest.resetModules();
+
+  const mockAxiosGet = jest.fn();
+
+  class MockStoreServiceBase {
+    store: MetamaskModeStore;
+
+    constructor(
+      _name: string,
+      template: MetamaskModeStore,
+      options: {
+        storageAdapter?: {
+          store?: MetamaskModeStore;
+        };
+      },
+    ) {
+      this.store = options.storageAdapter?.store || template;
+    }
+  }
+
+  jest.doMock('@rabby-wallet/persist-store', () => ({
+    StoreServiceBase: MockStoreServiceBase,
+  }));
+  jest.doMock('@/core/storage/storeConstant', () => ({
+    APP_STORE_NAMES: {
+      metamaskMode: 'metamaskMode',
+    },
+  }));
+  jest.doMock('axios', () => ({
+    get: (...args: unknown[]) => mockAxiosGet(...args),
+  }));
+
+  const { MetamaskModeService } =
+    require('./metamaskModeService') as typeof import('./metamaskModeService');
+
+  return {
+    MetamaskModeService,
+    mocks: {
+      mockAxiosGet,
+    },
+    storageAdapter: {
+      store: initialStore,
+    },
+  };
+}
+
+describe('core/services/metamaskModeService', () => {
+  afterEach(() => {
+    activeMetamaskTimers.forEach(timer => {
+      if (timer) {
+        clearInterval(timer);
+      }
+    });
+    activeMetamaskTimers = [];
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('skips remote refreshes inside the cooldown window and matches origins without protocol', async () => {
+    const now = 3_000_000;
+    jest.useFakeTimers().setSystemTime(new Date(now));
+    const { MetamaskModeService, mocks, storageAdapter } =
+      loadMetamaskModeServiceModule({
+        data: {
+          sites: ['fake.example'],
+          updatedAt: now,
+        },
+      });
+
+    const service = new MetamaskModeService({
+      storageAdapter: storageAdapter as never,
+    });
+    activeMetamaskTimers.push(service.timer);
+    await service.syncMetamaskModeList();
+
+    expect(mocks.mockAxiosGet).not.toHaveBeenCalled();
+    expect(service.checkIsMetamaskMode('https://fake.example')).toBe(true);
+    expect(service.checkIsMetamaskMode('http://fake.example')).toBe(true);
+    expect(service.checkIsMetamaskMode('https://other.example')).toBe(false);
+  });
+
+  it('refreshes the metamask-mode site list after the cooldown expires', async () => {
+    const now = 4_000_000;
+    jest.useFakeTimers().setSystemTime(new Date(now));
+    const { MetamaskModeService, mocks, storageAdapter } =
+      loadMetamaskModeServiceModule({
+        data: {
+          sites: [],
+          updatedAt: now,
+        },
+      });
+    mocks.mockAxiosGet.mockResolvedValue({
+      data: ['next.example'],
+    });
+    const service = new MetamaskModeService({
+      storageAdapter: storageAdapter as never,
+    });
+    activeMetamaskTimers.push(service.timer);
+    service.store.data.updatedAt = 0;
+
+    await service.syncMetamaskModeList();
+
+    expect(mocks.mockAxiosGet).toHaveBeenCalledWith(
+      'https://static.debank.com/fake_mm_dapps.json',
+    );
+    expect(service.store.data).toEqual({
+      sites: ['next.example'],
+      updatedAt: now,
+    });
+  });
+});

--- a/apps/mobile/src/core/services/offlineChain.test.ts
+++ b/apps/mobile/src/core/services/offlineChain.test.ts
@@ -1,0 +1,82 @@
+function loadOfflineChainModule({
+  isNonPublicProductionEnv,
+  persistedStore,
+}: {
+  isNonPublicProductionEnv: boolean;
+  persistedStore?: {
+    closeTipsChains: string[];
+  };
+}) {
+  jest.resetModules();
+
+  const mockCreatePersistStore = jest.fn(() => persistedStore);
+
+  jest.doMock('@rabby-wallet/persist-store', () => ({
+    __esModule: true,
+    default: (...args: unknown[]) => mockCreatePersistStore(...args),
+  }));
+  jest.doMock('@/core/storage/storeConstant', () => ({
+    APP_STORE_NAMES: {
+      offlineChain: 'offlineChain',
+    },
+  }));
+  jest.doMock('@/constant', () => ({
+    isNonPublicProductionEnv,
+  }));
+
+  const { OfflineChainService } =
+    require('./offlineChain') as typeof import('./offlineChain');
+
+  return {
+    OfflineChainService,
+    mocks: {
+      mockCreatePersistStore,
+    },
+  };
+}
+
+describe('core/services/offlineChain', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('appends closed-tip chains to the persisted list', () => {
+    const { OfflineChainService } = loadOfflineChainModule({
+      isNonPublicProductionEnv: false,
+      persistedStore: {
+        closeTipsChains: ['eth'],
+      },
+    });
+    const service = new OfflineChainService();
+
+    service.setCloseTipsChains(['arb', 'base']);
+
+    expect(service.getCloseTipsChains()).toEqual(['eth', 'arb', 'base']);
+  });
+
+  it('only allows mock clearing closed-tip chains in non-public production environments', () => {
+    const publicEnv = loadOfflineChainModule({
+      isNonPublicProductionEnv: false,
+      persistedStore: {
+        closeTipsChains: ['eth'],
+      },
+    });
+    const publicService = new publicEnv.OfflineChainService();
+
+    publicService.mockClearCloseTipsChains();
+
+    expect(publicService.getCloseTipsChains()).toEqual(['eth']);
+
+    const nonPublicEnv = loadOfflineChainModule({
+      isNonPublicProductionEnv: true,
+      persistedStore: {
+        closeTipsChains: ['eth'],
+      },
+    });
+    const nonPublicService = new nonPublicEnv.OfflineChainService();
+
+    nonPublicService.mockClearCloseTipsChains();
+
+    expect(nonPublicService.getCloseTipsChains()).toEqual([]);
+  });
+});

--- a/apps/mobile/src/core/services/syncChainService.test.ts
+++ b/apps/mobile/src/core/services/syncChainService.test.ts
@@ -1,0 +1,187 @@
+type SyncChainStore = {
+  data: {
+    chains: Array<Record<string, unknown>>;
+    updatedAt: number;
+  };
+};
+
+let activeTimers: Array<ReturnType<typeof setInterval> | null> = [];
+
+function loadSyncChainServiceModule(initialStore?: SyncChainStore) {
+  jest.resetModules();
+
+  const mockAxiosGet = jest.fn();
+  const mockSupportedChainToChain = jest.fn(
+    (chain: Record<string, unknown>) => ({
+      enum: chain.enum,
+      id: chain.id,
+      name: chain.name,
+      serverId: chain.server_id,
+    }),
+  );
+  const mockUpdateChainStore = jest.fn();
+
+  class MockStoreServiceBase {
+    store: SyncChainStore;
+
+    constructor(
+      _name: string,
+      template: SyncChainStore,
+      options: {
+        storageAdapter?: {
+          store?: SyncChainStore;
+        };
+      },
+    ) {
+      this.store = options.storageAdapter?.store || template;
+    }
+  }
+
+  jest.doMock('@rabby-wallet/persist-store', () => ({
+    StoreServiceBase: MockStoreServiceBase,
+  }));
+  jest.doMock('@/core/storage/storeConstant', () => ({
+    APP_STORE_NAMES: {
+      syncChain: 'syncChain',
+    },
+  }));
+  jest.doMock('axios', () => ({
+    get: (...args: unknown[]) => mockAxiosGet(...args),
+  }));
+  jest.doMock('@/isomorphic/chain', () => ({
+    supportedChainToChain: (...args: unknown[]) =>
+      mockSupportedChainToChain(...args),
+  }));
+  jest.doMock('@/constant/chains', () => ({
+    updateChainStore: (...args: unknown[]) => mockUpdateChainStore(...args),
+  }));
+
+  const { SyncChainService } =
+    require('./syncChainService') as typeof import('./syncChainService');
+
+  return {
+    SyncChainService,
+    mocks: {
+      mockAxiosGet,
+      mockSupportedChainToChain,
+      mockUpdateChainStore,
+    },
+    storageAdapter: {
+      store: initialStore,
+    },
+  };
+}
+
+describe('core/services/syncChainService', () => {
+  afterEach(() => {
+    activeTimers.forEach(timer => {
+      if (timer) {
+        clearInterval(timer);
+      }
+    });
+    activeTimers = [];
+    jest.useRealTimers();
+    jest.resetModules();
+  });
+
+  it('hydrates the global chain store from cached chains and skips refresh inside the cooldown window', async () => {
+    const now = 5_000_000;
+    jest.useFakeTimers().setSystemTime(new Date(now));
+    const cachedChains = [
+      {
+        enum: 'eth',
+        id: 1,
+        name: 'Ethereum',
+        serverId: 'eth',
+      },
+    ];
+    const { SyncChainService, mocks, storageAdapter } =
+      loadSyncChainServiceModule({
+        data: {
+          chains: cachedChains,
+          updatedAt: now,
+        },
+      });
+
+    const service = new SyncChainService({
+      storageAdapter: storageAdapter as never,
+    });
+    activeTimers.push(service.timer);
+    await service.syncMainnetChainList();
+
+    expect(mocks.mockUpdateChainStore).toHaveBeenCalledWith({
+      mainnetList: cachedChains,
+    });
+    expect(mocks.mockAxiosGet).not.toHaveBeenCalled();
+  });
+
+  it('fetches supported chains after cooldown, filters disabled chains, converts them, and updates storage', async () => {
+    const now = 6_000_000;
+    jest.useFakeTimers().setSystemTime(new Date(now));
+    const { SyncChainService, mocks, storageAdapter } =
+      loadSyncChainServiceModule({
+        data: {
+          chains: [],
+          updatedAt: now,
+        },
+      });
+    mocks.mockAxiosGet.mockResolvedValue({
+      data: [
+        {
+          enum: 'eth',
+          id: 1,
+          is_disabled: false,
+          name: 'Ethereum',
+          server_id: 'eth',
+        },
+        {
+          enum: 'disabled',
+          id: 999,
+          is_disabled: true,
+          name: 'Disabled',
+          server_id: 'disabled',
+        },
+      ],
+    });
+    const service = new SyncChainService({
+      storageAdapter: storageAdapter as never,
+    });
+    activeTimers.push(service.timer);
+    service.store.data.updatedAt = 0;
+
+    await service.syncMainnetChainList();
+
+    expect(mocks.mockAxiosGet).toHaveBeenCalledWith(
+      'https://static.debank.com/supported_chains.json',
+    );
+    expect(mocks.mockSupportedChainToChain).toHaveBeenCalledTimes(1);
+    expect(mocks.mockSupportedChainToChain).toHaveBeenCalledWith({
+      enum: 'eth',
+      id: 1,
+      is_disabled: false,
+      name: 'Ethereum',
+      server_id: 'eth',
+    });
+    expect(mocks.mockUpdateChainStore).toHaveBeenCalledWith({
+      mainnetList: [
+        {
+          enum: 'eth',
+          id: 1,
+          name: 'Ethereum',
+          serverId: 'eth',
+        },
+      ],
+    });
+    expect(service.store.data).toEqual({
+      chains: [
+        {
+          enum: 'eth',
+          id: 1,
+          name: 'Ethereum',
+          serverId: 'eth',
+        },
+      ],
+      updatedAt: now,
+    });
+  });
+});

--- a/apps/mobile/src/core/services/whitelist.test.ts
+++ b/apps/mobile/src/core/services/whitelist.test.ts
@@ -1,0 +1,129 @@
+const ADDRESS_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const ADDRESS_A_UPPER = '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const ADDRESS_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const ADDRESS_B_UPPER = '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+type WhitelistStore = {
+  enabled: boolean;
+  whitelists: Array<
+    | string
+    | {
+        addedAt?: number | null;
+        address: string;
+      }
+  >;
+};
+
+function loadWhitelistServiceModule(persistedStore?: WhitelistStore) {
+  jest.resetModules();
+
+  const mockCreatePersistStore = jest.fn(() => persistedStore);
+  const mockIsSameAddress = jest.fn(
+    (left?: string, right?: string) =>
+      (left || '').toLowerCase() === (right || '').toLowerCase(),
+  );
+
+  jest.doMock('@rabby-wallet/base-utils', () => ({
+    addressUtils: {
+      isSameAddress: (...args: unknown[]) => mockIsSameAddress(...args),
+    },
+  }));
+  jest.doMock('@rabby-wallet/persist-store', () => ({
+    __esModule: true,
+    default: (...args: unknown[]) => mockCreatePersistStore(...args),
+  }));
+  jest.doMock('@/core/storage/storeConstant', () => ({
+    APP_STORE_NAMES: {
+      whitelist: 'whitelist',
+    },
+  }));
+
+  const { WhitelistService } =
+    require('./whitelist') as typeof import('./whitelist');
+
+  return {
+    WhitelistService,
+    mocks: {
+      mockCreatePersistStore,
+      mockIsSameAddress,
+    },
+  };
+}
+
+describe('core/services/whitelist', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('normalizes persisted whitelist records and forces the whitelist feature enabled on construction', () => {
+    const { WhitelistService } = loadWhitelistServiceModule({
+      enabled: false,
+      whitelists: [
+        ADDRESS_A_UPPER,
+        {
+          addedAt: 1,
+          address: ADDRESS_A,
+        },
+        {
+          addedAt: 2,
+          address: ADDRESS_B_UPPER,
+        },
+      ],
+    });
+
+    const service = new WhitelistService();
+
+    expect(service.isWhitelistEnabled()).toBe(true);
+    expect(service.getWhitelistRecords()).toEqual([
+      {
+        address: ADDRESS_A,
+      },
+      {
+        addedAt: 2,
+        address: ADDRESS_B,
+      },
+    ]);
+    expect(service.getWhitelist()).toEqual([ADDRESS_A, ADDRESS_B]);
+  });
+
+  it('adds, syncs, checks, removes, and toggles whitelist records case-insensitively', () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(100);
+    const { WhitelistService } = loadWhitelistServiceModule();
+    const service = new WhitelistService();
+
+    service.addWhitelist(ADDRESS_A_UPPER);
+    service.addWhitelist(ADDRESS_A);
+
+    expect(service.isInWhiteList(ADDRESS_A_UPPER)).toBe(true);
+    expect(service.getWhitelistRecords()).toEqual([
+      {
+        addedAt: 100,
+        address: ADDRESS_A,
+      },
+    ]);
+
+    nowSpy.mockReturnValue(200);
+    service.setWhitelist([ADDRESS_A_UPPER, ADDRESS_B_UPPER]);
+
+    expect(service.getWhitelistRecords()).toEqual([
+      {
+        addedAt: 100,
+        address: ADDRESS_A,
+      },
+      {
+        addedAt: 200,
+        address: ADDRESS_B,
+      },
+    ]);
+
+    service.removeWhitelist(ADDRESS_A_UPPER);
+    expect(service.isInWhiteList(ADDRESS_A)).toBe(false);
+    expect(service.getWhitelist()).toEqual([ADDRESS_B]);
+
+    service.disableWhiteList();
+    expect(service.isWhitelistEnabled()).toBe(false);
+    service.enableWhitelist();
+    expect(service.isWhitelistEnabled()).toBe(true);
+  });
+});

--- a/apps/mobile/src/core/utils/createEntryAdapter.test.ts
+++ b/apps/mobile/src/core/utils/createEntryAdapter.test.ts
@@ -1,0 +1,151 @@
+import { createEntityAdapter, createEntityTools } from './createEntryAdapter';
+
+type Item = {
+  id: string;
+  name: string;
+  score: number;
+};
+
+function createItem(id: string, score: number): Item {
+  return {
+    id,
+    name: `item-${id}`,
+    score,
+  };
+}
+
+describe('core/utils/createEntryAdapter', () => {
+  it('adds entities by selected id, skips duplicates, sorts ids, and exposes selectors', () => {
+    const actions: string[] = [];
+    const adapter = createEntityAdapter<Item>({
+      onStateChange: (_state, action) => actions.push(action),
+      selectId: item => item.id,
+      sortComparer: (left, right) => right.score - left.score,
+    });
+
+    let state = adapter.getInitialState({
+      loaded: true,
+    });
+    state = adapter.addMany(state, [
+      createItem('low', 1),
+      createItem('high', 3),
+      createItem('mid', 2),
+    ]);
+    const duplicateState = adapter.addOne(state, createItem('mid', 99));
+
+    expect(duplicateState).toBe(state);
+    expect(adapter.getSelectors().selectIds(state)).toEqual([
+      'high',
+      'mid',
+      'low',
+    ]);
+    expect(
+      adapter
+        .getSelectors()
+        .selectAll(state)
+        .map(item => item.score),
+    ).toEqual([3, 2, 1]);
+    expect(adapter.getSelectors().selectById(state, 'mid')).toEqual(
+      createItem('mid', 2),
+    );
+    expect(adapter.getSelectors().selectTotal(state)).toBe(3);
+    expect(state.loaded).toBe(true);
+    expect(actions).toEqual(['init', 'addOne', 'addOne', 'addOne', 'addMany']);
+  });
+
+  it('updates, upserts, removes, and resets normalized entity state', () => {
+    const adapter = createEntityAdapter<Item>({
+      selectId: item => item.id,
+      sortComparer: (left, right) => right.score - left.score,
+    });
+    let state = adapter.getInitialState();
+
+    state = adapter.setAll(state, [
+      createItem('a', 1),
+      createItem('b', 2),
+      createItem('c', 3),
+    ]);
+    state = adapter.updateOne(state, {
+      changes: {
+        score: 10,
+      },
+      id: 'a',
+    });
+    state = adapter.upsertMany(state, [
+      {
+        ...createItem('b', 2),
+        name: 'updated-b',
+        score: 20,
+      },
+      createItem('d', 4),
+    ]);
+    state = adapter.removeMany(state, ['c', 'missing']);
+
+    expect(state.ids).toEqual(['b', 'a', 'd']);
+    expect(state.entities.b).toEqual({
+      id: 'b',
+      name: 'updated-b',
+      score: 20,
+    });
+    expect(state.entities.c).toBeUndefined();
+
+    state = adapter.removeOne(state, 'a');
+
+    expect(state.ids).toEqual(['b', 'd']);
+    expect(state.entities.a).toBeUndefined();
+  });
+
+  it('createEntityTools keeps internal state and writes changes through adapter callbacks', () => {
+    const snapshots: string[][] = [];
+    const adapter = createEntityAdapter<Item>({
+      onStateChange: state => snapshots.push([...state.ids]),
+      selectId: item => item.id,
+      sortComparer: (left, right) => right.score - left.score,
+    });
+    const tools = createEntityTools(adapter);
+
+    tools.addMany([createItem('a', 1), createItem('b', 2)]);
+    tools.upsertOne({
+      ...createItem('a', 3),
+      name: 'updated-a',
+    });
+
+    expect(tools.selectors.selectIds()).toEqual(['a', 'b']);
+    expect(tools.selectors.selectById('a')).toEqual({
+      id: 'a',
+      name: 'updated-a',
+      score: 3,
+    });
+    expect(tools.selectors.selectTotal()).toBe(2);
+
+    tools.reset({
+      entities: {
+        c: createItem('c', 5),
+      },
+      ids: ['c'],
+    });
+
+    expect(tools.selectors.selectAll()).toEqual([createItem('c', 5)]);
+    expect(snapshots).toContainEqual(['a', 'b']);
+  });
+
+  it('continues adapter operations when onStateChange throws', () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const adapter = createEntityAdapter<Item>({
+      onStateChange: () => {
+        throw new Error('listener failed');
+      },
+      selectId: item => item.id,
+    });
+
+    const state = adapter.addOne(adapter.getInitialState(), createItem('a', 1));
+
+    expect(state.entities.a).toEqual(createItem('a', 1));
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Error in onStateChange callback:',
+      expect.any(Error),
+    );
+  });
+});

--- a/apps/mobile/src/utils/walletUnlockGuard.test.ts
+++ b/apps/mobile/src/utils/walletUnlockGuard.test.ts
@@ -1,0 +1,103 @@
+function loadWalletUnlockGuardModule(isUnlocked: boolean) {
+  jest.resetModules();
+
+  const mockIsUnlocked = jest.fn(() => isUnlocked);
+
+  jest.doMock('@/core/apis/lock', () => ({
+    isUnlocked: (...args: unknown[]) => mockIsUnlocked(...args),
+  }));
+  jest.doMock('@rabby-wallet/keyring-utils', () => ({
+    KEYRING_TYPE: {
+      HdKeyring: 'HdKeyring',
+      SimpleKeyring: 'SimpleKeyring',
+      WatchAddressKeyring: 'WatchAddressKeyring',
+    },
+  }));
+
+  const walletUnlockGuard =
+    require('./walletUnlockGuard') as typeof import('./walletUnlockGuard');
+
+  return {
+    ...walletUnlockGuard,
+    mocks: {
+      mockIsUnlocked,
+    },
+  };
+}
+
+describe('utils/walletUnlockGuard', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('resolves immediately when the wallet is already unlocked', async () => {
+    const { ensureWalletUnlocked, mocks } = loadWalletUnlockGuardModule(true);
+
+    await expect(ensureWalletUnlocked()).resolves.toBeUndefined();
+
+    expect(mocks.mockIsUnlocked).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws the unlock sentinel error when locked and no requester is registered', async () => {
+    const { ensureWalletUnlocked, isWalletUnlockRequired } =
+      loadWalletUnlockGuardModule(false);
+
+    await expect(ensureWalletUnlocked()).rejects.toThrow(
+      'background.error.unlock',
+    );
+    expect(isWalletUnlockRequired(new Error('background.error.unlock'))).toBe(
+      true,
+    );
+    expect(isWalletUnlockRequired(new Error('other'))).toBe(false);
+  });
+
+  it('delegates to the registered requester when locked', async () => {
+    const { ensureWalletUnlocked, setWalletUnlockRequester } =
+      loadWalletUnlockGuardModule(false);
+    const requester = jest.fn().mockResolvedValue(undefined);
+
+    setWalletUnlockRequester(requester);
+
+    await expect(ensureWalletUnlocked()).resolves.toBeUndefined();
+    expect(requester).toHaveBeenCalledTimes(1);
+  });
+
+  it('classifies only sensitive keyring types as requiring unlock', () => {
+    const { isSensitiveKeyringType } = loadWalletUnlockGuardModule(true);
+
+    expect(isSensitiveKeyringType('SimpleKeyring')).toBe(true);
+    expect(isSensitiveKeyringType('HdKeyring')).toBe(true);
+    expect(isSensitiveKeyringType('WatchAddressKeyring')).toBe(false);
+    expect(isSensitiveKeyringType(undefined)).toBe(false);
+  });
+
+  it('wraps async work with unconditional and conditional unlock checks', async () => {
+    const unlocked = loadWalletUnlockGuardModule(true);
+    const guarded = jest.fn(async (value: number) => value + 1);
+
+    await expect(unlocked.withWalletUnlock(guarded)(1)).resolves.toBe(2);
+    expect(guarded).toHaveBeenCalledWith(1);
+    expect(unlocked.mocks.mockIsUnlocked).toHaveBeenCalledTimes(1);
+
+    const locked = loadWalletUnlockGuardModule(false);
+    const requester = jest.fn().mockResolvedValue(undefined);
+    const conditionalGuarded = jest.fn(async (value: number) => value * 2);
+    locked.setWalletUnlockRequester(requester);
+
+    await expect(
+      locked.withWalletUnlockIf(
+        (value: number) => value > 0,
+        conditionalGuarded,
+      )(2),
+    ).resolves.toBe(4);
+    await expect(
+      locked.withWalletUnlockIf(
+        (value: number) => value > 0,
+        conditionalGuarded,
+      )(0),
+    ).resolves.toBe(0);
+
+    expect(requester).toHaveBeenCalledTimes(1);
+    expect(conditionalGuarded).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Runtime impact: test-only

This aggregates the 17 confirmed test-only PRs into one PR:

#1826, #1827, #1828, #1829, #1830, #1831, #1832, #1833, #1834, #1835, #1838, #1839, #1840, #1841, #1842, #1844, #1845

Coverage:
- core API facade tests: lock, transactions, approvals, portfolio, address, custom RPC/testnet, read-only RPC/recommend nonce, token, perps, auto-lock/device
- core service behavior tests: whitelist, network preferences, dapp, browser, sync chain
- core utility/guard tests: entity adapter, wallet unlock guard

Verification:
- Changed files are all `*.test.ts` files.
- Targeted Jest passed for all 22 added test files: 22 suites, 92 tests.

Notes:
- This PR replaces the individual small PRs above; those will be closed after this aggregate PR exists.