### PR TITLE
fix: reset perps store on password reset

### DIFF
--- a/apps/mobile/src/core/apis/lock.test.ts
+++ b/apps/mobile/src/core/apis/lock.test.ts
@@ -61,8 +61,14 @@ const preferenceService = {
   initCurrentAccount: (...args: unknown[]) => mockInitCurrentAccount(...args),
 };
 
+const mockResetPerpsStore = jest.fn();
+
 const sessionService = {
   broadcastEvent: (...args: unknown[]) => mockBroadcastEvent(...args),
+};
+
+const perpsService = {
+  resetStore: (...args: unknown[]) => mockResetPerpsStore(...args),
 };
 
 const loadLockModule = () => {
@@ -88,6 +94,7 @@ const loadLockModule = () => {
 
   jest.doMock('../services', () => ({
     keyringService,
+    perpsService,
     preferenceService,
     sessionService,
   }));
@@ -152,6 +159,7 @@ describe('core/apis/lock password and session utilities', () => {
     mockIsUnlocked.mockReturnValue(false);
     mockSubmitPassword.mockResolvedValue(undefined);
     mockSetLocked.mockResolvedValue(undefined);
+    mockResetPerpsStore.mockResolvedValue(undefined);
     mockHasPublicAccountSnapshot.mockReturnValue(true);
     mockGetPreference.mockReturnValue(0);
     mockShouldRejectUnlockDueToMultipleFailed.mockReturnValue({

--- a/apps/mobile/src/core/apis/lock.ts
+++ b/apps/mobile/src/core/apis/lock.ts
@@ -1,7 +1,12 @@
 import { Platform } from 'react-native';
 import { RABBY_MOBILE_KR_PWD } from '@/constant/encryptor';
 import { BroadcastEvent } from '@/constant/event';
-import { keyringService, preferenceService, sessionService } from '../services';
+import {
+  keyringService,
+  perpsService,
+  preferenceService,
+  sessionService,
+} from '../services';
 import { makeEEClass } from './event';
 import { formatTimeReadable } from '@/utils/time';
 import {
@@ -202,6 +207,7 @@ export async function resetPasswordOnUI(newPassword: string) {
       // await updateWalletPassword(RABBY_MOBILE_KR_PWD, newPassword);
     } else {
       await keyringService.resetPassword(newPassword);
+      await perpsService.resetStore();
     }
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
## Summary
- Calls `perpsService.resetStore()` alongside `keyringService.resetPassword()` in `resetPasswordOnUI` to ensure perps state is cleaned up when the user resets their wallet password

