### PR TITLE
build: normalize ios hash xcode metadata

### DIFF
--- a/.github/workflows/hash_validate.yml
+++ b/.github/workflows/hash_validate.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: macos-26
     env:
       NODE_OPTIONS: '--max_old_space_size=8192'
-      XCODE_VER: '26.5'
+      XCODE_VER: '26.3'
 
     outputs:
       ios_hash: ${{ steps.generate_hash.outputs.hash }}

--- a/.github/workflows/hash_validate.yml
+++ b/.github/workflows/hash_validate.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: macos-26
     env:
       NODE_OPTIONS: '--max_old_space_size=8192'
-      XCODE_VER: '26.3'
+      XCODE_VER: '26.5'
 
     outputs:
       ios_hash: ${{ steps.generate_hash.outputs.hash }}

--- a/apps/mobile/scripts/validate-hash/ios.sh
+++ b/apps/mobile/scripts/validate-hash/ios.sh
@@ -55,6 +55,7 @@ run_ios_build_and_hash() {
     # "Authoring Tool": "@(#)PROGRAM:CoreThemeDefinition  PROJECT:CoreThemeDefinition-611  [IIO-2661.3.6]", 版本号会不一样
     sed -i '' -e 's/"Authoring Tool" : .*/"Authoring Tool" : "",/' "$app_path/Assets.car.json"
     # CoreUI 记录的是 assetutil/CoreUI 工具版本，系统补丁版本不同也可能变化
+    sed -i '' -e 's/"AssetStorageVersion" : .*/"AssetStorageVersion" : "",/' "$app_path/Assets.car.json"
     sed -i '' -e 's/"CoreUIVersion" : [0-9]*/"CoreUIVersion" : 0/' "$app_path/Assets.car.json"
     sed -i '' -e 's/"MainVersion" : "@(#)PROGRAM:CoreUI  PROJECT:CoreUI-[^"]*"/"MainVersion" : "@(#)PROGRAM:CoreUI  PROJECT:CoreUI-0"/' "$app_path/Assets.car.json"
     rm -f "$app_path/Assets.car"
@@ -67,7 +68,12 @@ run_ios_build_and_hash() {
   # Trim machine-related data from the assembly file
   fields_remove=(
     "BuildMachineOSBuild"
-    # "DTPlatformBuild" "DTPlatformVersion" "DTSDKBuild" "DTSDKName" "DTXcode" "DTXcodeBuild"
+    "DTPlatformBuild"
+    "DTPlatformVersion"
+    "DTSDKBuild"
+    "DTSDKName"
+    "DTXcode"
+    "DTXcodeBuild"
   )
   # 遍历并修改 Info.plist 中的字段
   for field in "${fields_remove[@]}"; do


### PR DESCRIPTION
## Summary
- Normalize iOS `Assets.car.json` `AssetStorageVersion` before hash calculation.
- Remove additional plist Xcode/SDK metadata fields from iOS hash inputs.
- Temporarily set the hash validation workflow iOS Xcode version to 26.5 on this experiment branch.

## Validation
- Local iOS validate: macOS 26.4.1 + Xcode 26.3 -> hash `6004bd1d93a4f297ce42ec9770df3ace5a5841b50b699941a0cecc3ab32ab4d0`, bundle hash `3b8c99200ad24a7f0161e34e4eb878f85edd7e28f98f731d9e93a925a2dde990`.
- CI iOS validate: run 27425130186, Xcode 26.5 -> hash `95583add3873fd945c70bedf9ce294a59715890f7e0d97db9a2a9dfea1802181`, bundle hash `3b8c99200ad24a7f0161e34e4eb878f85edd7e28f98f731d9e93a925a2dde990`.
- Compared 349 app files: only `RabbyMobile.asm` differs after this normalization; `Assets.car.json`, plist metadata outputs, JS bundle, and jsModuleId log match.

## Notes
- CI runner reported macOS 26.4 while using Xcode 26.5 / iPhoneOS26.5.sdk, so this specifically validates the Xcode 26.5 side of the requested matrix.
- This is opened as draft for comparison/discussion before deciding whether to keep the workflow Xcode change.