### PR TITLE
fix: sync notification openapi credentials

### DIFF
--- a/apps/mobile/src/core/notifications/openapi.ts
+++ b/apps/mobile/src/core/notifications/openapi.ts
@@ -1,13 +1,7 @@
 import { OpenApiService } from '@rabby-wallet/rabby-api';
-import { OpenApiStore } from '../services/openapiStore';
+import { notificationOpenApiStore } from '../services/openapiStore';
 import { SignApiPlugin } from '../request';
-import {
-  APP_VERSIONS,
-  APPLICATION_ID,
-  INITIAL_OPENAPI_URL,
-  isNonPublicProductionEnv,
-} from '@/constant';
-import { APP_STORE_NAMES } from '../storage/storeConstant';
+import { APP_VERSIONS, APPLICATION_ID } from '@/constant';
 import { makeDeviceUUID } from '../apis/device';
 import { TxHistoryResult } from '@rabby-wallet/rabby-api/dist/types';
 import { AppState } from 'react-native';
@@ -93,15 +87,8 @@ class NotificationsOpenApiService extends OpenApiService {
   }
 }
 
-const apiStore = new OpenApiStore({
-  name: APP_STORE_NAMES.notificationOpenapi,
-});
-apiStore.store.api.host = isNonPublicProductionEnv
-  ? INITIAL_OPENAPI_URL.replace('app-api.', 'alpha.')
-  : INITIAL_OPENAPI_URL;
-
 export const notificationOpenapi = new NotificationsOpenApiService({
-  store: apiStore,
+  store: notificationOpenApiStore,
   plugin: SignApiPlugin,
   clientName: 'rabbymobile',
   clientVersion: APP_VERSIONS.fromJs,

--- a/apps/mobile/src/core/request.ts
+++ b/apps/mobile/src/core/request.ts
@@ -12,6 +12,7 @@ const SIGN_HDS = [
   'x-api-ver',
   'x-api-sign',
 ] as const;
+const API_KEY_HDS = ['X-API-Key', 'X-API-Time'] as const;
 
 export const SignApiPlugin: RabbyApiPlugin = {
   async onSignRequest(ctx) {
@@ -20,6 +21,14 @@ export const SignApiPlugin: RabbyApiPlugin = {
     const res = gS(params, method, url);
 
     config.headers = config.headers || {};
+    if (openApiStore.apiKey && openApiStore.apiTime) {
+      config.headers[API_KEY_HDS[0]] = openApiStore.apiKey;
+      config.headers[API_KEY_HDS[1]] = openApiStore.apiTime;
+    } else {
+      delete config.headers[API_KEY_HDS[0]];
+      delete config.headers[API_KEY_HDS[1]];
+    }
+
     config.headers[SIGN_HDS[0]] = encodeURIComponent(res.ts);
     config.headers[SIGN_HDS[1]] = encodeURIComponent(res.nonce);
     config.headers[SIGN_HDS[2]] = encodeURIComponent(res.version);

--- a/apps/mobile/src/core/services/openapiStore.ts
+++ b/apps/mobile/src/core/services/openapiStore.ts
@@ -1,4 +1,4 @@
-import { INITIAL_OPENAPI_URL } from '@/constant';
+import { INITIAL_OPENAPI_URL, isNonPublicProductionEnv } from '@/constant';
 import type { StorageAdapaterOptions } from '@rabby-wallet/persist-store';
 import createPersistStore from '@rabby-wallet/persist-store';
 import { APP_STORE_NAMES } from '../storage/storeConstant';
@@ -14,6 +14,8 @@ export type Store = {
 };
 
 export class OpenApiStore {
+  private credentialsFrom?: OpenApiStore;
+
   store: Store = {
     api: {
       host: INITIAL_OPENAPI_URL,
@@ -24,9 +26,11 @@ export class OpenApiStore {
   constructor(
     options?: StorageAdapaterOptions & {
       name?: APP_STORE_NAMES.openapi | APP_STORE_NAMES.notificationOpenapi;
+      credentialsFrom?: OpenApiStore;
     },
   ) {
-    const { name = APP_STORE_NAMES.openapi } = options || {};
+    const { name = APP_STORE_NAMES.openapi, credentialsFrom } = options || {};
+    this.credentialsFrom = credentialsFrom;
     const storage = createPersistStore<Store>(
       {
         name: name,
@@ -44,7 +48,7 @@ export class OpenApiStore {
     );
 
     this.store = storage || this.store;
-    if (!this.store.apiKey) {
+    if (!this.apiKey) {
       this.generateAPIKey();
     }
   }
@@ -60,28 +64,56 @@ export class OpenApiStore {
   }
 
   get apiKey() {
+    if (this.credentialsFrom) {
+      return this.credentialsFrom.apiKey;
+    }
+
     return this.store.apiKey;
   }
 
   set apiKey(value: string | null) {
+    if (this.credentialsFrom) {
+      this.credentialsFrom.apiKey = value;
+      return;
+    }
+
     this.store.apiKey = value;
   }
 
   get apiTime() {
+    if (this.credentialsFrom) {
+      return this.credentialsFrom.apiTime;
+    }
+
     return this.store.apiTime;
   }
 
   set apiTime(value: number | null) {
+    if (this.credentialsFrom) {
+      this.credentialsFrom.apiTime = value;
+      return;
+    }
+
     this.store.apiTime = value;
   }
 
   generateAPIKey = () => {
     const uuid = uuidv4();
-    this.store.apiKey = uuid;
-    this.store.apiTime = Math.floor(Date.now() / 1000);
+    this.apiKey = uuid;
+    this.apiTime = Math.floor(Date.now() / 1000);
   };
 }
 
 export const openApiStore = new OpenApiStore({
   storageAdapter: appStorage,
 });
+
+export const notificationOpenApiStore = new OpenApiStore({
+  name: APP_STORE_NAMES.notificationOpenapi,
+  storageAdapter: appStorage,
+  credentialsFrom: openApiStore,
+});
+
+notificationOpenApiStore.host = isNonPublicProductionEnv
+  ? INITIAL_OPENAPI_URL.replace('app-api.', 'alpha.')
+  : INITIAL_OPENAPI_URL;


### PR DESCRIPTION
## Summary
- centralize notification openapi store creation in `openapiStore.ts`
- keep notification openapi host strategy independent while sharing apiKey/apiTime with the main openapi store
- refresh API key headers from the main store before signing each request

## Test
- `DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged`
- `corepack yarn workspace rabby-mobile typecheck`