### PR TITLE
fix: decouple screenshot feedback modal from unlock state

### DIFF
--- a/apps/mobile/src/AppNavigation.tsx
+++ b/apps/mobile/src/AppNavigation.tsx
@@ -53,6 +53,7 @@ import MoreImportMethods from '@/screens/Address/MoreImportMethods';
 import SelectAddMethod from '@/screens/Address/SelectAddMethod';
 import Backup from '@/screens/Address/Backup';
 import BiometricsStubModal from './components/AuthenticationModal/BiometricsStubModal';
+import { ScreenshotFeedbackGlobalHost } from './components/Screenshot/ScreenshotFeedbackGlobalHost';
 import { perfEvents } from './core/utils/perf';
 import { RefLikeObject } from './utils/type';
 import { useRendererDetect } from './components/Perf/PerfDetector';
@@ -73,7 +74,6 @@ import {
   GlobalSignerPortal,
   GlobalTipsPopup,
   InnerDappWebViewPreloadEntry,
-  ModalsSubmitFeedbackByScreenshotStub,
   QrCodeModal,
   ToggleCollateralModal,
   WideScreenDebugPanel,
@@ -390,13 +390,9 @@ function AppNavigationOverlayGlobals({
 }) {
   const showDiagnostics = deferredGlobalsEnabled || NEED_DEVSETTINGBLOCKS;
 
-  if (!showDiagnostics && !postUnlockGlobalsEnabled) {
-    return null;
-  }
-
   return (
     <>
-      {postUnlockGlobalsEnabled && <ModalsSubmitFeedbackByScreenshotStub />}
+      <ScreenshotFeedbackGlobalHost />
       {postUnlockGlobalsEnabled && <ToggleCollateralModal />}
 
       {/** @warning put all business stub components before this modal */}

--- a/apps/mobile/src/components/Screenshot/ScreenshotFeedbackGlobalHost.tsx
+++ b/apps/mobile/src/components/Screenshot/ScreenshotFeedbackGlobalHost.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { registerAppScreen } from '@/perfs/apis';
+
+import { useSubmitFeedbackModalVisible } from './hooks';
+
+const LazyModalsSubmitFeedbackByScreenshotStub = registerAppScreen<
+  typeof import('./ScreenshotModal').ModalsSubmitFeedbackByScreenshotStub
+>({
+  loader: () =>
+    import('./ScreenshotModal').then(m => ({
+      default: m.ModalsSubmitFeedbackByScreenshotStub,
+    })),
+});
+
+export function ScreenshotFeedbackGlobalHost() {
+  const { submitFeedbackModalVisible } = useSubmitFeedbackModalVisible();
+
+  if (!submitFeedbackModalVisible) {
+    return null;
+  }
+
+  return <LazyModalsSubmitFeedbackByScreenshotStub />;
+}

--- a/apps/mobile/src/components/Screenshot/hooks.ts
+++ b/apps/mobile/src/components/Screenshot/hooks.ts
@@ -578,6 +578,15 @@ const closeSubmitModal = ({
   }));
 };
 
+async function getScreenshotFeedbackExtraSafely(totalBalanceText: string) {
+  try {
+    return await getScreenshotFeedbackExtra({ totalBalanceText });
+  } catch (error) {
+    console.error('screenshot feedback extra error', error);
+    return {};
+  }
+}
+
 export function useSubmitFeedbackOnScreenshot() {
   const { lastScreenshot, totalBalanceText } = feedbackByScreenshotStore(
     useShallow(s => ({
@@ -594,9 +603,6 @@ export function useSubmitFeedbackOnScreenshot() {
     useRefState(false);
   const submitFeedbackByScreenshot = useCallback(
     async function () {
-      const extraInfo = await getScreenshotFeedbackExtra({ totalBalanceText });
-      // console.debug('[debug] extraInfo', extraInfo);
-
       if (isSubmittingRef.current) return;
       setSubmitting(true, true);
 
@@ -614,6 +620,11 @@ export function useSubmitFeedbackOnScreenshot() {
         if (!imageUrl) {
           throw new Error('No screenshot available');
         }
+
+        const extraInfo = await getScreenshotFeedbackExtraSafely(
+          totalBalanceText,
+        );
+        // console.debug('[debug] extraInfo', extraInfo);
 
         // TODO: report to sentry here, add extra fields here
         submitResult = await openapi.postUserFeedback({


### PR DESCRIPTION
## Summary

- mount a lightweight screenshot feedback host independently from unlock/deferred globals
- keep the full screenshot feedback modal lazy-loaded until `submitModalShown` is true
- make screenshot feedback extra collection best-effort so locked/session edge cases do not block submitting the screenshot itself

## Context

PR #1851 changes the screenshot feedback modal condition from `deferredGlobalsEnabled` to `postUnlockGlobalsEnabled`, which works around the observed post-unlock-session case. This PR keeps the behavior independent from both `isAppUnlocked` and `isUnlockSessionValid`, matching the intended behavior that screenshot-to-feedback is controlled by screenshot settings, sensitive-scene gating, platform support, and modal-gate state rather than wallet unlock state.

## Validation

- `corepack yarn install --immutable` completed with existing peer warnings
- `corepack yarn workspace rabby-mobile typecheck` passed
- `corepack yarn workspace rabby-mobile lint:cycles` passed
- `corepack yarn workspace rabby-mobile lint:cycles:eslint` passed
- `DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged` passed for staged files
- `corepack yarn workspace rabby-mobile test --runInBand` ran; 87 suites passed, 18 suites failed with the shared existing test-env error `TypeError: actImplementation is not a function` in `@testing-library/react-native` render/renderHook tests
