### PR TITLE
fix: handle biometric prompt retry on affected Android devices

### DIFF
--- a/apps/mobile/src/core/apis/keychainCommon.ts
+++ b/apps/mobile/src/core/apis/keychainCommon.ts
@@ -28,6 +28,8 @@ const AES_GCM_NO_AUTH_STORAGE_TYPE = 'KeystoreAESGCM_NoAuth';
 const IOS_KEYCHAIN_STORAGE_TYPE = 'keychain';
 const BROKEN_BIOMETRICS_ENTRY_MESSAGE =
   'Biometrics data could not be decrypted with the current keychain state. Inspect the keychain debug screen before resetting biometrics.';
+const ANDROID_SECURITY_RULE_AUTOMATIC_UPGRADE =
+  'automaticUpgradeToMoreSecuredStorage';
 const CANCELSTR = i18n.t('native.authentication.auth_prompt_cancel');
 const isAndroid = Platform.OS === 'android';
 
@@ -661,7 +663,9 @@ export function createBusinessKeychainApi({
     authenticationType:
       keychainModule.AUTHENTICATION_TYPE.DEVICE_PASSCODE_OR_BIOMETRICS,
     ...(isAndroid && {
-      rules: keychainModule.SECURITY_RULES.AUTOMATIC_UPGRADE,
+      rules:
+        keychainModule.SECURITY_RULES?.AUTOMATIC_UPGRADE ??
+        ANDROID_SECURITY_RULE_AUTOMATIC_UPGRADE,
     }),
   };
   const debugModule = (NativeModules as Record<string, unknown>)[

--- a/apps/mobile/src/core/apis/keychainDebug.ts
+++ b/apps/mobile/src/core/apis/keychainDebug.ts
@@ -31,6 +31,8 @@ export {
 
 const isAndroid = Platform.OS === 'android';
 const GENERIC_USER = 'rabbymobile-user';
+const ANDROID_SECURITY_RULE_AUTOMATIC_UPGRADE =
+  'automaticUpgradeToMoreSecuredStorage';
 export const KEYCHAIN_PROBE_SERVICE = `${KEYCHAIN_DEFAULT_SERVICE}.rn-keychain-v10`;
 export const KEYCHAIN_PROBE_PASSWORD = 'rn-keychain-v10-probe-password';
 export const KEYCHAIN_SOURCE_LABEL = 'react-native-keychain@10.0.0 raw';
@@ -78,7 +80,9 @@ const DEFAULT_GET_OPTIONS: RawOfficialOptions = {
   },
   authenticationType: OfficialKeychain.AUTHENTICATION_TYPE.BIOMETRICS,
   ...(isAndroid && {
-    rules: OfficialKeychain.SECURITY_RULES.AUTOMATIC_UPGRADE,
+    rules:
+      OfficialKeychain.SECURITY_RULES?.AUTOMATIC_UPGRADE ??
+      ANDROID_SECURITY_RULE_AUTOMATIC_UPGRADE,
   }),
 };
 

--- a/apps/mobile/src/screens/Unlock/Unlock.tsx
+++ b/apps/mobile/src/screens/Unlock/Unlock.tsx
@@ -720,6 +720,7 @@ export default function UnlockScreen() {
   );
 
   const processUnlockWithBiometrics = useCallback(async () => {
+    const startedAt = Date.now();
     if (
       lockBiometricRef.current ||
       usingPasswordRef.current ||
@@ -742,6 +743,7 @@ export default function UnlockScreen() {
       lockBiometricRef.current = false;
     };
 
+    traceAndroidUnlockPerf('biometrics_ready_check_start');
     const biometricsReady = await storeApisBiometrics
       .ensureBiometricsReadyForUnlock()
       .catch(error => {
@@ -750,6 +752,10 @@ export default function UnlockScreen() {
         });
         return false;
       });
+    traceAndroidUnlockPerf('biometrics_ready_check_end', {
+      elapsedMs: Date.now() - startedAt,
+      biometricsReady,
+    });
     if (!biometricsReady) {
       const latestBiometricsInfo =
         storeApisBiometrics.getBiometricsInfoSnapshot();

--- a/packages/react-native-keychain-9/android/src/main/java/com/oblador/keychain/resultHandler/ResultHandlerInteractiveBiometric.kt
+++ b/packages/react-native-keychain-9/android/src/main/java/com/oblador/keychain/resultHandler/ResultHandlerInteractiveBiometric.kt
@@ -74,6 +74,10 @@ open class ResultHandlerInteractiveBiometric(
 
   /** Called when an unrecoverable error has been encountered and the operation is complete. */
   override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+    Log.w(
+      LOG_TAG,
+      "onAuthenticationError code=$errorCode msg=$errString operation=${context?.operation}"
+    )
     val error = CryptoFailedException("code: $errorCode, msg: $errString")
     when (context?.operation) {
       CryptoOperation.ENCRYPT -> onEncrypt(null, error)
@@ -85,6 +89,7 @@ open class ResultHandlerInteractiveBiometric(
 
   /** Called when a biometric is recognized. */
   override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+    Log.i(LOG_TAG, "onAuthenticationSucceeded operation=${context?.operation}")
     try {
       context ?: throw NullPointerException("Crypto context is not assigned yet.")
 
@@ -109,6 +114,7 @@ open class ResultHandlerInteractiveBiometric(
         null -> Log.e(LOG_TAG, "No operation context available")
       }
     } catch (fail: Throwable) {
+      Log.e(LOG_TAG, "onAuthenticationSucceeded failed operation=${context?.operation}", fail)
       when (context?.operation) {
         CryptoOperation.ENCRYPT -> onEncrypt(null, fail)
         CryptoOperation.DECRYPT -> onDecrypt(null, fail)
@@ -121,9 +127,15 @@ open class ResultHandlerInteractiveBiometric(
   /** Trigger interactive authentication. */
   open fun startAuthentication() {
     val activity = getCurrentActivity()
+    val isMainThread = Thread.currentThread() == Looper.getMainLooper().thread
+    Log.d(
+      LOG_TAG,
+      "startAuthentication operation=${context?.operation} thread=${Thread.currentThread().name} isMain=$isMainThread"
+    )
 
     // Code can be executed only from MAIN thread
-    if (Thread.currentThread() != Looper.getMainLooper().thread) {
+    if (!isMainThread) {
+      Log.d(LOG_TAG, "startAuthentication reposting to main thread")
       activity.runOnUiThread { startAuthentication() }
       waitResult()
       return
@@ -138,8 +150,10 @@ open class ResultHandlerInteractiveBiometric(
   }
 
   protected fun authenticateWithPrompt(activity: FragmentActivity): BiometricPrompt {
+    Log.d(LOG_TAG, "authenticateWithPrompt start activity=${activity.javaClass.simpleName}")
     val prompt = BiometricPrompt(activity, executor, this)
     prompt.authenticate(this.promptInfo)
+    Log.d(LOG_TAG, "authenticateWithPrompt called")
     return prompt
   }
 

--- a/packages/react-native-keychain-9/android/src/main/java/com/oblador/keychain/resultHandler/ResultHandlerInteractiveBiometricManualRetry.kt
+++ b/packages/react-native-keychain-9/android/src/main/java/com/oblador/keychain/resultHandler/ResultHandlerInteractiveBiometricManualRetry.kt
@@ -26,7 +26,7 @@ class ResultHandlerInteractiveBiometricManualRetry(
 
   /** Manually cancel current (invisible) authentication to clear the fragment. */
   private fun cancelPresentedAuthentication() {
-    Log.d(LOG_TAG, "Cancelling authentication")
+    Log.d(LOG_TAG, "manualRetry cancelPresentedAuthentication didFail=$didFailBiometric")
     if (presentedPrompt == null) {
       return
     }
@@ -42,6 +42,10 @@ class ResultHandlerInteractiveBiometricManualRetry(
 
   /** Called when an unrecoverable error has been encountered and the operation is complete. */
   override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+    Log.w(
+      LOG_TAG,
+      "manualRetry onAuthenticationError code=$errorCode msg=$errString didFail=$didFailBiometric"
+    )
     if (didFailBiometric) {
       this.presentedPrompt = null
       this.didFailBiometric = false
@@ -57,7 +61,7 @@ class ResultHandlerInteractiveBiometricManualRetry(
    * belonging to the user.
    */
   override fun onAuthenticationFailed() {
-    Log.d(LOG_TAG, "Authentication failed: biometric not recognized.")
+    Log.d(LOG_TAG, "manualRetry onAuthenticationFailed presented=${presentedPrompt != null}")
     if (presentedPrompt != null) {
       this.didFailBiometric = true
       cancelPresentedAuthentication()
@@ -66,6 +70,7 @@ class ResultHandlerInteractiveBiometricManualRetry(
 
   /** Called when a biometric is recognized. */
   override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+    Log.i(LOG_TAG, "manualRetry onAuthenticationSucceeded")
     this.presentedPrompt = null
     this.didFailBiometric = false
     super.onAuthenticationSucceeded(result)
@@ -74,9 +79,14 @@ class ResultHandlerInteractiveBiometricManualRetry(
   /** Trigger interactive authentication. */
   override fun startAuthentication() {
     val activity = getCurrentActivity()
+    val isMainThread = Thread.currentThread() == Looper.getMainLooper().thread
+    Log.d(
+      LOG_TAG,
+      "manualRetry startAuthentication thread=${Thread.currentThread().name} isMain=$isMainThread"
+    )
 
     // Code can be executed only from MAIN thread
-    if (Thread.currentThread() != Looper.getMainLooper().thread) {
+    if (!isMainThread) {
       activity.runOnUiThread { startAuthentication() }
       waitResult()
       return
@@ -87,7 +97,11 @@ class ResultHandlerInteractiveBiometricManualRetry(
 
   /** Trigger interactive authentication without invoking another waitResult() */
   protected fun retryAuthentication() {
-    Log.d(LOG_TAG, "Retrying biometric authentication.")
+    Log.d(
+      LOG_TAG,
+      "manualRetry retryAuthentication thread=${Thread.currentThread().name} " +
+        "isMain=${Thread.currentThread() == Looper.getMainLooper().thread}"
+    )
 
     val activity = getCurrentActivity()
 

--- a/packages/react-native-keychain-9/android/src/main/java/com/oblador/keychain/resultHandler/ResultHandlerProvider.kt
+++ b/packages/react-native-keychain-9/android/src/main/java/com/oblador/keychain/resultHandler/ResultHandlerProvider.kt
@@ -1,6 +1,7 @@
 package com.rabbywallet.keychain9.resultHandler
 
 import android.os.Build
+import android.util.Log
 import androidx.biometric.BiometricPrompt
 import com.facebook.react.bridge.ReactApplicationContext
 import com.rabbywallet.keychain9.cipherStorage.CipherStorage
@@ -8,7 +9,17 @@ import com.rabbywallet.keychain9.cipherStorage.CipherStorage
 // NOTE: the logic for handling OnePlus bug is taken from the following forum post:
 // https://forums.oneplus.com/threads/oneplus-7-pro-fingerprint-biometricprompt-does-not-show.1035821/#post-21710422
 object ResultHandlerProvider {
+  private const val LOG_TAG = "RNKeychainV9PromptHandler"
   private const val ONE_PLUS_BRAND = "oneplus"
+  private const val XIAOMI_MANUFACTURER = "xiaomi"
+  private const val XIAOMI_14_ULTRA_CN_MODEL = "24031PN0DC"
+  private const val XIAOMI_14_ULTRA_DEVICE = "aurora"
+  private const val GOOGLE_MANUFACTURER = "google"
+  private val GOOGLE_PIXEL_MODELS_WITH_BIOMETRIC_BUG =
+    setOf(
+      "Pixel 9",
+      "Pixel 10 Pro"
+    )
   private val ONE_PLUS_MODELS_WITHOUT_BIOMETRIC_BUG =
     arrayOf(
       "A0001", // OnePlus One
@@ -33,19 +44,51 @@ object ResultHandlerProvider {
       !ONE_PLUS_MODELS_WITHOUT_BIOMETRIC_BUG.contains(Build.MODEL)
   }
 
+  private fun hasXiaomi14UltraBiometricPromptBug(): Boolean {
+    return Build.MANUFACTURER.equals(XIAOMI_MANUFACTURER, ignoreCase = true) &&
+      Build.MODEL == XIAOMI_14_ULTRA_CN_MODEL &&
+      Build.DEVICE.equals(XIAOMI_14_ULTRA_DEVICE, ignoreCase = true)
+  }
+
+  private fun hasGooglePixelBiometricPromptBug(): Boolean {
+    return Build.MANUFACTURER.equals(GOOGLE_MANUFACTURER, ignoreCase = true) &&
+      GOOGLE_PIXEL_MODELS_WITH_BIOMETRIC_BUG.contains(Build.MODEL)
+  }
+
+  private fun getManualRetryReason(): String? {
+    return when {
+      hasOnePlusBiometricBug() -> "oneplus"
+      hasXiaomi14UltraBiometricPromptBug() -> "xiaomi_14_ultra_aurora"
+      hasGooglePixelBiometricPromptBug() -> "google_pixel"
+      else -> null
+    }
+  }
+
   fun getHandler(
     reactContext: ReactApplicationContext,
     storage: CipherStorage,
     promptInfo: BiometricPrompt.PromptInfo
   ): ResultHandler {
-    return if (storage.isBiometrySupported()) {
-      if (hasOnePlusBiometricBug()) {
-        ResultHandlerInteractiveBiometricManualRetry(reactContext, storage, promptInfo)
-      } else {
-        ResultHandlerInteractiveBiometric(reactContext, storage, promptInfo)
-      }
+    if (!storage.isBiometrySupported()) {
+      Log.i(LOG_TAG, "selected=nonInteractive storage=${storage.javaClass.simpleName}")
+      return ResultHandlerNonInteractive()
+    }
+
+    val manualRetryReason = getManualRetryReason()
+    val shouldUseManualRetry = manualRetryReason != null
+    Log.i(
+      LOG_TAG,
+      "selected=${if (shouldUseManualRetry) "manualRetry" else "interactive"} " +
+        "reason=$manualRetryReason brand=${Build.BRAND} " +
+        "manufacturer=${Build.MANUFACTURER} model=${Build.MODEL} " +
+        "device=${Build.DEVICE} product=${Build.PRODUCT} " +
+        "sdk=${Build.VERSION.SDK_INT} storage=${storage.javaClass.simpleName}"
+    )
+
+    return if (shouldUseManualRetry) {
+      ResultHandlerInteractiveBiometricManualRetry(reactContext, storage, promptInfo)
     } else {
-      ResultHandlerNonInteractive()
+      ResultHandlerInteractiveBiometric(reactContext, storage, promptInfo)
     }
   }
 }


### PR DESCRIPTION
## Summary
- route RN keychain v9 biometric prompts through the manual retry handler only on affected device allowlists: existing OnePlus handling, Xiaomi 14 Ultra CN `24031PN0DC`/`aurora`, `Pixel 9`, and `Pixel 10 Pro`
- add Android keychain prompt and unlock readiness logs for diagnosing delayed or missing biometric callbacks
- fall back to the Android security rule string when `SECURITY_RULES` is unavailable, avoiding the v9 startup crash path

## Validation
- `git diff --check`
- `DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged`
- `./android/gradlew :rabby-wallet_react-native-keychain-9:compileReleaseKotlin`
- built Android regression APK with upload/notify/Sentry upload disabled
- installed on connected Xiaomi 14 Ultra `24031PN0DC` with `adb install --no-streaming -r -d -t`; cold launch verified