### PR TITLE
feat: include device info in rate feedback

### DIFF
--- a/apps/mobile/src/components/RateModal/hooks.ts
+++ b/apps/mobile/src/components/RateModal/hooks.ts
@@ -14,6 +14,7 @@ import { APP_URLS, APP_VERSIONS, APPLICATION_ID } from '@/constant';
 import { isNonPublicProductionEnv } from '@/constant';
 import { Platform } from 'react-native';
 import { matomoRequestEvent } from '@/utils/analytics';
+import { getDeviceInfoForFeedbackText } from '@/utils/deviceInfo';
 import { openExternalUrl } from '@/core/utils/linking';
 import {
   resolveValFromUpdater,
@@ -294,6 +295,7 @@ const pushRateDetails = async (params?: { userStar?: number }) => {
   const starText = `${makeStarText(userStar, 5)} (${userStar})`;
   const balanceText = rmState.totalBalanceText;
   const versionText = APP_VERSIONS.forFeedback;
+  const { deviceText, osText } = getDeviceInfoForFeedbackText();
 
   const feedbackContent = [
     ...(!needFeedbackText
@@ -303,6 +305,8 @@ const pushRateDetails = async (params?: { userStar?: number }) => {
           `Rate: ${starText}`,
           `Total Balance: ${balanceText}`,
           `App Version: ${versionText}`,
+          `Device: ${deviceText}`,
+          `OS: ${osText}`,
           '  ',
         ]),
   ]

--- a/apps/mobile/src/utils/deviceInfo.ts
+++ b/apps/mobile/src/utils/deviceInfo.ts
@@ -1,0 +1,69 @@
+import { Platform } from 'react-native';
+import DeviceInfo from 'react-native-device-info';
+
+function safeGet<T>(fn: () => T): T | null {
+  try {
+    return fn();
+  } catch (error) {
+    console.error('[deviceInfo] Failed to collect device info:', error);
+    return null;
+  }
+}
+
+function toNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return null;
+  }
+
+  const text = String(value).trim();
+  return text || null;
+}
+
+function uniqueNonEmptyStrings(values: unknown[]) {
+  const seen = new Set<string>();
+
+  return values.reduce<string[]>((acc, value) => {
+    const text = toNonEmptyString(value);
+    const key = text?.toLowerCase();
+
+    if (!text || !key || seen.has(key)) {
+      return acc;
+    }
+
+    seen.add(key);
+    acc.push(text);
+    return acc;
+  }, []);
+}
+
+export function getDeviceInfoForFeedbackText() {
+  const manufacturer = safeGet(() => DeviceInfo.getManufacturerSync());
+  const model = safeGet(() => DeviceInfo.getModel());
+  const deviceId = safeGet(() => DeviceInfo.getDeviceId());
+  const systemName = safeGet(() => DeviceInfo.getSystemName());
+  const systemVersion = safeGet(() => DeviceInfo.getSystemVersion());
+  const androidApiLevel =
+    Platform.OS === 'android'
+      ? safeGet(() => DeviceInfo.getApiLevelSync())
+      : null;
+
+  const deviceName = uniqueNonEmptyStrings([manufacturer, model]).join(' ');
+  const deviceCode = toNonEmptyString(deviceId);
+  const deviceText =
+    [deviceName, deviceCode ? `(${deviceCode})` : null]
+      .filter(Boolean)
+      .join(' ') || Platform.OS;
+
+  const osText =
+    [
+      uniqueNonEmptyStrings([systemName, systemVersion]).join(' '),
+      androidApiLevel ? `(API ${androidApiLevel})` : null,
+    ]
+      .filter(Boolean)
+      .join(' ') || Platform.OS;
+
+  return {
+    deviceText,
+    osText,
+  };
+}


### PR DESCRIPTION
## Summary
- Append device model and OS details to low-score Rabby rating feedback text.
- Reuse react-native-device-info with safe fallbacks so feedback submission still works if a native getter fails.
- Android feedback includes API level when available.

## Validation
- corepack yarn workspace rabby-mobile typecheck
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged

## Context
Requirement: Rabby 用户反馈补充上报机型. Base record: recvmBOdmpmOCJ.