### PR TITLE
Preload transaction navigator from single address

### DIFF
--- a/apps/mobile/src/screens/Navigators/SingleAddressNavigator.tsx
+++ b/apps/mobile/src/screens/Navigators/SingleAddressNavigator.tsx
@@ -1,9 +1,10 @@
 import 'react-native-gesture-handler';
-import React, { useCallback } from 'react';
+import React, { useCallback, useLayoutEffect } from 'react';
 import { createCustomNativeStackNavigator as createNativeStackNavigator } from '@/utils/CustomNativeStackNavigator';
 import { RootNames } from '@/constant/layout';
 import SingleAddressHome from '../Home/Home';
 import { useStackScreenConfig } from '@/hooks/navigation';
+import { preloadTransactionHotNavigator } from '@/perfs/preloads';
 const SingleAddressStack = createNativeStackNavigator();
 
 export function SingleAddressNavigator() {
@@ -13,6 +14,19 @@ export function SingleAddressNavigator() {
     console.debug('[SingleAddressNavigator] Render');
   }
   const renderHeader = useCallback(() => <SingleAddressHome.Header />, []);
+
+  useLayoutEffect(() => {
+    const timer = setTimeout(() => {
+      preloadTransactionHotNavigator().catch(error => {
+        console.error(
+          'preloadTransactionHotNavigator::singleAddress::error',
+          error,
+        );
+      });
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, []);
 
   return (
     <SingleAddressStack.Navigator


### PR DESCRIPTION
## Summary
- preload `StackTransaction` shortly after `SingleAddressNavigator` mounts
- reuse the existing transaction hot navigator preloader so Send / Swap / Bridge chunks are warmed for direct single-address entry
- keep the change scoped to the single-address path and avoid release-flow changes

## Validation
- `git diff --check`
- `corepack yarn prettier --check apps/mobile/src/screens/Navigators/SingleAddressNavigator.tsx`
- `corepack yarn eslint apps/mobile/src/screens/Navigators/SingleAddressNavigator.tsx --ext .ts,.tsx` could not run in this local install because ESLint cannot resolve `@react-native-community` from `apps/mobile/.eslintrc.js`
- `corepack yarn workspace rabby-mobile typecheck` was attempted in the new worktree but the local dependency layout does not resolve React Native TypeScript deps (`@tsconfig/react-native`, RN modules, JSX config), so it is not a meaningful validation signal here