### PR TITLE
feat: stabilize token history resource flow

### DIFF
--- a/apps/mobile/src/screens/TokenDetail/components/HistoryList.tsx
+++ b/apps/mobile/src/screens/TokenDetail/components/HistoryList.tsx
@@ -8,7 +8,7 @@ import React, {
 import { useTheme2024 } from '@/hooks/theme';
 import { HistoryDisplayItem } from '@/screens/Transaction/MultiAddressHistory';
 import { createGetStyles2024 } from '@/utils/styles';
-import { useInfiniteScroll, useMemoizedFn, useMount } from 'ahooks';
+import { useMemoizedFn, useMount } from 'ahooks';
 import { KeyringAccountWithAlias } from '@/hooks/account';
 import {
   ensureHistoryListItemFromDb,
@@ -34,6 +34,8 @@ import { KEYRING_CLASS } from '@rabby-wallet/keyring-utils/src/types';
 import { HistoryItemEntity } from '@/databases/entities/historyItem';
 import { ITokenItem } from '@/store/tokens';
 import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+import { syncSingleAddress } from '@/databases/hooks/history';
+import { useAppOrmSyncEvents } from '@/databases/sync/_event';
 
 interface IFetchHistory {
   last: number;
@@ -41,6 +43,15 @@ interface IFetchHistory {
 }
 
 const PAGE_COUNT = 20;
+
+type TokenHistoryData = {
+  list: HistoryDisplayItem[];
+  hasMore: boolean;
+};
+
+type TokenHistoryPage = TokenHistoryData & {
+  last: number;
+};
 
 export const TokenDetailHistoryList = ({
   finalAccount,
@@ -72,15 +83,33 @@ export const TokenDetailHistoryList = ({
   const currentAddress = finalAccount?.address;
 
   const isReady = useRef(false);
-  const lastMap = useRef<Record<string, number>>({});
-  const dbLastCursorRef = useRef<number>(0);
-  const hasMoreMap = useRef<Record<string, boolean>>({});
+  const mountedRef = useRef(true);
+  const requestSeqRef = useRef(0);
+  const cursorRef = useRef(0);
+  const hasMoreRef = useRef(true);
+  const loadingRef = useRef(false);
+  const loadingMoreRef = useRef(false);
+  const firstFetchDoneRef = useRef(false);
+  const [historyData, setHistoryData] = useState<TokenHistoryData>({
+    list: [],
+    hasMore: true,
+  });
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [firstFetchDone, setFirstFetchDone] = useState(false);
 
   const [historySuccessList, setHistorySuccessList] = useState<string[]>(
     transactionHistoryService.getSucceedList(),
   );
 
   const historyListRef = useRef<{ scrollToTop: () => void }>(null);
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      requestSeqRef.current += 1;
+    };
+  }, []);
+
   const handleScroll = useCallback(
     (event: NativeSyntheticEvent<NativeScrollEvent>) => {
       onReachTopStatusChange?.(event.nativeEvent.contentOffset.y <= 0);
@@ -178,100 +207,230 @@ export const TokenDetailHistoryList = ({
   };
 
   const isMyAddress = useMemo(() => {
+    if (!finalAccount) {
+      return false;
+    }
     return (
       finalAccount?.type !== KEYRING_CLASS.WATCH &&
       finalAccount?.type !== KEYRING_CLASS.GNOSIS
     );
   }, [finalAccount]);
 
-  const batchFetchData = useMemoizedFn(async () => {
-    const list: HistoryDisplayItem[] = [];
-    if (disableHistoryRequest) {
-      return {
-        list,
-        hasMore: false,
-      };
-    }
+  const requestKey = useMemo(
+    () =>
+      [
+        currentAddress?.toLowerCase() || '',
+        tokenItem.chain,
+        tokenItem.id,
+        isMyAddress ? 'db' : 'api',
+      ].join(':'),
+    [currentAddress, isMyAddress, tokenItem.chain, tokenItem.id],
+  );
 
-    const account = finalAccount;
-    if (!account) {
-      return {
+  const setLoadingState = useMemoizedFn((next: boolean) => {
+    loadingRef.current = next;
+    if (!mountedRef.current) {
+      return;
+    }
+    setLoading(next);
+  });
+
+  const setLoadingMoreState = useMemoizedFn((next: boolean) => {
+    loadingMoreRef.current = next;
+    if (!mountedRef.current) {
+      return;
+    }
+    setLoadingMore(next);
+  });
+
+  const setFirstFetchDoneState = useMemoizedFn((next: boolean) => {
+    firstFetchDoneRef.current = next;
+    if (!mountedRef.current) {
+      return;
+    }
+    setFirstFetchDone(next);
+  });
+
+  const resetHistoryData = useMemoizedFn(() => {
+    cursorRef.current = 0;
+    hasMoreRef.current = true;
+    setLoadingMoreState(false);
+    if (!mountedRef.current) {
+      return;
+    }
+    setHistoryData({
+      list: [],
+      hasMore: true,
+    });
+    setFirstFetchDoneState(false);
+  });
+
+  const fetchHistoryPage = useMemoizedFn(
+    async (startTime = 0): Promise<TokenHistoryPage> => {
+      const emptyPage = {
         list: [],
         hasMore: false,
+        last: 0,
       };
-    }
-    const addr = account.address.toLowerCase();
-    if (addr in hasMoreMap.current && !hasMoreMap.current[addr]) {
-      return {
-        list: [],
-        hasMore: false,
-      };
-    }
 
-    const result = await fetchData(
-      addr,
-      lastMap.current[addr] || 0,
-      tokenItem.chain,
-      tokenItem.id,
-      isMyAddress,
-    );
-    if (result.list.length < PAGE_COUNT) {
-      hasMoreMap.current[addr] = false;
-    } else {
-      hasMoreMap.current[addr] = true;
-    }
-    lastMap.current[addr] = result.last || 0;
-    list.push(
-      ...result.list.map(item => {
+      if (disableHistoryRequest) {
+        return emptyPage;
+      }
+
+      const account = finalAccount;
+      if (!account) {
+        return emptyPage;
+      }
+      const addr = account.address.toLowerCase();
+
+      const result = await fetchData(
+        addr,
+        startTime,
+        tokenItem.chain,
+        tokenItem.id,
+        isMyAddress,
+      );
+      const list = result.list.map(item => {
         return {
           ...item,
           account,
         };
-      }),
-    );
+      });
 
-    if (!isReady.current) {
-      isReady.current = true;
+      return {
+        list: orderBy(list, 'time_at', 'desc'),
+        hasMore: result.list.length >= PAGE_COUNT && !!result.last,
+        last: result.last || 0,
+      };
+    },
+  );
+
+  const applyHistoryPage = useMemoizedFn(
+    (page: TokenHistoryPage, mode: 'replace' | 'append') => {
+      if (!mountedRef.current) {
+        return;
+      }
+
+      setHistoryData(prev => {
+        if (mode === 'replace') {
+          if (!page.list.length && prev.list.length) {
+            hasMoreRef.current = prev.hasMore;
+            return prev;
+          }
+
+          cursorRef.current = page.last;
+          hasMoreRef.current = page.hasMore;
+          return {
+            list: page.list,
+            hasMore: page.hasMore,
+          };
+        }
+
+        if (!page.list.length) {
+          hasMoreRef.current = false;
+          return {
+            list: prev.list,
+            hasMore: false,
+          };
+        }
+
+        const existingKeys = new Set(prev.list.map(item => item.key));
+        const nextList = orderBy(
+          [
+            ...prev.list,
+            ...page.list.filter(item => !existingKeys.has(item.key)),
+          ],
+          'time_at',
+          'desc',
+        );
+
+        cursorRef.current = page.last;
+        hasMoreRef.current = page.hasMore;
+        return {
+          list: nextList,
+          hasMore: page.hasMore,
+        };
+      });
+    },
+  );
+
+  const reloadHistory = useMemoizedFn(async (clearList = false) => {
+    const requestId = ++requestSeqRef.current;
+
+    if (clearList) {
+      resetHistoryData();
+    } else {
+      setFirstFetchDoneState(false);
     }
-    return {
-      list: orderBy(list, 'time_at', 'desc'),
-      hasMore: Object.values(hasMoreMap.current).some(item => item),
-    };
+    setLoadingMoreState(false);
+    setLoadingState(true);
+
+    try {
+      const page = await fetchHistoryPage(0);
+      if (requestSeqRef.current !== requestId) {
+        return;
+      }
+      applyHistoryPage(page, 'replace');
+    } finally {
+      if (requestSeqRef.current === requestId) {
+        setLoadingState(false);
+        setFirstFetchDoneState(true);
+      }
+    }
   });
 
-  const {
-    data: fetchApiData,
-    loading,
-    loadingMore,
-    loadMore,
-    noMore,
-    reloadAsync,
-    cancel,
-  } = useInfiniteScroll(() => batchFetchData(), {
-    isNoMore: d => disableHistoryRequest || (d ? !d.hasMore : false),
-    onSuccess() {},
+  const loadMoreHistory = useMemoizedFn(async () => {
+    if (disableHistoryRequest) {
+      return;
+    }
+    if (
+      loadingRef.current ||
+      loadingMoreRef.current ||
+      !firstFetchDoneRef.current ||
+      !hasMoreRef.current
+    ) {
+      return;
+    }
+
+    const requestId = ++requestSeqRef.current;
+    setLoadingMoreState(true);
+
+    try {
+      const page = await fetchHistoryPage(cursorRef.current);
+      if (requestSeqRef.current !== requestId) {
+        return;
+      }
+      applyHistoryPage(page, 'append');
+    } finally {
+      if (requestSeqRef.current === requestId) {
+        setLoadingMoreState(false);
+      }
+    }
   });
 
   const refresh = useMemoizedFn(() => {
-    lastMap.current = {};
-    hasMoreMap.current = {};
-    if (!disableHistoryRequest) {
-      reloadAsync();
-    }
+    reloadHistory(false);
     onRefresh?.();
   });
 
   useEffect(() => {
-    if (isReady.current) {
-      cancel();
-      refresh();
+    const shouldScrollToTop = isReady.current;
+    reloadHistory(true);
+    if (shouldScrollToTop) {
+      historyListRef.current?.scrollToTop();
+    } else {
+      isReady.current = true;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sceneCurrentAccountDepKey, isSceneUsingAllAccounts]);
+  }, [
+    disableHistoryRequest,
+    isSceneUsingAllAccounts,
+    reloadHistory,
+    requestKey,
+    sceneCurrentAccountDepKey,
+  ]);
 
   const batchFetchDataFromDbUpsert = useMemoizedFn(async () => {
-    dbLastCursorRef.current = 0;
-    reloadAsync();
+    reloadHistory(false);
   });
 
   const throttleBatchFetchData = useMemo(
@@ -289,6 +448,19 @@ export const TokenDetailHistoryList = ({
     };
   }, [throttleBatchFetchData]);
 
+  useAppOrmSyncEvents({
+    taskFor: ['all-history'],
+    onRemoteDataUpserted: ctx => {
+      if (!ctx.success || !isMyAddress || !currentAddress) {
+        return;
+      }
+      if (ctx.owner_addr.toLowerCase() !== currentAddress.toLowerCase()) {
+        return;
+      }
+      throttleBatchFetchData();
+    },
+  });
+
   useMount(() => {
     const list = transactionHistoryService.getSucceedList();
     setHistorySuccessList(list);
@@ -297,12 +469,31 @@ export const TokenDetailHistoryList = ({
 
   const displayList = useMemo(() => {
     return (
-      fetchApiData?.list.filter(tx => {
+      historyData.list.filter(tx => {
         const shouldShowBasedOnType = !tx.is_scam;
         return shouldShowBasedOnType;
       }) || []
     );
-  }, [fetchApiData]);
+  }, [historyData.list]);
+
+  const noMore =
+    disableHistoryRequest || (firstFetchDone && !historyData.hasMore);
+
+  useEffect(() => {
+    if (!isMyAddress || !firstFetchDone || displayList.length || loading) {
+      return;
+    }
+    if (!currentAddress) {
+      return;
+    }
+    syncSingleAddress(currentAddress.toLowerCase());
+  }, [
+    currentAddress,
+    displayList.length,
+    firstFetchDone,
+    isMyAddress,
+    loading,
+  ]);
 
   return (
     <HistoryList
@@ -338,10 +529,10 @@ export const TokenDetailHistoryList = ({
       scrollEventThrottle={16}
       loadMore={() => {
         // avoid exec multi times loadMore
-        if (loadingMore || noMore) {
+        if (loading || loadingMore || noMore || !firstFetchDone) {
           return;
         }
-        loadMore();
+        loadMoreHistory();
       }}
       onRefresh={refresh}
     />


### PR DESCRIPTION
## Summary

- Stabilize token detail history pagination with an explicit resource-flow state.
- Preserve existing history rows when a same-token refresh returns an empty page without deletion evidence.
- Ignore stale async responses and trigger single-address sync for empty first fetches.

## Validation

- eslint apps/mobile/src/screens/TokenDetail/components/HistoryList.tsx --quiet
- git diff --check
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- Built Android regression APK 0.6.77+100225, installed and launched on Samsung RFCW613R7HV, uploaded to Lark.

## Notes

- Full workspace typecheck was attempted earlier but is currently blocked by existing unrelated workspace package/type resolution issues.
