### PR TITLE
fix: sync cross-arch mobile fixes

### DIFF
--- a/apps/mobile/ios/RabbyMobile/RNScreenshotPrevent.m
+++ b/apps/mobile/ios/RabbyMobile/RNScreenshotPrevent.m
@@ -76,9 +76,12 @@ RCT_EXPORT_MODULE();
             @"imageType": @"",
             @"captured": @FALSE
           } mutableCopy];
-          UIViewController *presentedViewController = RCTPresentedViewController();
-
-          UIImage *image = [self convertViewToImage:presentedViewController.view.superview];
+          UIImage *image = [self convertVisibleWindowsToImage];
+          if (!image) {
+              UIViewController *presentedViewController = RCTPresentedViewController();
+              UIView *fallbackView = presentedViewController.view.superview ?: presentedViewController.view;
+              image = [self convertViewToImage:fallbackView];
+          }
           NSData *data = UIImagePNGRepresentation(image);
           if (!data) {
               [self sendEventWithName:@"userDidTakeScreenshot" body: result];
@@ -281,10 +284,101 @@ CGSize CGSizeAspectFill(const CGSize aspectRatio, const CGSize minimumSize)
 }
 
 - (UIImage *)convertViewToImage:(UIView *)view {
+    if (!view) {
+        return nil;
+    }
+
     // UIGraphicsBeginImageContextWithOptions(view.bounds.size, view.opaque, 0.0);
     // [view.layer renderInContext:UIGraphicsGetCurrentContext()];
     UIGraphicsBeginImageContextWithOptions(view.bounds.size, NO, 0.0);
     [view drawViewHierarchyInRect:view.bounds afterScreenUpdates:YES];
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return image;
+}
+
+- (NSArray<UIWindow *> *)visibleWindowsForScreenshot {
+    NSMutableArray<UIWindow *> *windows = [NSMutableArray array];
+
+    if (@available(iOS 13.0, *)) {
+        for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+            if (![scene isKindOfClass:[UIWindowScene class]]) {
+                continue;
+            }
+
+            BOOL isForeground = scene.activationState == UISceneActivationStateForegroundActive ||
+                scene.activationState == UISceneActivationStateForegroundInactive;
+            if (!isForeground) {
+                continue;
+            }
+
+            UIWindowScene *windowScene = (UIWindowScene *)scene;
+            for (UIWindow *window in windowScene.windows) {
+                if (!window.hidden && window.alpha > 0.01 && !CGRectIsEmpty(window.bounds)) {
+                    [windows addObject:window];
+                }
+            }
+        }
+    }
+
+    if (windows.count == 0) {
+        for (UIWindow *window in [UIApplication sharedApplication].windows) {
+            if (!window.hidden && window.alpha > 0.01 && !CGRectIsEmpty(window.bounds)) {
+                [windows addObject:window];
+            }
+        }
+    }
+
+    [windows sortUsingComparator:^NSComparisonResult(UIWindow *left, UIWindow *right) {
+        if (left.windowLevel < right.windowLevel) {
+            return NSOrderedAscending;
+        }
+
+        if (left.windowLevel > right.windowLevel) {
+            return NSOrderedDescending;
+        }
+
+        return NSOrderedSame;
+    }];
+
+    return windows;
+}
+
+- (UIWindow *)baseWindowForScreenshot:(NSArray<UIWindow *> *)windows {
+    for (UIWindow *window in windows) {
+        if (window.isKeyWindow) {
+            return window;
+        }
+    }
+
+    return windows.firstObject;
+}
+
+- (UIImage *)convertVisibleWindowsToImage {
+    NSArray<UIWindow *> *windows = [self visibleWindowsForScreenshot];
+    if (windows.count == 0) {
+        return nil;
+    }
+
+    UIWindow *baseWindow = [self baseWindowForScreenshot:windows];
+    CGSize canvasSize = baseWindow.bounds.size;
+    CGFloat scale = baseWindow.screen.scale;
+    if (canvasSize.width <= 0 || canvasSize.height <= 0) {
+        canvasSize = [UIScreen mainScreen].bounds.size;
+    }
+    if (scale <= 0) {
+        scale = 0.0;
+    }
+
+    UIGraphicsBeginImageContextWithOptions(canvasSize, NO, scale);
+    for (UIWindow *window in windows) {
+        CGRect drawRect = window.frame;
+        if (CGRectIsEmpty(drawRect)) {
+            drawRect = (CGRect){CGPointZero, window.bounds.size};
+        }
+
+        [window drawViewHierarchyInRect:drawRect afterScreenUpdates:NO];
+    }
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
     return image;

--- a/apps/mobile/src/components/Screenshot/hooks.ts
+++ b/apps/mobile/src/components/Screenshot/hooks.ts
@@ -27,8 +27,8 @@ import DeviceUtils from '@/core/utils/device';
 import { perfEvents } from '@/core/utils/perf';
 import {
   getVisibleBlockingModalIds,
-  hasVisibleBlockingModal,
   MODAL_GATE_IDS,
+  subscribeModalGateDebugSnapshot,
 } from '@/utils/modalGate';
 
 export const FORCE_DISABLE_FEEDBACK_BY_SCREENSHOT =
@@ -429,26 +429,38 @@ const shouldToastFeedbackByScreenshot = () => {
   );
 };
 
-const setLastScreenshot = (
-  image: ImageResolvedAssetSource | null,
-  uploadNow = false,
-) => {
-  if (
-    image &&
-    hasVisibleBlockingModal({
-      excludeIds: [MODAL_GATE_IDS.screenshotFeedback],
-    })
-  ) {
-    __DEV__ &&
-      console.debug(
-        '[modal-gate] skip screenshot feedback modal open, blocking modals:',
-        getVisibleBlockingModalIds({
-          excludeIds: [MODAL_GATE_IDS.screenshotFeedback],
-        }),
-      );
+const SCREENSHOT_FEEDBACK_MODAL_GATE_EXCLUDE_IDS = [
+  MODAL_GATE_IDS.screenshotFeedback,
+];
+const DEFERRED_SCREENSHOT_MODAL_OPEN_DELAY_MS = 450;
+
+type PendingScreenshotFeedback = {
+  image: ImageResolvedAssetSource;
+  uploadNow: boolean;
+};
+
+let pendingScreenshotFeedback: PendingScreenshotFeedback | null = null;
+let pendingScreenshotFeedbackTimer: ReturnType<typeof setTimeout> | null = null;
+
+function getBlockingModalIdsForScreenshotFeedback() {
+  return getVisibleBlockingModalIds({
+    excludeIds: SCREENSHOT_FEEDBACK_MODAL_GATE_EXCLUDE_IDS,
+  });
+}
+
+function clearPendingScreenshotFeedbackTimer() {
+  if (!pendingScreenshotFeedbackTimer) {
     return;
   }
 
+  clearTimeout(pendingScreenshotFeedbackTimer);
+  pendingScreenshotFeedbackTimer = null;
+}
+
+const setLastScreenshotNow = (
+  image: ImageResolvedAssetSource | null,
+  uploadNow = false,
+) => {
   setFeedbackByScreenshot(prev => ({
     ...prev,
     lastScreenshot: image,
@@ -468,6 +480,76 @@ const setLastScreenshot = (
       },
     );
   }
+};
+
+function schedulePendingScreenshotFeedbackFlush() {
+  clearPendingScreenshotFeedbackTimer();
+
+  if (!pendingScreenshotFeedback) {
+    return;
+  }
+
+  const blockingModalIds = getBlockingModalIdsForScreenshotFeedback();
+  if (blockingModalIds.length) {
+    return;
+  }
+
+  pendingScreenshotFeedbackTimer = setTimeout(() => {
+    pendingScreenshotFeedbackTimer = null;
+
+    if (!pendingScreenshotFeedback) {
+      return;
+    }
+
+    const nextBlockingModalIds = getBlockingModalIdsForScreenshotFeedback();
+    if (nextBlockingModalIds.length) {
+      return;
+    }
+
+    const pending = pendingScreenshotFeedback;
+    pendingScreenshotFeedback = null;
+
+    if (!shouldToastFeedbackByScreenshot()) {
+      return;
+    }
+
+    setLastScreenshotNow(pending.image, pending.uploadNow);
+  }, DEFERRED_SCREENSHOT_MODAL_OPEN_DELAY_MS);
+}
+
+subscribeModalGateDebugSnapshot(() => {
+  schedulePendingScreenshotFeedbackFlush();
+});
+
+const setLastScreenshot = (
+  image: ImageResolvedAssetSource | null,
+  uploadNow = false,
+) => {
+  if (!image) {
+    pendingScreenshotFeedback = null;
+    clearPendingScreenshotFeedbackTimer();
+    setLastScreenshotNow(image, uploadNow);
+    return;
+  }
+
+  const blockingModalIds = getBlockingModalIdsForScreenshotFeedback();
+  if (blockingModalIds.length) {
+    pendingScreenshotFeedback = {
+      image,
+      uploadNow,
+    };
+
+    __DEV__ &&
+      console.debug(
+        '[modal-gate] defer screenshot feedback modal open, blocking modals:',
+        blockingModalIds,
+      );
+
+    schedulePendingScreenshotFeedbackFlush();
+    return;
+  }
+
+  setLastScreenshotNow(image, uploadNow);
 };
 
 export function debugShowSubmitFeedbackByScreenshotModal() {

--- a/apps/mobile/src/components/Tip.tsx
+++ b/apps/mobile/src/components/Tip.tsx
@@ -8,6 +8,7 @@ import { useSwitch } from '@/hooks/useSwitch';
 import { AppColorsVariants } from '@/constant/theme';
 import { RNGHPressable, RNGHPressableProps } from './customized/reexports';
 import { Text } from '@/components/Typography';
+import { TrackedModal } from './Modal/TrackedModal';
 
 type PressableComponent = 'RNPressable' | 'RNGHPressable';
 type PressableComProps<T extends PressableComponent> = T extends 'RNPressable'
@@ -26,9 +27,36 @@ type TipProps<T extends PressableComponent> = Omit<TooltipProps, 'content'> & {
     }) => void;
   };
   noPressable?: boolean;
+  modalGateId?: string;
+  modalGateBlocking?: boolean;
 };
 
 const destroyListeners = new Set<() => void>();
+
+const TipModalGateContext = React.createContext<{
+  modalGateId: string;
+  modalGateBlocking: boolean;
+} | null>(null);
+
+const TipModalWithGate = ({
+  children,
+  ...modalProps
+}: React.PropsWithChildren<Record<string, unknown>>) => {
+  const modalGate = React.useContext(TipModalGateContext);
+
+  if (!modalGate) {
+    return null;
+  }
+
+  return (
+    <TrackedModal
+      {...modalProps}
+      modalId={modalGate.modalGateId}
+      blocking={modalGate.modalGateBlocking}>
+      {children}
+    </TrackedModal>
+  );
+};
 
 function destroyTips() {
   destroyListeners.forEach(listener => {
@@ -47,6 +75,9 @@ const TipBase = <T extends PressableComponent = 'RNPressable'>({
   isLight,
   children,
   noPressable = false,
+  modalGateId,
+  modalGateBlocking = true,
+  modalComponent,
   ...rest
 }: TipProps<T>) => {
   const { colors, styles } = useThemeStyles(getStyle);
@@ -92,6 +123,17 @@ const TipBase = <T extends PressableComponent = 'RNPressable'>({
     [arrowSize, hideArrow],
   );
 
+  const modalGateContextValue = useMemo(
+    () =>
+      modalGateId
+        ? {
+            modalGateId,
+            modalGateBlocking,
+          }
+        : null,
+    [modalGateBlocking, modalGateId],
+  );
+
   const onPress = pressableProps?.onPress;
   const handleOnPress = useCallback<PressableComProps<T>['onPress'] & object>(
     evt => {
@@ -105,7 +147,7 @@ const TipBase = <T extends PressableComponent = 'RNPressable'>({
     [onPress, turnOff, turnOn],
   );
 
-  return (
+  const tooltipNode = (
     <Tooltip
       isVisible={on}
       placement="top"
@@ -119,6 +161,7 @@ const TipBase = <T extends PressableComponent = 'RNPressable'>({
       content={_content}
       showChildInTooltip={false}
       arrowSize={_arrowSize}
+      modalComponent={modalGateId ? TipModalWithGate : modalComponent}
       {...rest}
       contentStyle={StyleSheet.flatten([
         styles.tooltipContent,
@@ -143,6 +186,16 @@ const TipBase = <T extends PressableComponent = 'RNPressable'>({
       )}
     </Tooltip>
   );
+
+  if (modalGateContextValue) {
+    return (
+      <TipModalGateContext.Provider value={modalGateContextValue}>
+        {tooltipNode}
+      </TipModalGateContext.Provider>
+    );
+  }
+
+  return tooltipNode;
 };
 
 export const Tip = Object.assign(TipBase, {

--- a/apps/mobile/src/screens/GasAccount/components/HeaderRight.tsx
+++ b/apps/mobile/src/screens/GasAccount/components/HeaderRight.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/assets2024/icons/gas-account';
 import { Text } from '@/components/Typography';
 import { isSameAddress } from '@rabby-wallet/base-utils/dist/isomorphic/address';
+import { MODAL_GATE_IDS } from '@/utils/modalGate';
 
 export const GasAccountHeader: React.FC<{ showWithdraw: () => void }> = ({
   showWithdraw: openWithdrawPopup,
@@ -65,6 +66,7 @@ export const GasAccountHeader: React.FC<{ showWithdraw: () => void }> = ({
         ]}
         tooltipStyle={styles.tooltipStyle}
         isVisible={visible}
+        modalGateId={MODAL_GATE_IDS.gasAccountHeaderMenu}
         onClose={() => setVisible(false)}
         content={
           <View style={styles.optionList}>

--- a/apps/mobile/src/screens/Home/components/OfflineChainNotify.tsx
+++ b/apps/mobile/src/screens/Home/components/OfflineChainNotify.tsx
@@ -202,36 +202,35 @@ export const OfflineChainNotify = ({
 
   return (
     <View style={[styles.container, style]}>
-      <Image
-        source={{ uri: chainInfo.logo }}
-        width={16}
-        height={16}
-        style={styles.logo}
-      />
+      <Image source={{ uri: chainInfo.logo }} style={styles.logo} />
 
       <View style={styles.textWrapper}>
-        <Text style={styles.text}>
+        <Text style={styles.text} numberOfLines={3} ellipsizeMode="tail">
           {t('page.dashboard.offlineChain.chain', {
             chain: chainInfo.name,
           })}
         </Text>
       </View>
 
-      <TouchableOpacity onPress={showTips} style={{ marginLeft: 40 }}>
-        <RcIconTipsCC
-          color={colors2024['orange-default']}
-          width={16}
-          height={16}
-        />
-      </TouchableOpacity>
+      <View style={styles.actions}>
+        <TouchableOpacity onPress={showTips} style={styles.iconButton}>
+          <RcIconTipsCC
+            color={colors2024['orange-default']}
+            width={16}
+            height={16}
+          />
+        </TouchableOpacity>
 
-      <TouchableOpacity style={{ marginLeft: 16 }} onPress={handleClose}>
-        <RcIconCloseCC
-          color={colors2024['orange-default']}
-          width={16}
-          height={16}
-        />
-      </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.iconButton, styles.closeButton]}
+          onPress={handleClose}>
+          <RcIconCloseCC
+            color={colors2024['orange-default']}
+            width={16}
+            height={16}
+          />
+        </TouchableOpacity>
+      </View>
     </View>
   );
 };
@@ -244,7 +243,7 @@ const getStyle = createGetStyles2024(({ colors2024 }) => ({
     borderRadius: 12,
     backgroundColor: colors2024['orange-light-1'],
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: 'flex-start',
   },
   containerNone: {
     display: 'none',
@@ -253,14 +252,13 @@ const getStyle = createGetStyles2024(({ colors2024 }) => ({
     width: 16,
     height: 16,
     borderRadius: 9999,
-    alignSelf: 'flex-start',
     position: 'relative',
-    top: 1,
+    top: 2,
   },
   textWrapper: {
-    flexDirection: 'row',
-    alignItems: 'center',
     flex: 1,
+    minWidth: 0,
+    marginLeft: 4,
   },
   text: {
     color: colors2024['orange-default'],
@@ -268,7 +266,27 @@ const getStyle = createGetStyles2024(({ colors2024 }) => ({
     fontSize: 16,
     fontStyle: 'normal',
     fontWeight: 500,
-    paddingHorizontal: 4,
+    flex: 1,
+    flexShrink: 1,
+    lineHeight: 20,
+  },
+  actions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    marginLeft: 12,
+    position: 'relative',
+    top: -2,
+  },
+  iconButton: {
+    width: 20,
+    height: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  closeButton: {
+    marginLeft: 12,
   },
 
   title: {

--- a/apps/mobile/src/screens/RestoreFromCloud/RestoreFromCloud2024.tsx
+++ b/apps/mobile/src/screens/RestoreFromCloud/RestoreFromCloud2024.tsx
@@ -16,10 +16,10 @@ import { createGetStyles2024, makeDebugBorder } from '@/utils/styles';
 import { addressUtils } from '@rabby-wallet/base-utils';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { View, StyleSheet, ScrollView } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { BackupItem, BackupItemSkeleton } from './BackupItem2024';
 import { Button } from '@/components2024/Button';
-import { BottomSheetView } from '@gorhom/bottom-sheet';
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 
 import { IS_IOS } from '@/core/native/utils';
 import { BottomSheetHandlableView } from '@/components/customized/BottomSheetHandle';
@@ -172,7 +172,7 @@ export const RestoreFromCloud2024: React.FC<{
             </Text>
           </View>
         </BottomSheetHandlableView>
-        <ScrollView
+        <BottomSheetScrollView
           showsVerticalScrollIndicator={false}
           showsHorizontalScrollIndicator={false}
           style={styles.backupList}>
@@ -198,7 +198,7 @@ export const RestoreFromCloud2024: React.FC<{
               );
             })
           )}
-        </ScrollView>
+        </BottomSheetScrollView>
       </View>
       <Button
         title={t('global.confirm')}

--- a/apps/mobile/src/utils/modalGate.ts
+++ b/apps/mobile/src/utils/modalGate.ts
@@ -24,6 +24,7 @@ export const MODAL_GATE_IDS = {
   syncExtensionNoNewAddresses: 'sync-extension-no-new-addresses',
   gasAccountSwitchLoginAddress: 'gas-account-switch-login-address',
   gasAccountDepositTokenAlert: 'gas-account-deposit-token-alert',
+  gasAccountHeaderMenu: 'gas-account-header-menu',
   perpsAgentsLimit: 'perps-agents-limit',
   perpsDepositToken: 'perps-deposit-token',
   perpsEditTpSlPrice: 'perps-edit-tp-sl-price',


### PR DESCRIPTION
## Summary

- Sync the offline-chain notice layout adjustment back to the shared/old-arch path.
- Sync the screenshot feedback modal handoff fixes, including the iOS screenshot prevent bridge handling and modal gating.
- Use `BottomSheetScrollView` for the cloud restore backup list so iCloud/Google Drive mnemonic restore entries can scroll correctly inside the bottom sheet.

## Notes

This is intentionally opened as a draft while the cross-arch sync is reviewed. The cloud restore list change is the small new-architecture interaction fix Richard remembered, applied here without bringing over unrelated new-architecture changes.

## Validation

- `git diff --check`
- `DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged`
