### PR TITLE
feat: add debug dapp sign auth interval

### DIFF
--- a/apps/mobile/src/components/Approval/components/FooterBar/useSubmitAction.ts
+++ b/apps/mobile/src/components/Approval/components/FooterBar/useSubmitAction.ts
@@ -5,19 +5,15 @@ import {
 } from '@/assets/icons/lock';
 import { AuthenticationModal } from '@/components/AuthenticationModal/AuthenticationModal';
 import { useAuthenticationModal } from '@/components/AuthenticationModal/hooks';
-import { isNonPublicProductionEnv } from '@/constant';
 import { apisLock } from '@/core/apis';
 import { unlockTimeEvent, updateUnlockTime } from '@/core/apis/lock';
+import { useDappSignAuthSessionIntervalMs } from '@/hooks/appSettings';
 import { useBiometrics } from '@/hooks/biometrics';
 import { makeThemeIconFromCC } from '@/hooks/makeThemeIcon';
 import { usePasswordStatus } from '@/hooks/useLock';
 import { atom, useAtom } from 'jotai';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-
-const DEFAULT_VERIFY_INTERVAL = isNonPublicProductionEnv
-  ? 1000 * 60 * 1 // 1 minute
-  : 1000 * 60 * 10; // 10 minutes
 
 const unlockTimeAtom = atom(0);
 unlockTimeAtom.onMount = setter => {
@@ -56,8 +52,10 @@ export const useSubmitAction = ({
   const { isUseCustomPwd } = usePasswordStatus();
 
   const [unlockTime, setUnlockTime] = useAtom(unlockTimeAtom);
+  const { dappSignAuthSessionIntervalMs } = useDappSignAuthSessionIntervalMs();
 
-  const isInAuthSession = Date.now() - unlockTime < DEFAULT_VERIFY_INTERVAL;
+  const isInAuthSession =
+    Date.now() - unlockTime < dappSignAuthSessionIntervalMs;
   const isLastUnlockTimeValid = !!useLastUnlockedAuth && isInAuthSession;
 
   const disabledVerify =

--- a/apps/mobile/src/hooks/appSettings.ts
+++ b/apps/mobile/src/hooks/appSettings.ts
@@ -39,6 +39,34 @@ const DEFAULT_DEBUG_KEYCHAIN_STORAGE: KeychainStorageType =
 export const WIDE_SCREEN_DEBUG_PANEL_DEFAULT_MIN_WIDTH = 700;
 export const WIDE_SCREEN_DEBUG_PANEL_MIN_ALLOWED_WIDTH = 280;
 export const WIDE_SCREEN_DEBUG_PANEL_WIDTH = 320;
+export const DAPP_SIGN_AUTH_SESSION_INTERVAL_MS_PROD = 10 * 60 * 1000;
+export const DAPP_SIGN_AUTH_SESSION_INTERVAL_MS_DEFAULT_NON_PROD =
+  1 * 60 * 1000;
+export const DAPP_SIGN_AUTH_SESSION_INTERVAL_OPTIONS = [
+  {
+    label: '1 min',
+    value: 1 * 60 * 1000,
+  },
+  {
+    label: '3 min',
+    value: 3 * 60 * 1000,
+  },
+  {
+    label: '5 min',
+    value: 5 * 60 * 1000,
+  },
+  {
+    label: '10 min',
+    value: 10 * 60 * 1000,
+  },
+  {
+    label: '30 min',
+    value: 30 * 60 * 1000,
+  },
+] as const;
+
+export type DappSignAuthSessionIntervalMs =
+  (typeof DAPP_SIGN_AUTH_SESSION_INTERVAL_OPTIONS)[number]['value'];
 
 function coerceCurrentKeychainVersion(
   version: unknown,
@@ -58,6 +86,17 @@ function coerceWideScreenDebugPanelMinWidth(value: unknown) {
   }
 
   return Math.max(WIDE_SCREEN_DEBUG_PANEL_MIN_ALLOWED_WIDTH, Math.round(width));
+}
+
+function coerceDappSignAuthSessionIntervalMs(
+  value: unknown,
+): DappSignAuthSessionIntervalMs {
+  const numericValue = typeof value === 'number' ? value : Number(value);
+  const option = DAPP_SIGN_AUTH_SESSION_INTERVAL_OPTIONS.find(
+    item => item.value === numericValue,
+  );
+
+  return option?.value || DAPP_SIGN_AUTH_SESSION_INTERVAL_MS_DEFAULT_NON_PROD;
 }
 
 type DebugKeychainStorageByVersion = Record<
@@ -98,6 +137,7 @@ type ScreenshotSettings = {
   debugSwapHistorySkipLocalLookup: boolean;
   wideScreenDebugPanelEnabled: boolean;
   wideScreenDebugPanelMinWidth: number;
+  debugDappSignAuthSessionIntervalMs: DappSignAuthSessionIntervalMs;
   [DEBUG_CURRENT_KEYCHAIN_VERSION_FIELD]: CurrentKeychainVersion;
   debugKeychainStorageByVersion: DebugKeychainStorageByVersion;
   enablePerpsWatchAddress: boolean;
@@ -120,6 +160,8 @@ const experimentalSettingsStore = zustandByMMKV<ScreenshotSettings>(
     debugSwapHistorySkipLocalLookup: false,
     wideScreenDebugPanelEnabled: false,
     wideScreenDebugPanelMinWidth: WIDE_SCREEN_DEBUG_PANEL_DEFAULT_MIN_WIDTH,
+    debugDappSignAuthSessionIntervalMs:
+      DAPP_SIGN_AUTH_SESSION_INTERVAL_MS_DEFAULT_NON_PROD,
     [DEBUG_CURRENT_KEYCHAIN_VERSION_FIELD]: DEFAULT_CURRENT_KEYCHAIN_VERSION,
     debugKeychainStorageByVersion: makeDefaultDebugKeychainStorageByVersion(),
     enablePerpsWatchAddress: false,
@@ -687,6 +729,36 @@ export function useWideScreenDebugPanelSetting() {
       WIDE_SCREEN_DEBUG_PANEL_MIN_ALLOWED_WIDTH,
     setWideScreenDebugPanelMinWidth,
     toggleWideScreenDebugPanel,
+  };
+}
+
+export function setDappSignAuthSessionIntervalMs(value: unknown) {
+  if (!isNonPublicProductionEnv) {
+    return DAPP_SIGN_AUTH_SESSION_INTERVAL_MS_PROD;
+  }
+
+  const nextIntervalMs = coerceDappSignAuthSessionIntervalMs(value);
+
+  setExpSettingData(prev => ({
+    ...prev,
+    debugDappSignAuthSessionIntervalMs: nextIntervalMs,
+  }));
+
+  return nextIntervalMs;
+}
+
+export function useDappSignAuthSessionIntervalMs() {
+  const debugDappSignAuthSessionIntervalMs = experimentalSettingsStore(
+    s => s.debugDappSignAuthSessionIntervalMs,
+  );
+
+  return {
+    dappSignAuthSessionIntervalMs: isNonPublicProductionEnv
+      ? coerceDappSignAuthSessionIntervalMs(debugDappSignAuthSessionIntervalMs)
+      : DAPP_SIGN_AUTH_SESSION_INTERVAL_MS_PROD,
+    canSwitchDappSignAuthSessionInterval: isNonPublicProductionEnv,
+    dappSignAuthSessionIntervalOptions: DAPP_SIGN_AUTH_SESSION_INTERVAL_OPTIONS,
+    setDappSignAuthSessionIntervalMs,
   };
 }
 

--- a/apps/mobile/src/screens/Testkits/DevUIDapps.tsx
+++ b/apps/mobile/src/screens/Testkits/DevUIDapps.tsx
@@ -1,8 +1,7 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { Alert, Dimensions, ScrollView, StyleSheet, View } from 'react-native';
+import React from 'react';
+import { Dimensions, ScrollView, StyleSheet, View } from 'react-native';
 
 import { useTheme2024 } from '@/hooks/theme';
-import { useNavigation } from '@react-navigation/native';
 import { createGetStyles2024 } from '@/utils/styles';
 import NormalScreenContainer from '@/components/ScreenContainer/NormalScreenContainer';
 import {
@@ -16,6 +15,10 @@ import { formatTimeReadable } from '@/utils/time';
 import dayjs from 'dayjs';
 import { urlUtils } from '@rabby-wallet/base-utils';
 import { Text } from '@/components/Typography';
+import {
+  DAPP_SIGN_AUTH_SESSION_INTERVAL_MS_PROD,
+  useDappSignAuthSessionIntervalMs,
+} from '@/hooks/appSettings';
 
 const TEST_OPEN_DAPPS = [
   'https://debank.com',
@@ -25,14 +28,18 @@ const TEST_OPEN_DAPPS = [
 ];
 
 function DevUIDapps() {
-  const { styles, colors2024, colors } = useTheme2024({
+  const { styles, colors } = useTheme2024({
     getStyle: getStyles,
     isLight: true,
   });
 
-  const navigation = useNavigation();
-
   const { dappsViewConfig } = useDappsViewConfig();
+  const {
+    dappSignAuthSessionIntervalMs,
+    canSwitchDappSignAuthSessionInterval,
+    dappSignAuthSessionIntervalOptions,
+    setDappSignAuthSessionIntervalMs,
+  } = useDappSignAuthSessionIntervalMs();
 
   const {} = useOpenedActiveDappState();
   const { openedDappRecords } = useOpenedDappsRecordsOnDEV();
@@ -72,6 +79,46 @@ function DevUIDapps() {
               Open Dapp expire duration: {dappsViewConfig.expireDuration} ms
             </Text>
           </Text>
+        </View>
+        <View style={styles.showCaseRowsContainer}>
+          <Text
+            style={[styles.componentName, { fontSize: 24, marginBottom: 12 }]}>
+            Dapp Signing Auth Session
+          </Text>
+          <Text style={[styles.propertyDesc, { marginVertical: 12 }]}>
+            <Text style={{ marginBottom: 12 }}>
+              Current auth-free duration:{' '}
+              {formatTimeReadable(dappSignAuthSessionIntervalMs / 1000)}
+              {' '.repeat(100)}
+            </Text>
+            <Text style={{ marginBottom: 12 }}>
+              Non-production packages can override this value. Production
+              packages always use{' '}
+              {formatTimeReadable(
+                DAPP_SIGN_AUTH_SESSION_INTERVAL_MS_PROD / 1000,
+              )}
+              .
+            </Text>
+          </Text>
+          <View style={styles.durationOptionList}>
+            {dappSignAuthSessionIntervalOptions.map(option => {
+              const selected = option.value === dappSignAuthSessionIntervalMs;
+
+              return (
+                <Button
+                  key={option.value}
+                  title={option.label}
+                  type={selected ? 'primary' : 'ghost'}
+                  height={40}
+                  disabled={!canSwitchDappSignAuthSessionInterval}
+                  containerStyle={styles.durationOptionButton}
+                  onPress={() => {
+                    setDappSignAuthSessionIntervalMs(option.value);
+                  }}
+                />
+              );
+            })}
+          </View>
         </View>
         <View style={styles.showCaseRowsContainer}>
           <Text
@@ -177,6 +224,15 @@ const getStyles = createGetStyles2024(ctx =>
     propertyType: {
       color: ctx.colors2024['blue-default'],
       fontSize: 16,
+    },
+    durationOptionList: {
+      width: '100%',
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: 8,
+    },
+    durationOptionButton: {
+      minWidth: 92,
     },
 
     openedDappRecord: {


### PR DESCRIPTION
## Summary
- add a non-production-only dapp signing auth session interval setting
- keep production packages fixed at 10 minutes
- add controls on the Dapp UI testkit page

## Validation
- git diff --check
- yarn workspace rabby-mobile typecheck
- Android regression build