### PR TITLE
chore: disable transaction notifications

### DIFF
--- a/apps/mobile/src/constant/index.ts
+++ b/apps/mobile/src/constant/index.ts
@@ -128,6 +128,7 @@ export const APP_TEST_PWD = __DEV__ ? '11111111' : '';
 
 export const APP_FEATURE_SWITCH = {
   customizePassword: true,
+  transactionNotification: false,
   showBiometricUnlockProgressToast: false,
   get biometricsAuth() {
     return !!this.customizePassword;

--- a/apps/mobile/src/core/notifications/index.ts
+++ b/apps/mobile/src/core/notifications/index.ts
@@ -6,8 +6,13 @@ import {
 } from './register';
 
 import { startConnectFeServiceInterval } from './test-server';
+import { APP_FEATURE_SWITCH } from '@/constant';
 
 export async function connectPushServerOnBootstrap() {
+  if (!APP_FEATURE_SWITCH.transactionNotification) {
+    return;
+  }
+
   startSubscribePushNotifications();
   startConnectPushServerInterval();
 

--- a/apps/mobile/src/core/notifications/openapi.ts
+++ b/apps/mobile/src/core/notifications/openapi.ts
@@ -6,6 +6,7 @@ import { makeDeviceUUID } from '../apis/device';
 import { TxHistoryResult } from '@rabby-wallet/rabby-api/dist/types';
 import { AppState } from 'react-native';
 import { instrumentOpenApiFailureLogging } from '@/utils/openapiFailureLogging';
+import { APP_FEATURE_SWITCH } from '@/constant';
 
 export type DeviceActiveStatusResponse = {
   success: boolean;
@@ -35,6 +36,14 @@ class NotificationsOpenApiService extends OpenApiService {
     // deviceId: string;
     isActive: boolean;
   }): Promise<DeviceActiveStatusResponse> {
+    if (!APP_FEATURE_SWITCH.transactionNotification) {
+      return {
+        success: false,
+        device_id: '',
+        is_active: false,
+      };
+    }
+
     const response = await this.request.post('/v1/notification/device/active', {
       device_id: this.#getDeviceUUID(),
       is_active: params.isActive,
@@ -43,6 +52,14 @@ class NotificationsOpenApiService extends OpenApiService {
   }
 
   async heartbeat(/* params: { app_state: 'foreground' | 'background' } */): Promise<HeartbeatResponse> {
+    if (!APP_FEATURE_SWITCH.transactionNotification) {
+      return {
+        success: false,
+        device_id: '',
+        ttl: 0,
+      };
+    }
+
     const response = await this.request.post(
       '/v1/notification/device/heartbeat',
       {
@@ -60,6 +77,16 @@ class NotificationsOpenApiService extends OpenApiService {
     pushToken: string;
     userAddrs: string[];
   }): Promise<BindDeviceResponse> {
+    if (!APP_FEATURE_SWITCH.transactionNotification) {
+      return {
+        success: false,
+        device_id: '',
+        total: 0,
+        added: 0,
+        removed: 0,
+      };
+    }
+
     const response = await this.request.post('/v1/notification/bind', {
       application_id: APPLICATION_ID,
       device_id: this.#getDeviceUUID(),

--- a/apps/mobile/src/core/notifications/register.ts
+++ b/apps/mobile/src/core/notifications/register.ts
@@ -18,6 +18,7 @@ import { notificationEvents, parseRemoteData } from './data';
 import { getTopMyAccountsOnNotifications } from './utils';
 import { makeAvoidParallelAsyncFunc } from '../utils/concurrency';
 import { APP_MMKV_KEYS } from '../storage/mmkvConstants';
+import { APP_FEATURE_SWITCH } from '@/constant';
 
 const iosPush = {
   token: '',
@@ -49,35 +50,52 @@ export function useNotificationStore() {
   return { pushToken };
 }
 
-const iosTokenReady = new Promise<string>((resolve, reject) => {
-  if (IS_IOS) {
-    PushNotificationIOS.addEventListener('register', deviceToken => {
-      PushNotificationIOS.removeEventListener('register');
+let iosTokenReady: Promise<string> | null = null;
+const getIosTokenReady = () => {
+  if (!iosTokenReady) {
+    iosTokenReady = new Promise<string>((resolve, reject) => {
+      if (IS_IOS) {
+        PushNotificationIOS.addEventListener('register', deviceToken => {
+          PushNotificationIOS.removeEventListener('register');
 
-      console.debug('[iosTokenReady] iOS APNs device token:', deviceToken);
-      iosPush.token = deviceToken;
-      iosPush.error = null;
-      resolve(deviceToken);
+          console.debug('[iosTokenReady] iOS APNs device token:', deviceToken);
+          iosPush.token = deviceToken;
+          iosPush.error = null;
+          resolve(deviceToken);
+        });
+
+        PushNotificationIOS.addEventListener('registrationError', error => {
+          PushNotificationIOS.removeEventListener('registrationError');
+
+          console.error('[iosTokenReady] iOS APNs registration error:', error);
+          iosPush.error = error;
+          iosPush.token = '';
+          reject(error);
+        });
+      } else {
+        resolve('');
+      }
     });
-
-    PushNotificationIOS.addEventListener('registrationError', error => {
-      PushNotificationIOS.removeEventListener('registrationError');
-
-      console.error('[iosTokenReady] iOS APNs registration error:', error);
-      iosPush.error = error;
-      iosPush.token = '';
-      reject(error);
-    });
-  } else {
-    resolve('');
   }
-});
+
+  return iosTokenReady;
+};
 
 export const registerForPushNotifications = async () => {
+  if (!APP_FEATURE_SWITCH.transactionNotification) {
+    notificationStore.setState(prev => {
+      prev.pushToken = '';
+    });
+
+    return {
+      pushToken: '',
+    };
+  }
+
   let pushToken = '';
 
   if (Platform.OS === 'ios') {
-    pushToken = await iosTokenReady;
+    pushToken = await getIosTokenReady();
     const authStatus = await iosCheckPermission();
     const enabled = authStatus?.alert ?? false;
     if (!enabled) {
@@ -108,6 +126,10 @@ export const registerForPushNotifications = async () => {
 };
 
 export const startSubscribePushNotifications = async () => {
+  if (!APP_FEATURE_SWITCH.transactionNotification) {
+    return;
+  }
+
   if (IS_IOS) {
     const intialNotificationPromise =
       PushNotificationIOS.getInitialNotification();
@@ -250,6 +272,10 @@ function onHeartbeatResponse(resp: HeartbeatResponse) {
 
 const CONNECT_DURATION_MS = __DEV__ ? 5 * 1000 : 30 * 1000;
 export async function startConnectPushServerInterval() {
+  if (!APP_FEATURE_SWITCH.transactionNotification) {
+    return;
+  }
+
   const requstConnect = async (appEnabled?: boolean) => {
     const { enabled } = await checkIfEnabledNotificationWithPermission(
       appEnabled,
@@ -288,6 +314,16 @@ export async function startConnectPushServerInterval() {
 }
 
 export const requestBindDevice = async (pushToken: string) => {
+  if (!APP_FEATURE_SWITCH.transactionNotification) {
+    return {
+      success: false,
+      device_id: '',
+      total: 0,
+      added: 0,
+      removed: 0,
+    };
+  }
+
   return notificationOpenapi.bindDevice({
     platform: Platform.OS === 'ios' ? 'ios' : 'android',
     pushToken,
@@ -298,6 +334,10 @@ export const requestBindDevice = async (pushToken: string) => {
 };
 
 export async function startBindPushServerOnDemand(pushToken: string) {
+  if (!APP_FEATURE_SWITCH.transactionNotification) {
+    return;
+  }
+
   perfEvents.on('USER_MANUALLY_UNLOCK_UI_READY', () => {
     requestBindDevice(pushToken);
   });

--- a/apps/mobile/src/core/notifications/switch.ts
+++ b/apps/mobile/src/core/notifications/switch.ts
@@ -7,6 +7,7 @@ import { IS_ANDROID, IS_IOS } from '@/core/native/utils';
 import PushNotificationIOS, {
   PushNotificationPermissions,
 } from '@react-native-community/push-notification-ios';
+import { APP_FEATURE_SWITCH } from '@/constant';
 
 export function iosCheckPermission(): Promise<PushNotificationPermissions> {
   return new Promise(resolve => {
@@ -17,6 +18,10 @@ export function iosCheckPermission(): Promise<PushNotificationPermissions> {
 }
 
 export const checkNotificationPermission = async (): Promise<boolean> => {
+  if (!APP_FEATURE_SWITCH.transactionNotification) {
+    return false;
+  }
+
   if (Platform.OS === 'ios') {
     const settings = await iosCheckPermission();
 
@@ -34,6 +39,10 @@ export const checkNotificationPermission = async (): Promise<boolean> => {
 };
 
 export const requestUngrantedNotificationPermission = async () => {
+  if (!APP_FEATURE_SWITCH.transactionNotification) {
+    return 'denied';
+  }
+
   if (IS_ANDROID) {
     if (DeviceUtils.isGteAndroid(13)) {
       return PerAndroid.applyAndroidPermission(
@@ -60,6 +69,15 @@ export const requestUngrantedNotificationPermission = async () => {
 export async function checkIfEnabledNotificationWithPermission(
   inputAppEnabled?: boolean,
 ) {
+  if (!APP_FEATURE_SWITCH.transactionNotification) {
+    return {
+      hasPermission: false,
+      appEnabled: false,
+      iosDisabledDueToForeground: false,
+      enabled: false,
+    };
+  }
+
   const appEnabled =
     inputAppEnabled ??
     preferenceService.getPreferenceByKey('enabledTransactionNofification') ??

--- a/apps/mobile/src/core/notifications/test-server.ts
+++ b/apps/mobile/src/core/notifications/test-server.ts
@@ -7,6 +7,7 @@ import { stringUtils } from '@rabby-wallet/base-utils';
 import { checkIfEnabledNotificationWithPermission } from './switch';
 import { IS_IOS } from '../native/utils';
 import { AppState } from 'react-native';
+import { APP_FEATURE_SWITCH } from '@/constant';
 
 export function getFeServiceURL() {
   if (!isNonPublicProductionEnv) return RABBY_MOBILE_FE_SERVICE_URL || null;
@@ -24,6 +25,10 @@ export function getFeServiceURL() {
 }
 
 export const connectFeService = async (data: { pushToken: string }) => {
+  if (!APP_FEATURE_SWITCH.transactionNotification) {
+    return;
+  }
+
   const pushToken = data.pushToken;
   if (!pushToken) {
     throw new Error(
@@ -86,6 +91,10 @@ const connectFeServiceIntervalRef = {
   lastSuccessSignature: '',
 };
 export function startConnectFeServiceInterval(pushToken: string) {
+  if (!APP_FEATURE_SWITCH.transactionNotification) {
+    return;
+  }
+
   if (!pushToken) {
     if (__DEV__) {
       console.warn(

--- a/apps/mobile/src/hooks/appNotification.ts
+++ b/apps/mobile/src/hooks/appNotification.ts
@@ -22,6 +22,7 @@ import {
   checkNotificationPermission,
   requestUngrantedNotificationPermission,
 } from '@/core/notifications/switch';
+import { APP_FEATURE_SWITCH } from '@/constant';
 
 const appNotificationStore = zCreate<{
   /**
@@ -33,12 +34,22 @@ const appNotificationStore = zCreate<{
   return {
     hasSystemPermission: null,
     enabledTransactionNofification:
-      preferenceService.getPreferenceByKey('enabledTransactionNofification') ??
-      false,
+      APP_FEATURE_SWITCH.transactionNotification &&
+      (preferenceService.getPreferenceByKey('enabledTransactionNofification') ??
+        false),
   };
 });
 
 export async function fetchHasSystemPermission() {
+  if (!APP_FEATURE_SWITCH.transactionNotification) {
+    appNotificationStore.setState({
+      hasSystemPermission: false,
+      enabledTransactionNofification: false,
+    });
+
+    return false;
+  }
+
   const hasSystemPermission = await checkNotificationPermission();
   appNotificationStore.setState({ hasSystemPermission });
 
@@ -46,6 +57,10 @@ export async function fetchHasSystemPermission() {
 }
 
 export async function startCareAppNotificationPermissions() {
+  if (!APP_FEATURE_SWITCH.transactionNotification) {
+    return;
+  }
+
   const hasSystemPermission = await fetchHasSystemPermission();
 
   if (
@@ -66,6 +81,15 @@ export async function startCareAppNotificationPermissions() {
 export async function setEnableTransactionNofification(
   valOrFunc: UpdaterOrPartials<boolean>,
 ) {
+  if (!APP_FEATURE_SWITCH.transactionNotification) {
+    appNotificationStore.setState({
+      hasSystemPermission: false,
+      enabledTransactionNofification: false,
+    });
+
+    return false;
+  }
+
   fetchHasSystemPermission();
   const hasSystemPermission =
     appNotificationStore.getState().hasSystemPermission;
@@ -126,6 +150,15 @@ export const useAppNotificationEnabled = () => {
     s => s.enabledTransactionNofification,
   );
   const hasSystemPermission = appNotificationStore(s => s.hasSystemPermission);
+
+  if (!APP_FEATURE_SWITCH.transactionNotification) {
+    return {
+      enabledTransactionNofification: false,
+      hasSystemPermission: false,
+      value: false,
+      setValue: setEnableTransactionNofification,
+    };
+  }
 
   return {
     enabledTransactionNofification,

--- a/apps/mobile/src/hooks/navigation.tsx
+++ b/apps/mobile/src/hooks/navigation.tsx
@@ -18,6 +18,7 @@ import { CustomTouchableOpacity } from '@/components/CustomTouchableOpacity';
 
 import { default as RcIconHeaderBack } from '@/assets/icons/header/back-cc.svg';
 import { AppRootName, RootNames, makeHeadersPresets } from '@/constant/layout';
+import { APP_FEATURE_SWITCH } from '@/constant';
 import {
   NavigationContainerRef,
   useNavigation,
@@ -867,6 +868,10 @@ export function startSubscribeIOSScreenRecording() {
 }
 
 export function startSubscribeRemoteNotification() {
+  if (!APP_FEATURE_SWITCH.transactionNotification) {
+    return;
+  }
+
   function earlyReturnL1<T = any>(retValue?: T) {
     return retValue;
   }

--- a/apps/mobile/src/screens/Settings/Block.tsx
+++ b/apps/mobile/src/screens/Settings/Block.tsx
@@ -211,6 +211,7 @@ export type SettingConfBlock = {
     | 'rightNode'
     | 'disabled'
     | 'onDisabledPress'
+    | 'visible'
     | 'testID'
     | 'accessibilityLabel'
   >[];

--- a/apps/mobile/src/screens/Settings/Settings.tsx
+++ b/apps/mobile/src/screens/Settings/Settings.tsx
@@ -369,6 +369,10 @@ function SettingsBlocks() {
   }, []);
 
   const handleTransactionNotificationToggle = useCallback(async () => {
+    if (!APP_FEATURE_SWITCH.transactionNotification) {
+      return;
+    }
+
     const finalValue = await setEnableTransactionNofification(prev => !prev);
     if (typeof finalValue !== 'boolean') {
       return;
@@ -452,6 +456,7 @@ function SettingsBlocks() {
             label: t('page.setting.transactionNotification'),
             icon: RcNotification,
             rightNode: <TrackedTransactionNotificationSwitch />,
+            visible: APP_FEATURE_SWITCH.transactionNotification,
             onPress: () => {
               handleTransactionNotificationToggle();
             },

--- a/apps/mobile/src/setup-app-before-render.runtime.ts
+++ b/apps/mobile/src/setup-app-before-render.runtime.ts
@@ -68,13 +68,16 @@ import { startWatchLayoutChange } from './hooks/useAppLayout';
 import { startCareAppNotificationPermissions } from './hooks/appNotification';
 import nftListStore from './store/nfts';
 import { keyringService } from './core/services';
+import { APP_FEATURE_SWITCH } from './constant';
 
 const UNLOCKED_STORES_AFTER_UNLOCK_DELAY_MS = 800;
 
 startComputationThread();
 startSubscribeLangChange();
 
-connectPushServerOnBootstrap();
+if (APP_FEATURE_SWITCH.transactionNotification) {
+  connectPushServerOnBootstrap();
+}
 
 startManageAccountStoreLifecycle();
 loadLockInfoOnBootstrap();
@@ -120,8 +123,10 @@ trimNoLongerSupportsOnUnlock();
 startCheckClearAction();
 startSubscribeOpenApiHttpErrorDebugToast();
 
-startCareAppNotificationPermissions();
-startSubscribeRemoteNotification();
+if (APP_FEATURE_SWITCH.transactionNotification) {
+  startCareAppNotificationPermissions();
+  startSubscribeRemoteNotification();
+}
 
 async function initPersistedStores() {
   console.time('initPersistedStores');

--- a/apps/mobile/src/utils/analytics0331.ts
+++ b/apps/mobile/src/utils/analytics0331.ts
@@ -14,6 +14,7 @@ import { AppState } from 'react-native';
 
 import { SupportedLang } from '@/utils/i18n';
 import { matomoRequestEvent } from './analytics';
+import { APP_FEATURE_SWITCH } from '@/constant';
 
 type SettingsSnapshotPayload = {
   biometricsEnabled: boolean;
@@ -221,6 +222,10 @@ export const trackSettingsFaceId = async (enabled: boolean) => {
 };
 
 export const trackSettingsTxNotification = async (enabled: boolean) => {
+  if (!APP_FEATURE_SWITCH.transactionNotification) {
+    return false;
+  }
+
   return matomoRequestEvent({
     category: 'Settings Snapshot',
     action: 'Settings_TxNoti',
@@ -263,18 +268,12 @@ export const trackSettingsScreenshotToBug = async (enabled: boolean) => {
 export const trackSettingsSnapshotsOncePerDay = async (
   payload: SettingsSnapshotPayload,
 ) => {
-  await Promise.all([
+  const tasks = [
     trackSnapshotEventOncePerDay({
       trackKey: 'Settings_FaceID',
       category: 'Settings Snapshot',
       action: 'Settings_FaceID',
       label: getOnOffLabel(payload.biometricsEnabled),
-    }),
-    trackSnapshotEventOncePerDay({
-      trackKey: 'Settings_TxNoti',
-      category: 'Settings Snapshot',
-      action: 'Settings_TxNoti',
-      label: getOnOffLabel(payload.txNotificationEnabled),
     }),
     trackSnapshotEventOncePerDay({
       trackKey: 'Settings_LockTime',
@@ -300,7 +299,20 @@ export const trackSettingsSnapshotsOncePerDay = async (
       action: 'Settings_SStoBug',
       label: getOnOffLabel(payload.screenshotToBugEnabled),
     }),
-  ]);
+  ];
+
+  if (APP_FEATURE_SWITCH.transactionNotification) {
+    tasks.push(
+      trackSnapshotEventOncePerDay({
+        trackKey: 'Settings_TxNoti',
+        category: 'Settings Snapshot',
+        action: 'Settings_TxNoti',
+        label: getOnOffLabel(payload.txNotificationEnabled),
+      }),
+    );
+  }
+
+  await Promise.all(tasks);
 };
 
 export const useTrack0331HomeActiveSnapshots = () => {


### PR DESCRIPTION
## Summary
- Add a constant feature switch and turn transaction notifications off.
- Hide the Settings transaction notification entry.
- Stop push registration, notification permission prompting, APNs/FCM token collection, device binding, active/heartbeat reporting, FE push-service connect, and remote notification tap handling.
- Keep notificationOpenapi.getUserTxDetail available for non-push consumers such as Swap history fallback.

## Validation
- DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged
- corepack yarn workspace rabby-mobile typecheck