### PR TITLE
fix： some bug fix & perp data caching  & improve performance

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -93,7 +93,7 @@
     "@rabby-wallet/eth-keyring-watch": "*",
     "@rabby-wallet/eth-simple-keyring": "5.1.2",
     "@rabby-wallet/gnosis-sdk": "1.4.9",
-    "@rabby-wallet/hyperliquid-sdk": "1.1.15-beta.0",
+    "@rabby-wallet/hyperliquid-sdk": "1.1.15-beta.1",
     "@rabby-wallet/object-multiplex": "workspace:^",
     "@rabby-wallet/persist-store": "workspace:^",
     "@rabby-wallet/rabby-action": "0.1.14",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -93,7 +93,7 @@
     "@rabby-wallet/eth-keyring-watch": "*",
     "@rabby-wallet/eth-simple-keyring": "5.1.2",
     "@rabby-wallet/gnosis-sdk": "1.4.9",
-    "@rabby-wallet/hyperliquid-sdk": "1.1.15-beta.1",
+    "@rabby-wallet/hyperliquid-sdk": "1.1.15",
     "@rabby-wallet/object-multiplex": "workspace:^",
     "@rabby-wallet/persist-store": "workspace:^",
     "@rabby-wallet/rabby-action": "0.1.14",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -93,7 +93,7 @@
     "@rabby-wallet/eth-keyring-watch": "*",
     "@rabby-wallet/eth-simple-keyring": "5.1.2",
     "@rabby-wallet/gnosis-sdk": "1.4.9",
-    "@rabby-wallet/hyperliquid-sdk": "1.1.10",
+    "@rabby-wallet/hyperliquid-sdk": "1.1.15-beta.0",
     "@rabby-wallet/object-multiplex": "workspace:^",
     "@rabby-wallet/persist-store": "workspace:^",
     "@rabby-wallet/rabby-action": "0.1.14",

--- a/apps/mobile/src/components/AssetAvatar.tsx
+++ b/apps/mobile/src/components/AssetAvatar.tsx
@@ -3,7 +3,7 @@ import { useThemeStyles } from '@/hooks/theme';
 import { useFindChain } from '@/hooks/useFindChain';
 import { useSwitch } from '@/hooks/useSwitch';
 import { Chain } from '@debank/common';
-import { memo, ReactNode, useMemo } from 'react';
+import { memo, ReactNode, useEffect, useMemo } from 'react';
 import { Image, ImageStyle, StyleSheet, View, ViewStyle } from 'react-native';
 import FastImage, { FastImageProps } from 'react-native-fast-image';
 import { TestnetChainLogo } from './Chain/TestnetChainLogo';
@@ -59,7 +59,13 @@ export const AssetAvatar = memo(
     innerChainStyle,
   }: AssetAvatarProps) => {
     const { styles, isLight } = useThemeStyles(getStyles);
-    const { on, turnOn } = useSwitch();
+    const { on, turnOn, turnOff } = useSwitch();
+
+    // A load failure marks `on` for this instance's lifetime; clear it when
+    // the url changes so a late-arriving/corrected logo gets a fresh attempt.
+    useEffect(() => {
+      turnOff();
+    }, [logo, turnOff]);
 
     const chainInfo = useFindChain({
       serverId: chain || null,

--- a/apps/mobile/src/constant/PerpsTopAsset.json
+++ b/apps/mobile/src/constant/PerpsTopAsset.json
@@ -143,17 +143,6 @@
     "category_id": "memes"
   },
   {
-    "id": "c63538def0a6ce77678955cb8ace334e",
-    "token_id": 0,
-    "name": "cash:USA500",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/cash:USA500/3b03b47b3d0b04414545fa1acb155da7.png",
-    "daily_volume": 37947268,
-    "dex_id": "cash",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
     "id": "a7af2d46cfb6c8799f3e483f46bc17a0",
     "token_id": 3,
     "name": "xyz:GOLD",
@@ -163,6 +152,17 @@
     "category": "Commodities",
     "display_name": "GOLD",
     "category_id": "commodities"
+  },
+  {
+    "id": "63600daf7e650698c22ba1c78fd69354",
+    "token_id": 99,
+    "name": "xyz:SKHY",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:SKHY/3327daf0643c51f834a99982cf8e3bd0.png",
+    "daily_volume": 34917883,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "SKHY",
+    "category_id": "stocks"
   },
   {
     "id": "961cce65d2a7aee2256f404aa9c10c3a",
@@ -187,6 +187,28 @@
     "category_id": "stocks"
   },
   {
+    "id": "e2b9fbb8bfd8152e5081c62adc7cd6b9",
+    "token_id": 91,
+    "name": "xyz:ZHIPU",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:ZHIPU/1c7f9671fabfc7c5a68175c741f0e6a4.png",
+    "daily_volume": 28861835,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "ZHIPU",
+    "category_id": "stocks"
+  },
+  {
+    "id": "7abe7c3c4b225865ec5d63a6c3721475",
+    "token_id": 231,
+    "name": "CASHCAT",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/CASHCAT/a63a4c2e2d017990eb6896eb286706c4.png",
+    "daily_volume": 28282707,
+    "dex_id": "",
+    "category": "",
+    "display_name": "",
+    "category_id": ""
+  },
+  {
     "id": "de520da8877cbc789c6b210a696dcbc5",
     "token_id": 15,
     "name": "kPEPE",
@@ -207,6 +229,17 @@
     "category": "",
     "display_name": "",
     "category_id": ""
+  },
+  {
+    "id": "f46e209c929d03b518a7e39771f63ee1",
+    "token_id": 76,
+    "name": "xyz:SPCX",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:SPCX/eade42a664ebd40e6bcea3b031e5e363.png",
+    "daily_volume": 23783279,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "SPCX",
+    "category_id": "stocks"
   },
   {
     "id": "18e3da87a585b6d1cb00714c7781af6a",
@@ -308,6 +341,17 @@
     "category_id": ""
   },
   {
+    "id": "6f4862a9a705c7dea77f97b43ebfb7df",
+    "token_id": 230,
+    "name": "GRAM",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/GRAM/c39ebd2726bc74808a4a7702fb4fdf99.png",
+    "daily_volume": 14155419,
+    "dex_id": "",
+    "category": "",
+    "display_name": "",
+    "category_id": ""
+  },
+  {
     "id": "07a1204d9bf813c9f0d33f5725b83d07",
     "token_id": 4,
     "name": "xyz:HOOD",
@@ -317,17 +361,6 @@
     "category": "Stocks",
     "display_name": "HOOD",
     "category_id": "stocks"
-  },
-  {
-    "id": "ee746a46408218444948e30e5c10917b",
-    "token_id": 12,
-    "name": "cash:WTI",
-    "full_logo_url": null,
-    "daily_volume": 11975823,
-    "dex_id": "cash",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
   },
   {
     "id": "32a2021d439bd2ad321550b43cbd2f70",
@@ -385,17 +418,6 @@
     "category_id": ""
   },
   {
-    "id": "af687bd6b93d5c30a5f28d99e5b479a8",
-    "token_id": 0,
-    "name": "km:US500",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/km:US500/e42e8f682ffc6c0637ad8f62c2485614.png",
-    "daily_volume": 10482728,
-    "dex_id": "km",
-    "category": "Indices",
-    "display_name": "",
-    "category_id": "indices"
-  },
-  {
     "id": "64edd4ee9ed5a7e9621fd405be8244d5",
     "token_id": 74,
     "name": "NEAR",
@@ -415,6 +437,17 @@
     "dex_id": "xyz",
     "category": "Stocks",
     "display_name": "EWY",
+    "category_id": "stocks"
+  },
+  {
+    "id": "809ccf053690e55d6e7343f74493adea",
+    "token_id": 83,
+    "name": "xyz:IBM",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:IBM/c49129b8dcbd00e5f4d4dceafc5d7a6c.png",
+    "daily_volume": 9002748,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "IBM",
     "category_id": "stocks"
   },
   {
@@ -451,15 +484,15 @@
     "category_id": "stocks"
   },
   {
-    "id": "0ff8e8b50ea9488e520b0dc5162826d8",
-    "token_id": 3,
-    "name": "cash:HOOD",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/cash:HOOD/0a5d5c64932e971bcddad7a5510f503f.png",
-    "daily_volume": 8463629,
-    "dex_id": "cash",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
+    "id": "1682d224f5ad7e031d0411819b7cf4bb",
+    "token_id": 84,
+    "name": "xyz:AVGO",
+    "full_logo_url": null,
+    "daily_volume": 8635685,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "AVGO",
+    "category_id": "stocks"
   },
   {
     "id": "347cbca85aed318356cd4f78b6509882",
@@ -479,9 +512,9 @@
     "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:HIMS/a1ed92a7009c27ac1cc3f5101b555eb9.png",
     "daily_volume": 7802472,
     "dex_id": "xyz",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
+    "category": "Stocks",
+    "display_name": "HIMS",
+    "category_id": "stocks"
   },
   {
     "id": "24ab470c1bb82044446662a989d55e29",
@@ -528,17 +561,6 @@
     "category_id": ""
   },
   {
-    "id": "5a33195892a43a9cb5f8dd6304a77380",
-    "token_id": 1,
-    "name": "cash:TSLA",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/cash:TSLA/0a5d5c64932e971bcddad7a5510f503f.png",
-    "daily_volume": 7457290,
-    "dex_id": "cash",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
     "id": "369225b84b2ee40dbabe94f6793add76",
     "token_id": 7,
     "name": "xyz:COIN",
@@ -559,17 +581,6 @@
     "category": "Stocks",
     "display_name": "MSFT",
     "category_id": "stocks"
-  },
-  {
-    "id": "c93533341e875a16ee3c7867983080a0",
-    "token_id": 10,
-    "name": "cash:SILVER",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/cash:SILVER/0a5d5c64932e971bcddad7a5510f503f.png",
-    "daily_volume": 6928500,
-    "dex_id": "cash",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
   },
   {
     "id": "ec9aa8c1456dc3f8f4c723581838e949",
@@ -625,17 +636,6 @@
     "category": "Stocks",
     "display_name": "MU",
     "category_id": "stocks"
-  },
-  {
-    "id": "840c129931871c040acd789049445439",
-    "token_id": 7,
-    "name": "flx:OIL",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/flx:OIL/bd7277332e2f3559920eb50998d7837f.png",
-    "daily_volume": 6595158,
-    "dex_id": "flx",
-    "category": "Commodities",
-    "display_name": "",
-    "category_id": "commodities"
   },
   {
     "id": "30f56421281e386db702343848c647a4",
@@ -713,17 +713,6 @@
     "category": "Stocks",
     "display_name": "AMZN",
     "category_id": "stocks"
-  },
-  {
-    "id": "98bed1fff7cf22e18f95a5d88f8d5a1d",
-    "token_id": 7,
-    "name": "km:USOIL",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/km:USOIL/be8f53b5ba27eeef8668685fa1b8c169.png",
-    "daily_volume": 5209609,
-    "dex_id": "km",
-    "category": "Commodities",
-    "display_name": "",
-    "category_id": "commodities"
   },
   {
     "id": "f61f321babbab9ebed14041b1ddddcd2",
@@ -825,15 +814,15 @@
     "category_id": ""
   },
   {
-    "id": "442ef0d967ba07fcd9b6cc107892f2bc",
-    "token_id": 5,
-    "name": "cash:INTC",
-    "full_logo_url": null,
-    "daily_volume": 4402720,
-    "dex_id": "cash",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
+    "id": "45ed3bd5a65b8b8f1dbee27220988bce",
+    "token_id": 81,
+    "name": "xyz:QNT",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:QNT/aa2168afb50f1640fa8dee30f078c476.png",
+    "daily_volume": 4236264,
+    "dex_id": "xyz",
+    "category": "preipo",
+    "display_name": "QNT",
+    "category_id": "preipo"
   },
   {
     "id": "f6f636f8205394168e8c8fbdaf467faa",
@@ -880,28 +869,6 @@
     "category_id": ""
   },
   {
-    "id": "8d4d5e0d41a12d5996e8d36f8066ccc9",
-    "token_id": 168,
-    "name": "ZEREBRO",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/ZEREBRO/ac69e36f55bcb71353d640366a9f911a.png",
-    "daily_volume": 3302494,
-    "dex_id": "",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
-    "id": "830967d0d8af8347ad5ef6cadcbdb0de",
-    "token_id": 4,
-    "name": "cash:GOOGL",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/cash:GOOGL/0a5d5c64932e971bcddad7a5510f503f.png",
-    "daily_volume": 3238872,
-    "dex_id": "cash",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
     "id": "5a7e5405631202874b1aca0d8284ff39",
     "token_id": 30,
     "name": "xyz:COPPER",
@@ -924,28 +891,6 @@
     "category_id": "stocks"
   },
   {
-    "id": "56bdc1de890bc540ef0db1a01bb2b90f",
-    "token_id": 9,
-    "name": "km:SILVER",
-    "full_logo_url": null,
-    "daily_volume": 3069401,
-    "dex_id": "km",
-    "category": "Commodities",
-    "display_name": "",
-    "category_id": "commodities"
-  },
-  {
-    "id": "a12a3079e14ced46e69ba52b8a90b21a",
-    "token_id": 183,
-    "name": "IP",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/IP/672d11093fff9898fb7ed16484e55063.png",
-    "daily_volume": 3055679,
-    "dex_id": "",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
     "id": "99ace1aa61927cb05ec651b20a3d6397",
     "token_id": 9,
     "name": "xyz:AAPL",
@@ -966,17 +911,6 @@
     "category": "Memes",
     "display_name": "",
     "category_id": "memes"
-  },
-  {
-    "id": "99f2dada6f62ed81892b1ddedae7a8de",
-    "token_id": 66,
-    "name": "TON",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/TON/c9ee9c517023051e14511f481f75cf71.png",
-    "daily_volume": 2920966,
-    "dex_id": "",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
   },
   {
     "id": "2b333aaa7d749af5eb4b8a377e4ea96a",
@@ -1089,17 +1023,6 @@
     "category_id": ""
   },
   {
-    "id": "741f23f936b334ac89b85d6edac93d55",
-    "token_id": 4,
-    "name": "km:SMALL2000",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/km:SMALL2000/a2ae9803dfcacf27dc9a302d8b081f92.png",
-    "daily_volume": 2438646,
-    "dex_id": "km",
-    "category": "Indices",
-    "display_name": "",
-    "category_id": "indices"
-  },
-  {
     "id": "50c26816bdd3bb2a02def8e11a5cd5a3",
     "token_id": 108,
     "name": "ZETA",
@@ -1109,28 +1032,6 @@
     "category": "",
     "display_name": "",
     "category_id": ""
-  },
-  {
-    "id": "46589dbc497478193d0fc922e5421196",
-    "token_id": 181,
-    "name": "TST",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/TST/dd7460b1f1fc51c2a54bacc1f029a544.png",
-    "daily_volume": 2386319,
-    "dex_id": "",
-    "category": "Memes",
-    "display_name": "",
-    "category_id": "memes"
-  },
-  {
-    "id": "bbff0c486096c0d653fa4961fb18ebe1",
-    "token_id": 10,
-    "name": "km:GOLD",
-    "full_logo_url": null,
-    "daily_volume": 2319306,
-    "dex_id": "km",
-    "category": "Commodities",
-    "display_name": "",
-    "category_id": "commodities"
   },
   {
     "id": "7b98f792fccb603a0c59af0a8f4bdcfa",
@@ -1221,6 +1122,17 @@
     "category_id": ""
   },
   {
+    "id": "8720edfa3e4729babb1c27bc9b142a2d",
+    "token_id": 46,
+    "name": "xyz:KIOXIA",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:KIOXIA/f87cc1ff113965fd8cf88998af46e1e6.png",
+    "daily_volume": 1986651,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "KIOXIA",
+    "category_id": "stocks"
+  },
+  {
     "id": "6a62300b802598c73bde0a2548c72e3c",
     "token_id": 171,
     "name": "SPX",
@@ -1254,26 +1166,15 @@
     "category_id": "memes"
   },
   {
-    "id": "2b3592bde4b93c88169dfd8a2e5c3d23",
-    "token_id": 5,
-    "name": "km:USTECH",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/km:USTECH/eb85fa6def0cdca2d642de000b93e99d.png",
-    "daily_volume": 1744586,
-    "dex_id": "km",
-    "category": "Indices",
-    "display_name": "USTECH100",
-    "category_id": "indices"
-  },
-  {
-    "id": "082415eeb7e51a11a33fab9c6886e132",
-    "token_id": 2,
-    "name": "cash:NVDA",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/cash:NVDA/0a5d5c64932e971bcddad7a5510f503f.png",
-    "daily_volume": 1599699,
-    "dex_id": "cash",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
+    "id": "768fda093426aae2cacda7e80cd9c7a7",
+    "token_id": 80,
+    "name": "xyz:BB",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:BB/1b7641d21e4515f3061b7d9e2f9e5c6c.png",
+    "daily_volume": 1808312,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "BB",
+    "category_id": "stocks"
   },
   {
     "id": "bf1e2d28ca9ca99d7f10c663e672f989",
@@ -1282,28 +1183,6 @@
     "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/FET/5b2cbcaf4c4b67ddde2a040ab368e78b.png",
     "daily_volume": 1589763,
     "dex_id": "",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
-    "id": "02e3c9521667194e7805076209ca8e38",
-    "token_id": 6,
-    "name": "cash:AMZN",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/cash:AMZN/353e48ee26ee5b1cfecc722dced86804.png",
-    "daily_volume": 1561034,
-    "dex_id": "cash",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
-    "id": "2ea2b4b5200b987d781ee7cd4bd52bde",
-    "token_id": 7,
-    "name": "cash:MSFT",
-    "full_logo_url": null,
-    "daily_volume": 1533753,
-    "dex_id": "cash",
     "category": "",
     "display_name": "",
     "category_id": ""
@@ -1353,15 +1232,26 @@
     "category_id": ""
   },
   {
+    "id": "61bb214e47efb230ce2d286feebba3f6",
+    "token_id": 86,
+    "name": "xyz:NBIS",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:NBIS/03e50e2597a5e9714db04d297e13858b.png",
+    "daily_volume": 1393177,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "NBIS",
+    "category_id": "stocks"
+  },
+  {
     "id": "dfdeddbcac99538b1d38b1cf510dbc65",
     "token_id": 63,
     "name": "xyz:BIRD",
     "full_logo_url": null,
     "daily_volume": 1318167,
     "dex_id": "xyz",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
+    "category": "Stocks",
+    "display_name": "BIRD",
+    "category_id": "stocks"
   },
   {
     "id": "9a96bf72912d59d7e8fb05109dcbcba6",
@@ -1375,15 +1265,15 @@
     "category_id": ""
   },
   {
-    "id": "d195eaceb9567f5c49fc53b3a1c53167",
-    "token_id": 9,
-    "name": "cash:GOLD",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/cash:GOLD/0a5d5c64932e971bcddad7a5510f503f.png",
-    "daily_volume": 1295801,
-    "dex_id": "cash",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
+    "id": "de17d9bdb3f112a153bc1efceb3396f3",
+    "token_id": 94,
+    "name": "xyz:BOT",
+    "full_logo_url": null,
+    "daily_volume": 1234158,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "BOT",
+    "category_id": "stocks"
   },
   {
     "id": "ab0e9b0d2cd437c917eda38d15489215",
@@ -1405,6 +1295,17 @@
     "dex_id": "xyz",
     "category": "Stocks",
     "display_name": "SKHYNIX",
+    "category_id": "stocks"
+  },
+  {
+    "id": "a2a8c2942bd1ea6873cdfe2253f4d634",
+    "token_id": 98,
+    "name": "xyz:SHAZ",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:SHAZ/f892783b5fa8325b1ce1245cdeb20116.png",
+    "daily_volume": 1162430,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "SHAZ",
     "category_id": "stocks"
   },
   {
@@ -1441,17 +1342,6 @@
     "category_id": ""
   },
   {
-    "id": "e725cc43880ea966727a756ff9167f0d",
-    "token_id": 8,
-    "name": "cash:META",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/cash:META/0a5d5c64932e971bcddad7a5510f503f.png",
-    "daily_volume": 1120786,
-    "dex_id": "cash",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
     "id": "a3bfe5939361801ae7ecade32605e526",
     "token_id": 180,
     "name": "BERA",
@@ -1463,23 +1353,23 @@
     "category_id": ""
   },
   {
+    "id": "125918c96f86d373275462544de354f4",
+    "token_id": 82,
+    "name": "xyz:DELL",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:DELL/9146d512ab0f898c73d449483b946cbb.png",
+    "daily_volume": 1110773,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "DELL",
+    "category_id": "stocks"
+  },
+  {
     "id": "85a1cdddc59cb89e6297acc2f2fc1755",
     "token_id": 29,
     "name": "COMP",
     "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/COMP/500c26e44c699edec15c24aeb9cdfdeb.png",
     "daily_volume": 1023446,
     "dex_id": "",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
-    "id": "623632226cd3db9ce0875a354fea4518",
-    "token_id": 11,
-    "name": "cash:EWY",
-    "full_logo_url": null,
-    "daily_volume": 1020347,
-    "dex_id": "cash",
     "category": "",
     "display_name": "",
     "category_id": ""
@@ -1494,17 +1384,6 @@
     "category": "",
     "display_name": "",
     "category_id": ""
-  },
-  {
-    "id": "5ac84ce89dd856ea0b0576f894460b1d",
-    "token_id": 6,
-    "name": "flx:SILVER",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/flx:SILVER/44e9080ac322f58147a0d5d83ae1f238.png",
-    "daily_volume": 998695,
-    "dex_id": "flx",
-    "category": "Commodities",
-    "display_name": "",
-    "category_id": "commodities"
   },
   {
     "id": "479b9804810ad36e01d1d453d54102a1",
@@ -1573,15 +1452,15 @@
     "category_id": ""
   },
   {
-    "id": "3236b2b23934b4f16e3ccb8d242d930d",
-    "token_id": 8,
-    "name": "flx:GAS",
+    "id": "01f99cbfedee0db9daee801c397db085",
+    "token_id": 92,
+    "name": "xyz:QCOM",
     "full_logo_url": null,
-    "daily_volume": 825331,
-    "dex_id": "flx",
-    "category": "Commodities",
-    "display_name": "",
-    "category_id": "commodities"
+    "daily_volume": 810142,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "QCOM",
+    "category_id": "stocks"
   },
   {
     "id": "3bbdb0e72accb85b8d2343441674f2ca",
@@ -1628,17 +1507,6 @@
     "category_id": ""
   },
   {
-    "id": "a8337f438d017df84b51e4e8014b8906",
-    "token_id": 2,
-    "name": "vntl:ANTHROPIC",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/vntl:ANTHROPIC/9421acbcf6c79584a86f38319de7a13f.png",
-    "daily_volume": 747924,
-    "dex_id": "vntl",
-    "category": "preipo",
-    "display_name": "",
-    "category_id": "preipo"
-  },
-  {
     "id": "4a7ea31814f9d393c92bd8cc21759b68",
     "token_id": 121,
     "name": "ETHFI",
@@ -1672,6 +1540,17 @@
     "category_id": ""
   },
   {
+    "id": "4a86c1e5d33f7793223467bdb5be4d75",
+    "token_id": 95,
+    "name": "xyz:AMAT",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:AMAT/516f82791d3c0cd7c9a5635105e6d652.png",
+    "daily_volume": 712978,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "AMAT",
+    "category_id": "stocks"
+  },
+  {
     "id": "02f386111efd455902e5d314b8797d29",
     "token_id": 0,
     "name": "para:TOTAL2",
@@ -1681,6 +1560,28 @@
     "category": "crypto",
     "display_name": "TOTAL2",
     "category_id": "crypto"
+  },
+  {
+    "id": "f7751ebb36cc58d97367b2a4eba388f3",
+    "token_id": 0,
+    "name": "mkts:US500",
+    "full_logo_url": null,
+    "daily_volume": 702245,
+    "dex_id": "mkts",
+    "category": "Indices",
+    "display_name": "",
+    "category_id": "indices"
+  },
+  {
+    "id": "1a98b93e4802908998e034fe37584906",
+    "token_id": 60,
+    "name": "xyz:PURRDAT",
+    "full_logo_url": null,
+    "daily_volume": 700781,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "PURRDAT",
+    "category_id": "stocks"
   },
   {
     "id": "8fcce50f392a6fab43f30d3af609d4e3",
@@ -1705,26 +1606,15 @@
     "category_id": ""
   },
   {
-    "id": "06bcd79797d61882974bb492c4047cf6",
-    "token_id": 9,
-    "name": "vntl:ENERGY",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/vntl:ENERGY/2c5cc366d73bdfcff9d59f83d41de345.png",
-    "daily_volume": 645800,
-    "dex_id": "vntl",
-    "category": "Indices",
-    "display_name": "",
-    "category_id": "indices"
-  },
-  {
-    "id": "bbfcb6fcbf83e4da435b864328568315",
-    "token_id": 18,
-    "name": "hyna:IP",
-    "full_logo_url": null,
-    "daily_volume": 601889,
-    "dex_id": "hyna",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
+    "id": "44be9b3fd0e38e97f5af8c9204b7db5c",
+    "token_id": 65,
+    "name": "xyz:DRAM",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:DRAM/c1791a4317ccf445036d667131931259.png",
+    "daily_volume": 605958,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "DRAM",
+    "category_id": "stocks"
   },
   {
     "id": "4f6f18fc46c2b25436b90f473074cca0",
@@ -1780,17 +1670,6 @@
     "category": "Memes",
     "display_name": "",
     "category_id": "memes"
-  },
-  {
-    "id": "b8881d75d2f68bb493365695daafec19",
-    "token_id": 15,
-    "name": "km:NVDA",
-    "full_logo_url": null,
-    "daily_volume": 549530,
-    "dex_id": "km",
-    "category": "Stocks",
-    "display_name": "",
-    "category_id": "stocks"
   },
   {
     "id": "5bc0918cd4091850eaf5154cc8bd1550",
@@ -1870,17 +1749,6 @@
     "category_id": "stocks"
   },
   {
-    "id": "58d1d4ccc7cf8d7afcce09a44adfa415",
-    "token_id": 14,
-    "name": "cash:KWEB",
-    "full_logo_url": null,
-    "daily_volume": 492233,
-    "dex_id": "cash",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
     "id": "f791e215081d6dfc15b9a6eb525f5b29",
     "token_id": 99,
     "name": "CAKE",
@@ -1890,6 +1758,17 @@
     "category": "",
     "display_name": "",
     "category_id": ""
+  },
+  {
+    "id": "ac11c5230978775182c760d25b5588d7",
+    "token_id": 89,
+    "name": "xyz:SMH",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:SMH/3005189c3f2776ccb97d85cc09f76419.png",
+    "daily_volume": 481918,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "SMH",
+    "category_id": "stocks"
   },
   {
     "id": "aa53ca0b650dfd85c4f59fa156f7a2cc",
@@ -1923,17 +1802,6 @@
     "category": "",
     "display_name": "",
     "category_id": ""
-  },
-  {
-    "id": "431db37ac4c6d0efbfd624107a55c774",
-    "token_id": 14,
-    "name": "flx:USA500",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/flx:USA500/72c7b18da390f541b78ec2cca051120c.png",
-    "daily_volume": 467944,
-    "dex_id": "flx",
-    "category": "Indices",
-    "display_name": "",
-    "category_id": "indices"
   },
   {
     "id": "aa8bcb2a6a7a1716989f28216e736ebc",
@@ -1980,6 +1848,17 @@
     "category_id": "memes"
   },
   {
+    "id": "98bf57ab1942c5e925aa84c88f3999db",
+    "token_id": 5,
+    "name": "mkts:USTECH",
+    "full_logo_url": null,
+    "daily_volume": 433711,
+    "dex_id": "mkts",
+    "category": "Indices",
+    "display_name": "QQQ",
+    "category_id": "indices"
+  },
+  {
     "id": "8cfbc6bc8db98c5bd60362347fca2da7",
     "token_id": 10,
     "name": "hyna:SUI",
@@ -2002,17 +1881,6 @@
     "category_id": "commodities"
   },
   {
-    "id": "8ea8a87841909a1e5dbaf975c43cae90",
-    "token_id": 8,
-    "name": "km:TSLA",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/km:TSLA/f80e9ad5e82c4d2222ed03beeccef977.png",
-    "daily_volume": 415277,
-    "dex_id": "km",
-    "category": "Stocks",
-    "display_name": "",
-    "category_id": "stocks"
-  },
-  {
     "id": "cb057b846b0f80c3bb7ae130530b3a27",
     "token_id": 136,
     "name": "ZK",
@@ -2024,26 +1892,15 @@
     "category_id": ""
   },
   {
-    "id": "cd0fed7df2774435d4378553c8be6d15",
-    "token_id": 3,
-    "name": "flx:COIN",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/flx:COIN/99a18e4fd1a3ee16ad8de26dccc34d67.png",
-    "daily_volume": 402650,
-    "dex_id": "flx",
+    "id": "20fd99f5946a930ef6487a8fc3b49e8f",
+    "token_id": 4,
+    "name": "para:AVGO",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/para:AVGO/f968ee66e5665d9438ac1767cbef53f3.png",
+    "daily_volume": 405041,
+    "dex_id": "para",
     "category": "Stocks",
     "display_name": "",
     "category_id": "stocks"
-  },
-  {
-    "id": "13b09d6da1893ee050627fa898c6c1fc",
-    "token_id": 8,
-    "name": "vntl:DEFENSE",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/vntl:DEFENSE/0ff8391ff2d853f373158a5193ff7b96.png",
-    "daily_volume": 395280,
-    "dex_id": "vntl",
-    "category": "Indices",
-    "display_name": "",
-    "category_id": "indices"
   },
   {
     "id": "602bcb15b1e1b9719d1fae7b1b512431",
@@ -2055,6 +1912,17 @@
     "category": "",
     "display_name": "",
     "category_id": ""
+  },
+  {
+    "id": "b00e3e558557cdffb8ec5fb1a55b16c8",
+    "token_id": 78,
+    "name": "xyz:ASML",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:ASML/7acdace54327e5d8b50f7cd7a6c343a3.png",
+    "daily_volume": 372799,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "ASML",
+    "category_id": "stocks"
   },
   {
     "id": "b849337a5ae05daf6d0fd9cc2214c668",
@@ -2079,33 +1947,11 @@
     "category_id": ""
   },
   {
-    "id": "7c9b59cc221737a33e77e3304b4a3bc9",
-    "token_id": 3,
-    "name": "vntl:MAG7",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/vntl:MAG7/6b573b3ccecbb05dce733a79f0d3ee79.png",
-    "daily_volume": 362740,
-    "dex_id": "vntl",
-    "category": "Indices",
-    "display_name": "",
-    "category_id": "indices"
-  },
-  {
     "id": "a5c1a87dbb772cf8e08aac34634da407",
     "token_id": 209,
     "name": "STBL",
     "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/STBL/dcc88da5916306ed73e0e7a764bb4a7e.png",
     "daily_volume": 355772,
-    "dex_id": "",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
-    "id": "9c0c527b9fed5549c3312964834ea7f6",
-    "token_id": 155,
-    "name": "CHILLGUY",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/CHILLGUY/cbd259b10f94c41722e6a2b9f9c463d3.png",
-    "daily_volume": 344023,
     "dex_id": "",
     "category": "",
     "display_name": "",
@@ -2132,6 +1978,17 @@
     "category": "",
     "display_name": "",
     "category_id": ""
+  },
+  {
+    "id": "9a45dc3d1e6645bc878c8539ee720aee",
+    "token_id": 85,
+    "name": "xyz:NOW",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:NOW/7cd4a0341ceea4a8f578fad5a167c59e.png",
+    "daily_volume": 332624,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "NOW",
+    "category_id": "stocks"
   },
   {
     "id": "9619ecd8a91e5d749cbcf79f6a4081d8",
@@ -2178,6 +2035,17 @@
     "category_id": ""
   },
   {
+    "id": "2bc9c05403fba42fbc91d3121347509f",
+    "token_id": 56,
+    "name": "xyz:XLE",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:XLE/4ad52bdccbc345617954426585fdbe0d.png",
+    "daily_volume": 311224,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "XLE",
+    "category_id": "stocks"
+  },
+  {
     "id": "fc91b14eef9c58c4cad8fdf87b4c0bea",
     "token_id": 87,
     "name": "SUPER",
@@ -2222,39 +2090,6 @@
     "category_id": ""
   },
   {
-    "id": "8569c5906bbeef46a0f4387d66460216",
-    "token_id": 7,
-    "name": "vntl:NUCLEAR",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/vntl:NUCLEAR/ad92e4dff2338ce6d2301da104f63dd6.png",
-    "daily_volume": 287408,
-    "dex_id": "vntl",
-    "category": "Indices",
-    "display_name": "",
-    "category_id": "indices"
-  },
-  {
-    "id": "e8308b53534b200f3887472b79eb630c",
-    "token_id": 2,
-    "name": "flx:CRCL",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/flx:CRCL/1cbc2d7730090b0f99946487b725ccbf.png",
-    "daily_volume": 287108,
-    "dex_id": "flx",
-    "category": "Stocks",
-    "display_name": "",
-    "category_id": "stocks"
-  },
-  {
-    "id": "fcaf10dc30817f4c9b490c80a65ba548",
-    "token_id": 5,
-    "name": "flx:GOLD",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/flx:GOLD/ec6a1aff13c1e381cd228242d6c72a2f.png",
-    "daily_volume": 283483,
-    "dex_id": "flx",
-    "category": "Commodities",
-    "display_name": "",
-    "category_id": "commodities"
-  },
-  {
     "id": "3bf9c3275729a12e43039b5eec192003",
     "token_id": 60,
     "name": "KAS",
@@ -2264,17 +2099,6 @@
     "category": "",
     "display_name": "",
     "category_id": ""
-  },
-  {
-    "id": "1699091e0299faeccb625f702279b696",
-    "token_id": 11,
-    "name": "flx:PALLADIUM",
-    "full_logo_url": null,
-    "daily_volume": 282198,
-    "dex_id": "flx",
-    "category": "Commodities",
-    "display_name": "",
-    "category_id": "commodities"
   },
   {
     "id": "eb118d899043dc20122a190fbd0f6376",
@@ -2354,15 +2178,15 @@
     "category_id": ""
   },
   {
-    "id": "b543131f3ccab793cd6725de0e072097",
-    "token_id": 13,
-    "name": "vntl:WHEAT",
-    "full_logo_url": null,
-    "daily_volume": 236697,
-    "dex_id": "vntl",
-    "category": "Commodities",
-    "display_name": "",
-    "category_id": "commodities"
+    "id": "8c3615046cc87bf51c520ce5c8ba62d8",
+    "token_id": 41,
+    "name": "xyz:GME",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:GME/20e33b3c79d05a3206ec69450cff9a86.png",
+    "daily_volume": 240904,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "GME",
+    "category_id": "stocks"
   },
   {
     "id": "b5f12e7fa0f97efcd75bdd6518de44f7",
@@ -2519,15 +2343,15 @@
     "category_id": "memes"
   },
   {
-    "id": "b9c29cd5f83c535b0bcaf31343315bad",
-    "token_id": 146,
-    "name": "SCR",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/SCR/e06c04acdbfcf47f3fd34a1e3599b99a.png",
-    "daily_volume": 197904,
-    "dex_id": "",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
+    "id": "77c1449a55b91b252d7e0b37c0f62be6",
+    "token_id": 61,
+    "name": "xyz:MRVL",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:MRVL/b4daf853b3f385faa11760f07badf9ea.png",
+    "daily_volume": 195445,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "MRVL",
+    "category_id": "stocks"
   },
   {
     "id": "983deea599927c5af7f56840e435a4e3",
@@ -2583,17 +2407,6 @@
     "category": "",
     "display_name": "",
     "category_id": ""
-  },
-  {
-    "id": "dc311b44a5a8fb5cb7cb712c0e2f49db",
-    "token_id": 19,
-    "name": "km:PLTR",
-    "full_logo_url": null,
-    "daily_volume": 188205,
-    "dex_id": "km",
-    "category": "Stocks",
-    "display_name": "",
-    "category_id": "stocks"
   },
   {
     "id": "efeea5c34b078cdca23c3a2e43d43c48",
@@ -2662,17 +2475,6 @@
     "category_id": ""
   },
   {
-    "id": "a51f01232a644dde9add6fceba96b91e",
-    "token_id": 4,
-    "name": "vntl:SEMIS",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/vntl:SEMIS/70c76f539bc1e53e92d78f1e0a090591.png",
-    "daily_volume": 182414,
-    "dex_id": "vntl",
-    "category": "Indices",
-    "display_name": "",
-    "category_id": "indices"
-  },
-  {
     "id": "d2a0e12f2582cb9cb956a0f8c7400fc2",
     "token_id": 182,
     "name": "LAYER",
@@ -2704,17 +2506,6 @@
     "category": "",
     "display_name": "",
     "category_id": ""
-  },
-  {
-    "id": "4a2d11bdc8b702e8afaed2ecbafd29f9",
-    "token_id": 5,
-    "name": "vntl:ROBOT",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/vntl:ROBOT/d3affbf3520d1ad4ad9456ae0daa6ea0.png",
-    "daily_volume": 171880,
-    "dex_id": "vntl",
-    "category": "Indices",
-    "display_name": "",
-    "category_id": "indices"
   },
   {
     "id": "b33650c3049093777ce4f171b0cc3f8e",
@@ -2783,37 +2574,15 @@
     "category_id": ""
   },
   {
-    "id": "70efaa0394c477d84db802cb53bb6aa3",
-    "token_id": 13,
-    "name": "flx:USDE",
-    "full_logo_url": null,
-    "daily_volume": 156114,
-    "dex_id": "flx",
-    "category": "crypto",
-    "display_name": "",
-    "category_id": "crypto"
-  },
-  {
-    "id": "74214ea7ac010e07f2468e10ac1c5344",
-    "token_id": 18,
-    "name": "km:MU",
-    "full_logo_url": null,
-    "daily_volume": 152369,
-    "dex_id": "km",
+    "id": "f0999e7beb22f5502bb7835da701ae4c",
+    "token_id": 88,
+    "name": "xyz:NOK",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:NOK/1ff94da1001f9accf9a3a9d960c47242.png",
+    "daily_volume": 157126,
+    "dex_id": "xyz",
     "category": "Stocks",
-    "display_name": "",
+    "display_name": "NOK",
     "category_id": "stocks"
-  },
-  {
-    "id": "37afa53921f04141b089aec3bb26211c",
-    "token_id": 188,
-    "name": "PROMPT",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/PROMPT/a8edbcc7641430b4c6bc9596da2d965d.png",
-    "daily_volume": 150558,
-    "dex_id": "",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
   },
   {
     "id": "24fe976b135d343ba350030deee5a543",
@@ -2854,17 +2623,6 @@
     "name": "BRETT",
     "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/BRETT/76685304ade54755db9d9d3404925132.png",
     "daily_volume": 147021,
-    "dex_id": "",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
-    "id": "8fc4318743b20712610bb5d9d6e80fe0",
-    "token_id": 88,
-    "name": "USTC",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/USTC/6ece7316faedd94d184216b933736f22.png",
-    "daily_volume": 145914,
     "dex_id": "",
     "category": "",
     "display_name": "",
@@ -2915,17 +2673,6 @@
     "category_id": ""
   },
   {
-    "id": "a9720539eb07413562ebfa296463f3f4",
-    "token_id": 1,
-    "name": "km:BABA",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/km:BABA/38731648a97a831971135e6e4f01b134.png",
-    "daily_volume": 135204,
-    "dex_id": "km",
-    "category": "Stocks",
-    "display_name": "",
-    "category_id": "stocks"
-  },
-  {
     "id": "40b81d079e9898fd450a53999ac28a41",
     "token_id": 67,
     "name": "MINA",
@@ -2959,25 +2706,25 @@
     "category_id": ""
   },
   {
-    "id": "a296e5d5a7bd199515f5379b62dc3e02",
-    "token_id": 55,
-    "name": "ARK",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/ARK/b2b6d697c9afa62004e918f4c2ebd9aa.png",
-    "daily_volume": 112119,
-    "dex_id": "",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
+    "id": "87b099378c77e4c034fe4342556a8c63",
+    "token_id": 75,
+    "name": "xyz:GBP",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:GBP/a38af32854cc0772507cfc346d0192d3.png",
+    "daily_volume": 119643,
+    "dex_id": "xyz",
+    "category": "FX",
+    "display_name": "GBPUSD",
+    "category_id": "fx"
   },
   {
-    "id": "4692fee3fc564e24b9c739479519cb6a",
-    "token_id": 12,
-    "name": "km:GOOGL",
-    "full_logo_url": null,
-    "daily_volume": 108194,
-    "dex_id": "km",
+    "id": "d68a4d427475c8c0195ca6daad6c27bc",
+    "token_id": 43,
+    "name": "xyz:SOFTBANK",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:SOFTBANK/185b372d1bbf5cbc53217e135b0b6908.png",
+    "daily_volume": 114493,
+    "dex_id": "xyz",
     "category": "Stocks",
-    "display_name": "",
+    "display_name": "SOFTBANK",
     "category_id": "stocks"
   },
   {
@@ -2992,45 +2739,12 @@
     "category_id": ""
   },
   {
-    "id": "6f009305e1648cc08c658d764f8a2f90",
-    "token_id": 6,
-    "name": "km:USENERGY",
-    "full_logo_url": null,
-    "daily_volume": 105963,
-    "dex_id": "km",
-    "category": "Indices",
-    "display_name": "",
-    "category_id": "indices"
-  },
-  {
-    "id": "ca63a9e30a35f8f3d0070d974143f1e2",
-    "token_id": 1,
-    "name": "vntl:OPENAI",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/vntl:OPENAI/940537cd89399957699ce9315687e38f.png",
-    "daily_volume": 103201,
-    "dex_id": "vntl",
-    "category": "preipo",
-    "display_name": "",
-    "category_id": "preipo"
-  },
-  {
     "id": "8b0e0e08bc6d67128a264df24df0c34b",
     "token_id": 9,
     "name": "hyna:DOGE",
     "full_logo_url": null,
     "daily_volume": 102428,
     "dex_id": "hyna",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
-    "id": "977a916a311854fb0a0a7d4bc82b553b",
-    "token_id": 97,
-    "name": "MAV",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/MAV/c31ec874558ff78f6c7f6fd0c4ccdf3e.png",
-    "daily_volume": 101576,
-    "dex_id": "",
     "category": "",
     "display_name": "",
     "category_id": ""
@@ -3080,14 +2794,25 @@
     "category_id": "stocks"
   },
   {
-    "id": "68d4ef136c384be293577daa860a78bd",
-    "token_id": 20,
-    "name": "km:XIAOMI",
+    "id": "46ac51ac2115be47b47b0cc42dc53b16",
+    "token_id": 73,
+    "name": "xyz:ARM",
     "full_logo_url": null,
-    "daily_volume": 96985,
-    "dex_id": "km",
+    "daily_volume": 95273,
+    "dex_id": "xyz",
     "category": "Stocks",
-    "display_name": "",
+    "display_name": "ARM",
+    "category_id": "stocks"
+  },
+  {
+    "id": "59f5e77706f6c73a58795bc9ee3edec4",
+    "token_id": 69,
+    "name": "xyz:ZM",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:ZM/7875c72a935c3f1163547aa5e75390f6.png",
+    "daily_volume": 94955,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "ZM",
     "category_id": "stocks"
   },
   {
@@ -3100,39 +2825,6 @@
     "category": "",
     "display_name": "",
     "category_id": ""
-  },
-  {
-    "id": "f7d8b12e260d275d8dcdcc7f004167ad",
-    "token_id": 202,
-    "name": "YZY",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/YZY/05f3e30a2a1ea94144ad1e0bb011dfe7.png",
-    "daily_volume": 94053,
-    "dex_id": "",
-    "category": "Memes",
-    "display_name": "",
-    "category_id": "memes"
-  },
-  {
-    "id": "4974d591db664ba0cfbdeeaa8bc11c5c",
-    "token_id": 11,
-    "name": "km:AAPL",
-    "full_logo_url": null,
-    "daily_volume": 89729,
-    "dex_id": "km",
-    "category": "Stocks",
-    "display_name": "",
-    "category_id": "stocks"
-  },
-  {
-    "id": "91268ddd705b225553297028e1ddf4e7",
-    "token_id": 0,
-    "name": "flx:TSLA",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/flx:TSLA/ddded05e9bc380648cc791ccac25943d.png",
-    "daily_volume": 87196,
-    "dex_id": "flx",
-    "category": "Stocks",
-    "display_name": "",
-    "category_id": "stocks"
   },
   {
     "id": "34bdde38789308ab22fdef9177b60db9",
@@ -3152,9 +2844,9 @@
     "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:DKNG/83e878cad01ced7bffee0cc4af845c96.png",
     "daily_volume": 82735,
     "dex_id": "xyz",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
+    "category": "Stocks",
+    "display_name": "DKNG",
+    "category_id": "stocks"
   },
   {
     "id": "505273a0a2bba0111a40f6cccbc55d69",
@@ -3173,17 +2865,6 @@
     "name": "TNSR",
     "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/TNSR/c62422737c6930a3e3550f6328f0e3d7.png",
     "daily_volume": 79279,
-    "dex_id": "",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
-    "id": "9d149112a747cab74a47e232bc2f1687",
-    "token_id": 194,
-    "name": "DOOD",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/DOOD/72d1ee60f6a42349c0d265dcddbfc1aa.png",
-    "daily_volume": 75990,
     "dex_id": "",
     "category": "",
     "display_name": "",
@@ -3212,17 +2893,6 @@
     "category_id": ""
   },
   {
-    "id": "4ce31ee83d010b8ce5ecec17c99ad163",
-    "token_id": 110,
-    "name": "MAVIA",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/MAVIA/b7266b99c3fd5eb38c05aa567fcb0ad7.png",
-    "daily_volume": 75177,
-    "dex_id": "",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
     "id": "94b88e89ebb3c130b49e27ab66c3c0d2",
     "token_id": 42,
     "name": "xyz:KR200",
@@ -3243,28 +2913,6 @@
     "category": "",
     "display_name": "",
     "category_id": ""
-  },
-  {
-    "id": "d69f3a9ad0fd32086ba65b667ba95987",
-    "token_id": 12,
-    "name": "flx:PLATINUM",
-    "full_logo_url": null,
-    "daily_volume": 72310,
-    "dex_id": "flx",
-    "category": "Commodities",
-    "display_name": "",
-    "category_id": "commodities"
-  },
-  {
-    "id": "5f84b931a5aca2b435e90f29beebdef9",
-    "token_id": 10,
-    "name": "vntl:BIOTECH",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/vntl:BIOTECH/b7c50e2e353a49c789b8e308fc7be509.png",
-    "daily_volume": 70195,
-    "dex_id": "vntl",
-    "category": "Indices",
-    "display_name": "",
-    "category_id": "indices"
   },
   {
     "id": "82aa127a04ab2654382c15c27ab0a8a8",
@@ -3300,6 +2948,17 @@
     "category_id": ""
   },
   {
+    "id": "22e74da7cc909b10b16fac9be1db5b84",
+    "token_id": 79,
+    "name": "xyz:MINIMAX",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:MINIMAX/eed56e9235cd663e6bc8a336d82e129e.png",
+    "daily_volume": 59873,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "MINIMAX",
+    "category_id": "stocks"
+  },
+  {
     "id": "0d53bdf61d28614a0df8081c6eaccf14",
     "token_id": 45,
     "name": "xyz:HYUNDAI",
@@ -3333,14 +2992,14 @@
     "category_id": ""
   },
   {
-    "id": "38e01e242021f3b252dd3d404dff8011",
-    "token_id": 16,
-    "name": "km:TENCENT",
-    "full_logo_url": null,
-    "daily_volume": 46671,
-    "dex_id": "km",
+    "id": "2e3223b322a26155bbbd88ec496963eb",
+    "token_id": 59,
+    "name": "xyz:BX",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:BX/807e785b60332fe2da0f6a162445fbbe.png",
+    "daily_volume": 46485,
+    "dex_id": "xyz",
     "category": "Stocks",
-    "display_name": "",
+    "display_name": "BX",
     "category_id": "stocks"
   },
   {
@@ -3355,26 +3014,15 @@
     "category_id": ""
   },
   {
-    "id": "64fef6ca3f0cf88cc32eb41646a5b6ae",
-    "token_id": 19,
-    "name": "hyna:BCH",
-    "full_logo_url": null,
-    "daily_volume": 45147,
-    "dex_id": "hyna",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
-    "id": "3e0cce5da5b8d70140366bd294d84901",
-    "token_id": 137,
-    "name": "BLAST",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/BLAST/959dfed2b26669bc8b1fb86fc2eaacd8.png",
-    "daily_volume": 43770,
-    "dex_id": "",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
+    "id": "29b95f12441761b5570279cd6b03839b",
+    "token_id": 101,
+    "name": "xyz:CXMT",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:CXMT/d14bdae19606e42d0b27515aad297374.png",
+    "daily_volume": 45261,
+    "dex_id": "xyz",
+    "category": "preipo",
+    "display_name": "CXMT",
+    "category_id": "preipo"
   },
   {
     "id": "10df3d67626099df882920ba6552f16d",
@@ -3388,15 +3036,26 @@
     "category_id": ""
   },
   {
-    "id": "6b38b4ee7e0175bc8cceb62c7457f50f",
-    "token_id": 0,
-    "name": "vntl:SPACEX",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/vntl:SPACEX/aae4613e87fa208b5d439d015af5fa07.png",
-    "daily_volume": 41600,
-    "dex_id": "vntl",
-    "category": "preipo",
-    "display_name": "",
-    "category_id": "preipo"
+    "id": "6252d61922b40e0450aa72d80cf7b279",
+    "token_id": 87,
+    "name": "xyz:WDC",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:WDC/b85123d9ac0d923dbac29eb65c55125c.png",
+    "daily_volume": 39208,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "WDC",
+    "category_id": "stocks"
+  },
+  {
+    "id": "93063ee1eb1fe1b828efa00fafd34b2c",
+    "token_id": 74,
+    "name": "xyz:EWT",
+    "full_logo_url": null,
+    "daily_volume": 34512,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "EWT",
+    "category_id": "stocks"
   },
   {
     "id": "375fabdcc1d1bc6c71a7766741c22182",
@@ -3410,26 +3069,26 @@
     "category_id": ""
   },
   {
-    "id": "45ba280eb8f677f5648d3caae1484ec7",
-    "token_id": 139,
-    "name": "MEW",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/MEW/6455ba4fa8c684c34477fbd3eb980de3.png",
-    "daily_volume": 29166,
-    "dex_id": "",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
+    "id": "18b262e85a7a9a4378a106045997d682",
+    "token_id": 90,
+    "name": "xyz:BE",
+    "full_logo_url": null,
+    "daily_volume": 28600,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "BE",
+    "category_id": "stocks"
   },
   {
-    "id": "a19943cd058fc7156a0ffcf29aaea797",
-    "token_id": 51,
-    "name": "FTT",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/FTT/a69a60c837f81b71cdd2ac1c6c4ebdbf.png",
-    "daily_volume": 26398,
-    "dex_id": "",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
+    "id": "3e6672ae87777d465ba28460cebdd2ae",
+    "token_id": 70,
+    "name": "xyz:EBAY",
+    "full_logo_url": null,
+    "daily_volume": 26920,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "EBAY",
+    "category_id": "stocks"
   },
   {
     "id": "0b6af1076205190b8f6f7bf5ca8fe206",
@@ -3443,28 +3102,6 @@
     "category_id": ""
   },
   {
-    "id": "f6a62119ee2d178d746320ff5b41f74a",
-    "token_id": 7,
-    "name": "hyna:LIGHTER",
-    "full_logo_url": null,
-    "daily_volume": 25044,
-    "dex_id": "hyna",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
-    "id": "711084227cc0882835d45d19557a5f7a",
-    "token_id": 21,
-    "name": "km:BMNR",
-    "full_logo_url": null,
-    "daily_volume": 21682,
-    "dex_id": "km",
-    "category": "Stocks",
-    "display_name": "",
-    "category_id": "stocks"
-  },
-  {
     "id": "59192b4bb8bc3bdcdb8a28efc30ae2fc",
     "token_id": 20,
     "name": "hyna:ADA",
@@ -3476,124 +3113,58 @@
     "category_id": ""
   },
   {
-    "id": "be51bdd975c1bb01126bc3384e12565d",
-    "token_id": 10,
-    "name": "flx:COPPER",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/flx:COPPER/e994d728baa5ceaa05fbbc44e023ba64.png",
-    "daily_volume": 15809,
-    "dex_id": "flx",
-    "category": "Commodities",
-    "display_name": "",
-    "category_id": "commodities"
-  },
-  {
-    "id": "f55ba45f254e7636f0be08043a28756d",
-    "token_id": 14,
-    "name": "vntl:SOY",
-    "full_logo_url": null,
-    "daily_volume": 12245,
-    "dex_id": "vntl",
-    "category": "Commodities",
-    "display_name": "",
-    "category_id": "commodities"
-  },
-  {
-    "id": "071492874adc40cb08c077f4320b5e86",
-    "token_id": 13,
-    "name": "km:SEMI",
-    "full_logo_url": null,
-    "daily_volume": 12166,
-    "dex_id": "km",
-    "category": "Indices",
-    "display_name": "",
-    "category_id": "indices"
-  },
-  {
-    "id": "febc02f07848a67f7818c30e61039604",
-    "token_id": 1,
-    "name": "flx:NVDA",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/flx:NVDA/abcd16a8bf3f2b8958215006e51e57b3.png",
-    "daily_volume": 11230,
-    "dex_id": "flx",
+    "id": "b6d8af42b1e0e96ef9f4feeedd3e539c",
+    "token_id": 93,
+    "name": "xyz:STRC",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:STRC/e7c0ca02befb1a31818ab7fd9a237d60.png",
+    "daily_volume": 12856,
+    "dex_id": "xyz",
     "category": "Stocks",
-    "display_name": "",
+    "display_name": "STRC",
     "category_id": "stocks"
   },
   {
-    "id": "4e928d509d2d90452a8e245606e712cb",
-    "token_id": 14,
-    "name": "km:GLDMINE",
-    "full_logo_url": null,
-    "daily_volume": 7966,
-    "dex_id": "km",
-    "category": "Indices",
-    "display_name": "",
-    "category_id": "indices"
-  },
-  {
-    "id": "dd145bb0e8c04dfdeeaa5aeb6d5718ad",
-    "token_id": 22,
-    "name": "km:RTX",
-    "full_logo_url": null,
-    "daily_volume": 7640,
-    "dex_id": "km",
+    "id": "067bca9c22ae0e78fad950787ba3eb84",
+    "token_id": 62,
+    "name": "xyz:RKLB",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:RKLB/3be1dba4d3e9e49ca1a6b5aa184ec4cf.png",
+    "daily_volume": 11796,
+    "dex_id": "xyz",
     "category": "Stocks",
-    "display_name": "",
+    "display_name": "RKLB",
     "category_id": "stocks"
   },
   {
-    "id": "05e2d3a728a951abf8e111695aa0ffc9",
-    "token_id": 3,
-    "name": "km:USBOND",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/km:USBOND/0c9de32240c4b6815d8f057978f1144c.png",
-    "daily_volume": 5013,
-    "dex_id": "km",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
+    "id": "33366df03d7f19b07b40334556b679bc",
+    "token_id": 67,
+    "name": "xyz:EWZ",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:EWZ/e8aa248da3690a1249c68e245a47c7ef.png",
+    "daily_volume": 11443,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "EWZ",
+    "category_id": "stocks"
   },
   {
-    "id": "4e1b28b1f93a0b34562137c0d9e1479c",
-    "token_id": 4,
-    "name": "flx:XMR",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/flx:XMR/05eca2dae6366ad15662b650a5874fe9.png",
-    "daily_volume": 3998,
-    "dex_id": "flx",
-    "category": "crypto",
-    "display_name": "",
-    "category_id": "crypto"
+    "id": "df1b7b076ab5e2addcf186b74d2b3ddb",
+    "token_id": 66,
+    "name": "xyz:CBRS",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:CBRS/5be7d56ee59a01d9572e5873bb4f9e20.png",
+    "daily_volume": 220,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "CBRS",
+    "category_id": "stocks"
   },
   {
-    "id": "4f10e178ca20356641f2ddc7a3903658",
-    "token_id": 6,
-    "name": "vntl:INFOTECH",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/vntl:INFOTECH/da0d421fc8db0892088757dcc2d21002.png",
-    "daily_volume": 1936,
-    "dex_id": "vntl",
-    "category": "Indices",
-    "display_name": "",
-    "category_id": "indices"
-  },
-  {
-    "id": "126a7a056c6b68a240a56d29d0dd34f0",
-    "token_id": 14,
-    "name": "hyna:XMR",
-    "full_logo_url": null,
-    "daily_volume": 1199,
-    "dex_id": "hyna",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
-  },
-  {
-    "id": "c8b0582d16677db401cc4ba59c5123c5",
-    "token_id": 15,
-    "name": "flx:USA100",
-    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/flx:USA100/9386f1450897af476ac41bdc020b13f4.png",
-    "daily_volume": 192,
-    "dex_id": "flx",
-    "category": "",
-    "display_name": "",
-    "category_id": ""
+    "id": "ca583f43f4e67a51c53d8eabbd386dd0",
+    "token_id": 54,
+    "name": "xyz:LITE",
+    "full_logo_url": "https://static.debank.com/image/hyper_liquid/logo_url/xyz:LITE/143f8fe3d2a3a340bb14282ca806fd36.png",
+    "daily_volume": 0,
+    "dex_id": "xyz",
+    "category": "Stocks",
+    "display_name": "LITE",
+    "category_id": "stocks"
   }
 ]

--- a/apps/mobile/src/core/services/perpsService.ts
+++ b/apps/mobile/src/core/services/perpsService.ts
@@ -65,8 +65,19 @@ export interface PerpsServiceMemoryState {
   unlockPromise: Promise<void> | null;
 }
 
+// Generic item type — importing MarketData here would create a hooks <-> core cycle.
+export interface PerpsMarketDataCache<TItem = unknown> {
+  v: number;
+  updatedAt: number;
+  list: TItem[];
+}
+
 export class PerpsService {
   private store?: PerpsServiceStore;
+  // ~150KB write-once/read-once blob: bypasses createPersistStore (boot-time
+  // clone + rewrite) and must own its own key — the perps store proxy
+  // rewrites its whole object and would clobber foreign fields.
+  private marketCacheStorage?: StorageAdapaterOptions['storageAdapter'];
   private keyringCrypto: KeyringCrypto;
   private agentWalletUnlockVersion = 0;
   private memoryState: PerpsServiceMemoryState = {
@@ -100,8 +111,28 @@ export class PerpsService {
         storage: options?.storageAdapter,
       },
     );
+    this.marketCacheStorage = options?.storageAdapter;
     this.memoryState.agentWallets = {};
   }
+
+  getMarketDataCache = <TItem = unknown>() => {
+    try {
+      return (this.marketCacheStorage?.getItem(
+        APP_STORE_NAMES.perpsMarketCache,
+      ) ?? null) as PerpsMarketDataCache<TItem> | null;
+    } catch (error) {
+      console.error('Failed to read perps market cache:', error);
+      return null;
+    }
+  };
+
+  setMarketDataCache = (cache: PerpsMarketDataCache) => {
+    try {
+      this.marketCacheStorage?.setItem(APP_STORE_NAMES.perpsMarketCache, cache);
+    } catch (error) {
+      console.error('Failed to write perps market cache:', error);
+    }
+  };
 
   getFavoriteMarkets = async () => {
     if (!this.store) {

--- a/apps/mobile/src/core/storage/storeConstant.ts
+++ b/apps/mobile/src/core/storage/storeConstant.ts
@@ -31,6 +31,7 @@ export const enum APP_STORE_NAMES {
   'metamaskMode' = 'metamaskMode',
 
   'perps' = 'perps',
+  'perpsMarketCache' = 'perpsMarketCache',
   'lending' = 'lending',
 
   'currency' = 'currency',

--- a/apps/mobile/src/hooks/perps/usePerpsStore.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsStore.ts
@@ -49,6 +49,7 @@ import {
 } from '@rabby-wallet/rabby-api/dist/types';
 import { stats } from '@/utils/stats';
 import BigNumber from 'bignumber.js';
+import { mergeUserFills, reconcileHttpFills } from './userFills';
 
 let perpsTopTokenCache: PerpTopTokenV3[] = [];
 let perpsCategoryCache: PerpTopTokenCategory[] = [];
@@ -68,6 +69,29 @@ const EMPTY_MARKET_TICKER = {
   premium: '0',
   prevDayPx: '',
 } satisfies Partial<MarketData>;
+
+// A blanket `{ ...item, ...EMPTY_MARKET_TICKER }` would persist undeclared
+// extras riding along from `applyAssetCtxsToList`'s ctx spread (e.g.
+// `impactPxs`, a live price pair) — stale prices must never hit the disk.
+const toCachedMarketData = (item: MarketData): MarketData => ({
+  index: item.index,
+  logoUrl: item.logoUrl,
+  name: item.name,
+  displayName: item.displayName,
+  quoteAsset: item.quoteAsset,
+  maxLeverage: item.maxLeverage,
+  minLeverage: item.minLeverage,
+  maxUsdValueSize: item.maxUsdValueSize,
+  szDecimals: item.szDecimals,
+  pxDecimals: item.pxDecimals,
+  onlyIsolated: item.onlyIsolated,
+  dexId: item.dexId,
+  category: item.category,
+  categoryId: item.categoryId,
+  brief: item.brief,
+  description: item.description,
+  ...EMPTY_MARKET_TICKER,
+});
 
 // Per-dex raw snapshots, source of truth for rebuilding the aggregated
 // `currentClearinghouseState`. Stale frames (older `time`) never win.
@@ -415,6 +439,13 @@ const setCurrentPerpsAccount = (payload: Account) => {
   perpsService.setCurrentAccount(payload);
 };
 
+/**
+ * Caller MUST navigate to a screen mounting `usePerpsState` right after:
+ * `unsubscribeAll()` also drops the global ticker streams, and nothing on
+ * this flow restores them except the init effect re-running off
+ * `isInitialized: false` — skipping the navigation leaves perps prices
+ * silently frozen until some unrelated resubscription path runs.
+ */
 export const switchPerpsAccountBeforeNavigate = (payload: Account) => {
   const clearinghouseState =
     perpsStore.getState().clearinghouseStateMap[payload.address.toLowerCase()];
@@ -673,9 +704,7 @@ const runFetchMarketData = async () => {
       updatedAt: Date.now(),
       // Blank the ticker; read from the store (WS-merged) so the cached
       // pxDecimals is the price-informed one.
-      list: perpsStore
-        .getState()
-        .marketData.map(item => ({ ...item, ...EMPTY_MARKET_TICKER })),
+      list: perpsStore.getState().marketData.map(toCachedMarketData),
     });
   } catch (error) {
     console.error('Failed to fetch market data:', error);
@@ -853,56 +882,6 @@ const resetAccountState = () => {
     userAbstractionReady: false,
     currentClearinghouseState: null,
   }));
-};
-
-const MAX_USER_FILLS = 2000;
-
-// tid alone is only a 50-bit hash of (buyer_oid, seller_oid) — HL docs say a
-// globally unique trade id is (time, coin, tid); side disambiguates the two
-// legs of a self-trade, which share one tid.
-const getFillKey = (fill: WsFill): string =>
-  `${fill.time}-${fill.coin}-${fill.side}-${fill.tid}`;
-
-// Merge, newest first. A WS reconnect snapshot only carries recent fills and
-// must never overwrite the fuller HTTP history — overwriting blanks the
-// single-coin history until the HTTP refetch lands.
-const mergeUserFills = (incoming: WsFill[], prev: WsFill[]): WsFill[] => {
-  const seen = new Set<string>();
-  const merged: WsFill[] = [];
-  for (const fill of [...incoming, ...prev].sort((a, b) => b.time - a.time)) {
-    const key = getFillKey(fill);
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    merged.push(fill);
-    if (merged.length >= MAX_USER_FILLS) {
-      break;
-    }
-  }
-  return merged;
-};
-
-// The HTTP result is authoritative inside its own time window: replace
-// overlapping entries (normalizes any WS-vs-HTTP aggregation drift) but keep
-// WS fills newer than the response and history older than its window.
-const reconcileHttpFills = (res: WsFill[], prev: WsFill[]): WsFill[] => {
-  const first = res[0];
-  if (!first) {
-    return prev;
-  }
-  let newest = first.time;
-  let oldest = first.time;
-  for (const fill of res) {
-    if (fill.time > newest) {
-      newest = fill.time;
-    }
-    if (fill.time < oldest) {
-      oldest = fill.time;
-    }
-  }
-  const keep = prev.filter(fill => fill.time > newest || fill.time < oldest);
-  return mergeUserFills(res, keep);
 };
 
 const fetchUserFillHistory = async () => {

--- a/apps/mobile/src/hooks/perps/usePerpsStore.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsStore.ts
@@ -619,7 +619,7 @@ const runFetchMarketData = async () => {
   }
 };
 
-const fetchMarketData = (): Promise<void> => {
+export const fetchMarketData = (): Promise<void> => {
   if (marketDataPromise) {
     return marketDataPromise;
   }

--- a/apps/mobile/src/hooks/perps/usePerpsStore.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsStore.ts
@@ -448,9 +448,8 @@ const applyAssetCtxsToList = (
     return {
       ...item,
       ...ctx,
-      pxDecimals: ctx.markPx
-        ? getPxDecimals(String(ctx.markPx))
-        : item.pxDecimals,
+      // Tick precision follows the price magnitude (5-sig-figs rule).
+      pxDecimals: getPxDecimals(item.szDecimals, ctx.markPx ?? item.markPx),
     };
   });
 };
@@ -1028,7 +1027,7 @@ const overlayFastCtxsToMarketData = (
       ...item,
       markPx,
       midPx,
-      pxDecimals: getPxDecimals(String(markPx ?? item.markPx ?? '')),
+      pxDecimals: getPxDecimals(item.szDecimals, markPx ?? item.markPx),
     };
   });
   return changed ? next : list;

--- a/apps/mobile/src/hooks/perps/usePerpsStore.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsStore.ts
@@ -1,4 +1,5 @@
 import { isSameAddress } from '@rabby-wallet/base-utils/dist/isomorphic/address';
+import { KEYRING_CLASS } from '@rabby-wallet/keyring-utils';
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useMemoizedFn } from 'ahooks';
 import {
@@ -1479,9 +1480,44 @@ export const fetchAllDexsPositionOpenOrdersHttp = async () => {
   }
 };
 
+// Boot-time head start for the Home position card: the WS connection is
+// created lazily by the first subscribe, and the Home top-10 subscription
+// can't start until Home mounts and the account store fills. The persisted
+// perps account (MMKV, readable without keyring/unlock) is almost always the
+// position-bearing one, so subscribing to it at boot overlaps the whole
+// connect + first-snapshot round-trip with app startup. The subscription
+// itself is issued by a boot IIFE at the bottom of this module.
+let earlyPositionSubscription: { unsubscribe: () => void } | null = null;
+// Once torn down (top-10 handoff or logout), the boot IIFE must not install
+// a late subscription — its awaits could in principle resolve after that.
+let earlyPositionSubscriptionStopped = false;
+
+const teardownEarlyPositionSubscription = () => {
+  earlyPositionSubscriptionStopped = true;
+  if (!earlyPositionSubscription) {
+    return;
+  }
+  try {
+    earlyPositionSubscription.unsubscribe();
+  } catch (error) {
+    console.error('[earlyPerpsPosition] unsubscribe failed', error);
+  }
+  earlyPositionSubscription = null;
+};
+
+// Mirrors isMyAccount (core/apis/account) — kept local to avoid a
+// hooks -> core/apis/account import cycle. Keep the excluded types in sync.
+// The render-side lookup drops these types too, so an early snapshot for
+// them could never be shown anyway.
+const canSubscribePerpsPosition = (type: string) =>
+  type !== KEYRING_CLASS.WATCH &&
+  type !== KEYRING_CLASS.GNOSIS &&
+  type !== KEYRING_CLASS.WALLETCONNECT;
+
 export const apisPerpsStore = {
   logout: () => {
     unsubscribeAll();
+    teardownEarlyPositionSubscription();
     resetAccountState();
     // The SDK singleton is torn down on lock (destroyPerpsSDK), so force the
     // init effect to run again on next entry and reinstall the signer
@@ -1706,6 +1742,35 @@ runIIFEFunc(fetchMarketData);
 runIIFEFunc(fetchFavoriteMarkets);
 runIIFEFunc(fetchMarginModeByCoin);
 
+runIIFEFunc(async () => {
+  try {
+    const [currentAccount, lastUsedAccount] = await Promise.all([
+      apisPerps.getPerpsCurrentAccount(),
+      apisPerps.getPerpsLastUsedAccount(),
+    ]);
+    const cached = currentAccount || lastUsedAccount;
+    if (
+      !cached?.address ||
+      !canSubscribePerpsPosition(cached.type) ||
+      earlyPositionSubscriptionStopped
+    ) {
+      return;
+    }
+    const sdk = apisPerps.getPerpsSDK();
+    earlyPositionSubscription = sdk.ws.subscribeToAllDexsClearinghouseState(
+      cached.address,
+      data => {
+        setClearinghouseStateMap({
+          address: data.user,
+          data: formatAllDexsClearinghouseState(data.clearinghouseStates),
+        });
+      },
+    );
+  } catch (error) {
+    console.error('[earlyPerpsPosition] boot subscribe failed', error);
+  }
+});
+
 export function startSubscribePerpsOnAppState() {
   const sdk = apisPerps.getPerpsSDK();
   const subscription = AppState.addEventListener('change', nextAppState => {
@@ -1786,6 +1851,10 @@ export const useSubscribePosition = (sortedAccounts: Account[]) => {
         }
       }, 5 * 1000);
       const top10Addresses = top10Accounts.map(item => item.address);
+      // Hand off from the boot-time single-account subscription: the top-10
+      // set re-subscribes that address, and clearinghouseStateMap keeps its
+      // data in the meantime, so there is no visible gap.
+      teardownEarlyPositionSubscription();
       sdk.ws.subscribeToAllDexsClearinghouseState(top10Addresses, data => {
         if (!currentHasFetchAddresses.current.includes(data.user)) {
           currentHasFetchAddresses.current.push(data.user);

--- a/apps/mobile/src/hooks/perps/usePerpsStore.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsStore.ts
@@ -375,30 +375,26 @@ export const getClearinghouseStateByMap = (address: string) => {
   return perpsStore.getState().clearinghouseStateMap[address.toLowerCase()];
 };
 
+const isSamePerpsAccount = (prev: Account | null, next: Account): boolean =>
+  !!prev &&
+  isSameAddress(prev.address, next.address) &&
+  prev.type === next.type;
+
 const setCurrentPerpsAccount = (payload: Account) => {
-  setPerpsState(prev => ({
-    ...prev,
-    currentPerpsAccount: payload,
-    isLogin: !!payload,
-    isUserDataReady:
-      prev.currentPerpsAccount &&
-      isSameAddress(prev.currentPerpsAccount.address, payload.address) &&
-      prev.currentPerpsAccount.type === payload.type
-        ? prev.isUserDataReady
-        : false,
-    isSpotStateReady:
-      prev.currentPerpsAccount &&
-      isSameAddress(prev.currentPerpsAccount.address, payload.address) &&
-      prev.currentPerpsAccount.type === payload.type
-        ? prev.isSpotStateReady
-        : false,
-    userAbstractionReady:
-      prev.currentPerpsAccount &&
-      isSameAddress(prev.currentPerpsAccount.address, payload.address) &&
-      prev.currentPerpsAccount.type === payload.type
-        ? prev.userAbstractionReady
-        : false,
-  }));
+  setPerpsState(prev => {
+    const sameAccount = isSamePerpsAccount(prev.currentPerpsAccount, payload);
+    return {
+      ...prev,
+      currentPerpsAccount: payload,
+      isLogin: !!payload,
+      isUserDataReady: sameAccount ? prev.isUserDataReady : false,
+      isSpotStateReady: sameAccount ? prev.isSpotStateReady : false,
+      userAbstractionReady: sameAccount ? prev.userAbstractionReady : false,
+      // Fills are merged (not overwritten) on WS snapshots, so a stale
+      // account's list must be cleared explicitly on switch.
+      userFills: sameAccount ? prev.userFills : [],
+    };
+  });
   perpsService.setCurrentAccount(payload);
 };
 
@@ -412,6 +408,10 @@ export const switchPerpsAccountBeforeNavigate = (payload: Account) => {
   // previous account's sub-dex data still in the cache.
   dexClearinghouseStatesCache.clear();
   dexOpenOrdersCache.clear();
+  // Tear down the old account's subscriptions now — resubscription happens on
+  // the Perps screen init, and with merge semantics a late push from the old
+  // account would pollute the cleared fills list until the next switch.
+  unsubscribeAll();
   setPerpsState(prev => ({
     ...prev,
     currentPerpsAccount: payload,
@@ -424,6 +424,9 @@ export const switchPerpsAccountBeforeNavigate = (payload: Account) => {
     homePositionPnl: pnl,
     accountNeedApproveAgent: false,
     accountNeedApproveBuilderFee: false,
+    userFills: isSamePerpsAccount(prev.currentPerpsAccount, payload)
+      ? prev.userFills
+      : [],
   }));
   perpsService.setCurrentAccount(payload);
 };
@@ -502,6 +505,41 @@ async function withRetry<T>(
 // Single-flight: concurrent callers await the same in-flight fetch, so an
 // awaited fetchMarketData() resolves only when data is loaded.
 let marketDataPromise: Promise<void> | null = null;
+
+// The boot-time fetch races network/VPN readiness and can fail before any
+// screen is around to retry it. Reschedule from the store itself: first retry
+// fires immediately (the failed round is already over), then capped backoff.
+let marketDataRetryTimer: ReturnType<typeof setTimeout> | null = null;
+let marketDataRetryCount = 0;
+
+const clearMarketDataRetry = () => {
+  if (marketDataRetryTimer) {
+    clearTimeout(marketDataRetryTimer);
+    marketDataRetryTimer = null;
+  }
+};
+
+const scheduleMarketDataRetry = () => {
+  if (marketDataRetryTimer) {
+    return;
+  }
+  const delay =
+    marketDataRetryCount === 0
+      ? 0
+      : Math.min(30_000, 1_000 * 2 ** marketDataRetryCount);
+  marketDataRetryTimer = setTimeout(() => {
+    marketDataRetryTimer = null;
+    marketDataRetryCount += 1;
+    // Don't burn requests in background — reschedule so the chain survives
+    // an early-boot 'unknown' state; on resume the AppState 'active'
+    // listener refetches anyway (deduped by single-flight).
+    if (AppState.currentState === 'active') {
+      fetchMarketData();
+    } else {
+      scheduleMarketDataRetry();
+    }
+  }, delay);
+};
 
 // These openapi endpoints have no axios timeout — a stalled connection would
 // hang fetchMarketData forever. Cap them and fall back to defaults on timeout.
@@ -619,12 +657,20 @@ const runFetchMarketData = async () => {
   }
 };
 
-export const fetchMarketData = (): Promise<void> => {
+const fetchMarketData = (): Promise<void> => {
   if (marketDataPromise) {
     return marketDataPromise;
   }
+  // Any fetch (boot, AppState resume, Perps screen init, pull-to-refresh)
+  // doubles as the pending retry.
+  clearMarketDataRetry();
   marketDataPromise = runFetchMarketData().finally(() => {
     marketDataPromise = null;
+    if (perpsStore.getState().marketDataStatus === 'success') {
+      marketDataRetryCount = 0;
+    } else {
+      scheduleMarketDataRetry();
+    }
   });
   return marketDataPromise;
 };
@@ -783,13 +829,74 @@ const resetAccountState = () => {
   }));
 };
 
+const MAX_USER_FILLS = 2000;
+
+// tid alone is only a 50-bit hash of (buyer_oid, seller_oid) — HL docs say a
+// globally unique trade id is (time, coin, tid); side disambiguates the two
+// legs of a self-trade, which share one tid.
+const getFillKey = (fill: WsFill): string =>
+  `${fill.time}-${fill.coin}-${fill.side}-${fill.tid}`;
+
+// Merge, newest first. A WS reconnect snapshot only carries recent fills and
+// must never overwrite the fuller HTTP history — overwriting blanks the
+// single-coin history until the HTTP refetch lands.
+const mergeUserFills = (incoming: WsFill[], prev: WsFill[]): WsFill[] => {
+  const seen = new Set<string>();
+  const merged: WsFill[] = [];
+  for (const fill of [...incoming, ...prev].sort((a, b) => b.time - a.time)) {
+    const key = getFillKey(fill);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    merged.push(fill);
+    if (merged.length >= MAX_USER_FILLS) {
+      break;
+    }
+  }
+  return merged;
+};
+
+// The HTTP result is authoritative inside its own time window: replace
+// overlapping entries (normalizes any WS-vs-HTTP aggregation drift) but keep
+// WS fills newer than the response and history older than its window.
+const reconcileHttpFills = (res: WsFill[], prev: WsFill[]): WsFill[] => {
+  const first = res[0];
+  if (!first) {
+    return prev;
+  }
+  let newest = first.time;
+  let oldest = first.time;
+  for (const fill of res) {
+    if (fill.time > newest) {
+      newest = fill.time;
+    }
+    if (fill.time < oldest) {
+      oldest = fill.time;
+    }
+  }
+  const keep = prev.filter(fill => fill.time > newest || fill.time < oldest);
+  return mergeUserFills(res, keep);
+};
+
 const fetchUserFillHistory = async () => {
   const sdk = apisPerps.getPerpsSDK();
-  const res = await sdk.info.getUserFills();
-  setPerpsState(prev => ({
-    ...prev,
-    userFills: (res as unknown as WsFill[]).slice(0, 2000),
-  }));
+  const expectedAddress = perpsStore.getState().currentPerpsAccount?.address;
+  try {
+    const res = await sdk.info.getUserFills();
+    // Account switched during the await — drop the response.
+    if (
+      perpsStore.getState().currentPerpsAccount?.address !== expectedAddress
+    ) {
+      return;
+    }
+    setPerpsState(prev => ({
+      ...prev,
+      userFills: reconcileHttpFills(res as unknown as WsFill[], prev.userFills),
+    }));
+  } catch (error) {
+    console.error('Failed to fetch user fill history:', error);
+  }
 };
 
 const addUserFills = (payload: {
@@ -798,13 +905,20 @@ const addUserFills = (payload: {
   user: string;
 }) => {
   const { fills, isSnapshot } = payload;
+  // The subscription callback filters by its own account; also check the
+  // store's CURRENT account so a not-yet-unsubscribed old subscription can't
+  // pollute the list right after a switch (merge never self-heals).
+  const currentAddress = perpsStore.getState().currentPerpsAccount?.address;
+  if (!currentAddress || !isSameAddress(payload.user, currentAddress)) {
+    return;
+  }
   if (isSnapshot) {
     fetchUserFillHistory();
   }
 
   setPerpsState(prev => ({
     ...prev,
-    userFills: isSnapshot ? fills : [...fills, ...prev.userFills],
+    userFills: mergeUserFills(fills, prev.userFills),
   }));
 };
 
@@ -1420,6 +1534,9 @@ export const usePerpsStore = () => {
       userAbstraction: UserAbstractionResp.default,
       userAbstractionReady: false,
       localLoadingHistory: [],
+      userFills: isSamePerpsAccount(prev.currentPerpsAccount, account)
+        ? prev.userFills
+        : [],
     }));
     fetchUserHistoricalOrders();
     subscribeToUserData(account);

--- a/apps/mobile/src/hooks/perps/usePerpsStore.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsStore.ts
@@ -1480,17 +1480,18 @@ export const fetchAllDexsPositionOpenOrdersHttp = async () => {
   }
 };
 
-// Boot-time head start for the Home position card: the WS connection is
-// created lazily by the first subscribe, and the Home top-10 subscription
-// can't start until Home mounts and the account store fills. The persisted
-// perps account (MMKV, readable without keyring/unlock) is almost always the
-// position-bearing one, so subscribing to it at boot overlaps the whole
-// connect + first-snapshot round-trip with app startup. The subscription
-// itself is issued by a boot IIFE at the bottom of this module.
-let earlyPositionSubscription: { unsubscribe: () => void } | null = null;
-// Once torn down (top-10 handoff or logout), the boot IIFE must not install
-// a late subscription — its awaits could in principle resolve after that.
+// The Home top-10 subscription waits for Home mount + account store, seconds
+// after boot — subscribing the persisted perps account at boot lets the Home
+// position card render immediately.
+let earlyPositionSubscription: {
+  address: string;
+  unsubscribe: () => void;
+} | null = null;
+// A start resolving after teardown must not install a zombie subscription.
 let earlyPositionSubscriptionStopped = false;
+
+const getEarlyPositionSubscriptionAddress = () =>
+  earlyPositionSubscription?.address ?? null;
 
 const teardownEarlyPositionSubscription = () => {
   earlyPositionSubscriptionStopped = true;
@@ -1505,10 +1506,8 @@ const teardownEarlyPositionSubscription = () => {
   earlyPositionSubscription = null;
 };
 
-// Mirrors isMyAccount (core/apis/account) — kept local to avoid a
-// hooks -> core/apis/account import cycle. Keep the excluded types in sync.
-// The render-side lookup drops these types too, so an early snapshot for
-// them could never be shown anyway.
+// Mirrors isMyAccount (core/apis/account); local copy because its parameter
+// type rejects the persisted StoreAccount. Keep the excluded types in sync.
 const canSubscribePerpsPosition = (type: string) =>
   type !== KEYRING_CLASS.WATCH &&
   type !== KEYRING_CLASS.GNOSIS &&
@@ -1752,12 +1751,13 @@ runIIFEFunc(async () => {
     if (
       !cached?.address ||
       !canSubscribePerpsPosition(cached.type) ||
-      earlyPositionSubscriptionStopped
+      earlyPositionSubscriptionStopped ||
+      earlyPositionSubscription
     ) {
       return;
     }
     const sdk = apisPerps.getPerpsSDK();
-    earlyPositionSubscription = sdk.ws.subscribeToAllDexsClearinghouseState(
+    const { unsubscribe } = sdk.ws.subscribeToAllDexsClearinghouseState(
       cached.address,
       data => {
         setClearinghouseStateMap({
@@ -1766,8 +1766,9 @@ runIIFEFunc(async () => {
         });
       },
     );
+    earlyPositionSubscription = { address: cached.address, unsubscribe };
   } catch (error) {
-    console.error('[earlyPerpsPosition] boot subscribe failed', error);
+    console.error('[earlyPerpsPosition] subscribe failed', error);
   }
 });
 
@@ -1850,15 +1851,21 @@ export const useSubscribePosition = (sortedAccounts: Account[]) => {
         }
       }, 5 * 1000);
       const top10Addresses = top10Accounts.map(item => item.address);
-      // Hand off from the boot-time single-account subscription: the top-10
-      // set re-subscribes that address, and clearinghouseStateMap keeps its
-      // data in the meantime, so there is no visible gap.
+      // Keep the early-subscribed address live — it may rank outside the
+      // top 10, and a dropped address would render frozen data all session.
+      const earlyAddress = getEarlyPositionSubscriptionAddress();
+      const subscribeAddresses = unionBy(
+        top10Addresses,
+        earlyAddress ? [earlyAddress] : [],
+        address => address.toLowerCase(),
+      );
       teardownEarlyPositionSubscription();
-      sdk.ws.subscribeToAllDexsClearinghouseState(top10Addresses, data => {
+      sdk.ws.subscribeToAllDexsClearinghouseState(subscribeAddresses, data => {
         if (!currentHasFetchAddresses.current.includes(data.user)) {
           currentHasFetchAddresses.current.push(data.user);
           if (
-            currentHasFetchAddresses.current.length === top10Addresses.length
+            currentHasFetchAddresses.current.length ===
+            subscribeAddresses.length
           ) {
             setIsFetchAllDone(true);
             clearTimeout(timeout);

--- a/apps/mobile/src/hooks/perps/usePerpsStore.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsStore.ts
@@ -52,6 +52,22 @@ import BigNumber from 'bignumber.js';
 let perpsTopTokenCache: PerpTopTokenV3[] = [];
 let perpsCategoryCache: PerpTopTokenCategory[] = [];
 
+// Meta-only marketData snapshot: ticker fields are blanked (stale prices must
+// never render as current). Bump the version on MarketData shape changes.
+const MARKET_DATA_CACHE_VERSION = 1;
+const MARKET_DATA_CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
+const EMPTY_MARKET_TICKER = {
+  dayBaseVlm: '0',
+  dayNtlVlm: '0',
+  funding: '0',
+  markPx: '',
+  midPx: '',
+  openInterest: '0',
+  oraclePx: '',
+  premium: '0',
+  prevDayPx: '',
+} satisfies Partial<MarketData>;
+
 // Per-dex raw snapshots, source of truth for rebuilding the aggregated
 // `currentClearinghouseState`. Stale frames (older `time`) never win.
 // Key '' === hyper native dex.
@@ -651,6 +667,15 @@ const runFetchMarketData = async () => {
     }
     setMarketData(marketData, categories);
     setMarketDataStatus('success');
+    perpsService.setMarketDataCache({
+      v: MARKET_DATA_CACHE_VERSION,
+      updatedAt: Date.now(),
+      // Blank the ticker; read from the store (WS-merged) so the cached
+      // pxDecimals is the price-informed one.
+      list: perpsStore
+        .getState()
+        .marketData.map(item => ({ ...item, ...EMPTY_MARKET_TICKER })),
+    });
   } catch (error) {
     console.error('Failed to fetch market data:', error);
     setMarketDataStatus('error');
@@ -1645,6 +1670,38 @@ export const usePerpsStore = () => {
   };
 };
 
+// Cold-start bootstrap: hydrate last-known meta so logos/names/decimals
+// render before the first fetch lands. Status is left untouched.
+runIIFEFunc(() => {
+  try {
+    const cache = perpsService.getMarketDataCache<MarketData>();
+    if (
+      !cache ||
+      cache.v !== MARKET_DATA_CACHE_VERSION ||
+      Date.now() - cache.updatedAt > MARKET_DATA_CACHE_TTL ||
+      !Array.isArray(cache.list) ||
+      cache.list.length === 0
+    ) {
+      return;
+    }
+    setPerpsState(prev => {
+      // A fetch already landed — never overwrite fresh data with cache.
+      if (prev.marketData.length > 0) {
+        return prev;
+      }
+      const list = lastCtxsByDex
+        ? applyAssetCtxsToList(cache.list, lastCtxsByDex)
+        : cache.list;
+      return {
+        ...prev,
+        marketData: list,
+        marketDataMap: buildMarketDataMap(list),
+      };
+    });
+  } catch (error) {
+    console.error('Failed to hydrate market data cache:', error);
+  }
+});
 runIIFEFunc(fetchMarketData);
 runIIFEFunc(fetchFavoriteMarkets);
 runIIFEFunc(fetchMarginModeByCoin);

--- a/apps/mobile/src/hooks/perps/usePerpsStore.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsStore.ts
@@ -1533,9 +1533,10 @@ runIIFEFunc(fetchFavoriteMarkets);
 runIIFEFunc(fetchMarginModeByCoin);
 
 export function startSubscribePerpsOnAppState() {
+  const sdk = apisPerps.getPerpsSDK();
   const subscription = AppState.addEventListener('change', nextAppState => {
-    // Resolve per event — destroyPerpsSDK (wallet lock) replaces the singleton.
-    apisPerps.getPerpsSDK().ws.handleAppStateChange(nextAppState);
+    // Pass the state string ('active', 'background', 'inactive') directly
+    sdk.ws.handleAppStateChange(nextAppState);
 
     // When app returns to active, retry market data if it previously failed or never loaded.
     if (nextAppState === 'active') {

--- a/apps/mobile/src/hooks/perps/usePerpsStore.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsStore.ts
@@ -1772,10 +1772,9 @@ runIIFEFunc(async () => {
 });
 
 export function startSubscribePerpsOnAppState() {
-  const sdk = apisPerps.getPerpsSDK();
   const subscription = AppState.addEventListener('change', nextAppState => {
     // Pass the state string ('active', 'background', 'inactive') directly
-    sdk.ws.handleAppStateChange(nextAppState);
+    apisPerps.getPerpsSDK().ws.handleAppStateChange(nextAppState);
 
     // When app returns to active, retry market data if it previously failed or never loaded.
     if (nextAppState === 'active') {

--- a/apps/mobile/src/hooks/perps/usePerpsStore.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsStore.ts
@@ -596,10 +596,14 @@ const runFetchMarketData = async () => {
       return;
     }
 
-    // perpDexs failure is degradable
-    perpDexsCache = perpDexs ?? null;
+    // perpDexs failure falls back to the last known roster — an empty
+    // dexIdMap would fail the whole round in formatMarkData.
+    if (perpDexs) {
+      perpDexsCache = perpDexs;
+    }
+    const effectivePerpDexs = perpDexs ?? perpDexsCache ?? [];
     const dexIdMap: Record<number, string> = {};
-    (perpDexs ?? []).forEach((dex, idx) => {
+    effectivePerpDexs.forEach((dex, idx) => {
       dexIdMap[idx] = dex?.name ?? '';
     });
 
@@ -1530,10 +1534,9 @@ runIIFEFunc(fetchFavoriteMarkets);
 runIIFEFunc(fetchMarginModeByCoin);
 
 export function startSubscribePerpsOnAppState() {
-  const sdk = apisPerps.getPerpsSDK();
   const subscription = AppState.addEventListener('change', nextAppState => {
-    // Pass the state string ('active', 'background', 'inactive') directly
-    sdk.ws.handleAppStateChange(nextAppState);
+    // Resolve per event — destroyPerpsSDK (wallet lock) replaces the singleton.
+    apisPerps.getPerpsSDK().ws.handleAppStateChange(nextAppState);
 
     // When app returns to active, retry market data if it previously failed or never loaded.
     if (nextAppState === 'active') {

--- a/apps/mobile/src/hooks/perps/userFills.test.ts
+++ b/apps/mobile/src/hooks/perps/userFills.test.ts
@@ -1,0 +1,133 @@
+import type { WsFill } from '@rabby-wallet/hyperliquid-sdk';
+import {
+  MAX_USER_FILLS,
+  getFillKey,
+  mergeUserFills,
+  reconcileHttpFills,
+} from './userFills';
+
+const makeFill = (overrides: Partial<WsFill> = {}): WsFill => ({
+  coin: 'BTC',
+  px: '64000',
+  sz: '0.1',
+  side: 'B',
+  time: 1_700_000_000_000,
+  startPosition: '0',
+  dir: 'Open Long',
+  closedPnl: '0',
+  hash: '0xabc',
+  oid: 1,
+  crossed: true,
+  fee: '0.01',
+  tid: 111,
+  ...overrides,
+});
+
+describe('getFillKey', () => {
+  it('treats the two legs of a self-trade (same tid, opposite side) as distinct', () => {
+    const buyLeg = makeFill({ time: 1000, tid: 5, side: 'B' });
+    const sellLeg = makeFill({ time: 1000, tid: 5, side: 'A' });
+    expect(getFillKey(buyLeg)).not.toBe(getFillKey(sellLeg));
+  });
+
+  it('identifies the same trade regardless of non-key fields', () => {
+    const ws = makeFill({ time: 1000, tid: 5, px: '100', hash: '0x1' });
+    const http = makeFill({ time: 1000, tid: 5, px: '100.0', hash: '0x2' });
+    expect(getFillKey(ws)).toBe(getFillKey(http));
+  });
+});
+
+describe('mergeUserFills', () => {
+  it('dedups by key and lets the incoming version win (WS-vs-HTTP drift)', () => {
+    const prev = [makeFill({ time: 1000, tid: 1, px: '100' })];
+    const incoming = [makeFill({ time: 1000, tid: 1, px: '100.5' })];
+    const merged = mergeUserFills(incoming, prev);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.px).toBe('100.5');
+  });
+
+  it('returns fills ordered newest first', () => {
+    const prev = [
+      makeFill({ time: 300, tid: 3 }),
+      makeFill({ time: 100, tid: 1 }),
+    ];
+    const incoming = [makeFill({ time: 200, tid: 2 })];
+    const merged = mergeUserFills(incoming, prev);
+    expect(merged.map(f => f.time)).toEqual([300, 200, 100]);
+  });
+
+  it('never drops fuller history when merging a partial reconnect snapshot', () => {
+    const fullHistory = [5, 4, 3, 2, 1].map(t => makeFill({ time: t, tid: t }));
+    const reconnectSnapshot = [makeFill({ time: 5, tid: 5 })];
+    const merged = mergeUserFills(reconnectSnapshot, fullHistory);
+    expect(merged.map(f => f.time)).toEqual([5, 4, 3, 2, 1]);
+  });
+
+  it('caps the list at MAX_USER_FILLS, keeping the newest', () => {
+    const overflow = 10;
+    const incoming = Array.from({ length: MAX_USER_FILLS + overflow }, (_, i) =>
+      makeFill({ time: i + 1, tid: i + 1 }),
+    );
+    const merged = mergeUserFills(incoming, []);
+    expect(merged).toHaveLength(MAX_USER_FILLS);
+    expect(merged[0]?.time).toBe(MAX_USER_FILLS + overflow);
+    expect(merged[merged.length - 1]?.time).toBe(overflow + 1);
+  });
+});
+
+describe('reconcileHttpFills', () => {
+  it('returns prev untouched for an empty response', () => {
+    const prev = [makeFill({ time: 100, tid: 1 })];
+    expect(reconcileHttpFills([], prev)).toBe(prev);
+  });
+
+  it('is authoritative inside its own window: drops WS-only fills the response does not carry', () => {
+    const prev = [
+      makeFill({ time: 200, tid: 2 }), // inside window, not in res → replaced away
+      makeFill({ time: 100, tid: 1 }), // older than window → kept
+    ];
+    const res = [
+      makeFill({ time: 250, tid: 4 }),
+      makeFill({ time: 150, tid: 3 }),
+    ];
+    const merged = reconcileHttpFills(res, prev);
+    expect(merged.map(f => f.time)).toEqual([250, 150, 100]);
+    expect(merged.some(f => f.tid === 2)).toBe(false);
+  });
+
+  it('keeps WS fills newer than the window and history older than it', () => {
+    const prev = [
+      makeFill({ time: 300, tid: 30 }), // WS push newer than the HTTP response
+      makeFill({ time: 50, tid: 5 }), // history beyond the response depth
+    ];
+    const res = [
+      makeFill({ time: 200, tid: 20 }),
+      makeFill({ time: 100, tid: 10 }),
+    ];
+    const merged = reconcileHttpFills(res, prev);
+    expect(merged.map(f => f.time)).toEqual([300, 200, 100, 50]);
+  });
+
+  it('treats window boundaries as inclusive: a prev fill at exactly the newest time is replaced', () => {
+    const prev = [makeFill({ time: 200, tid: 99 })];
+    const res = [
+      makeFill({ time: 200, tid: 20 }),
+      makeFill({ time: 100, tid: 10 }),
+    ];
+    const merged = reconcileHttpFills(res, prev);
+    expect(merged.some(f => f.tid === 99)).toBe(false);
+    expect(merged.map(f => f.tid)).toEqual([20, 10]);
+  });
+
+  it('normalizes drift for the same trade inside the window (HTTP version wins)', () => {
+    const prev = [makeFill({ time: 150, tid: 7, px: '99.9' })];
+    const res = [
+      makeFill({ time: 200, tid: 8 }),
+      makeFill({ time: 150, tid: 7, px: '100' }),
+      makeFill({ time: 100, tid: 6 }),
+    ];
+    const merged = reconcileHttpFills(res, prev);
+    expect(merged).toHaveLength(3);
+    expect(merged.find(f => f.tid === 7)?.px).toBe('100');
+  });
+});

--- a/apps/mobile/src/hooks/perps/userFills.ts
+++ b/apps/mobile/src/hooks/perps/userFills.ts
@@ -1,0 +1,54 @@
+import type { WsFill } from '@rabby-wallet/hyperliquid-sdk';
+
+export const MAX_USER_FILLS = 2000;
+
+// tid alone is only a 50-bit hash of (buyer_oid, seller_oid) — HL docs say a
+// globally unique trade id is (time, coin, tid); side disambiguates the two
+// legs of a self-trade, which share one tid.
+export const getFillKey = (fill: WsFill): string =>
+  `${fill.time}-${fill.coin}-${fill.side}-${fill.tid}`;
+
+// Merge, newest first. A WS reconnect snapshot only carries recent fills and
+// must never overwrite the fuller HTTP history — overwriting blanks the
+// single-coin history until the HTTP refetch lands.
+export const mergeUserFills = (
+  incoming: WsFill[],
+  prev: WsFill[],
+): WsFill[] => {
+  const seen = new Set<string>();
+  const merged: WsFill[] = [];
+  for (const fill of [...incoming, ...prev].sort((a, b) => b.time - a.time)) {
+    const key = getFillKey(fill);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    merged.push(fill);
+    if (merged.length >= MAX_USER_FILLS) {
+      break;
+    }
+  }
+  return merged;
+};
+
+// The HTTP result is authoritative inside its own time window: replace
+// overlapping entries (normalizes any WS-vs-HTTP aggregation drift) but keep
+// WS fills newer than the response and history older than its window.
+export const reconcileHttpFills = (res: WsFill[], prev: WsFill[]): WsFill[] => {
+  const first = res[0];
+  if (!first) {
+    return prev;
+  }
+  let newest = first.time;
+  let oldest = first.time;
+  for (const fill of res) {
+    if (fill.time > newest) {
+      newest = fill.time;
+    }
+    if (fill.time < oldest) {
+      oldest = fill.time;
+    }
+  }
+  const keep = prev.filter(fill => fill.time > newest || fill.time < oldest);
+  return mergeUserFills(res, keep);
+};

--- a/apps/mobile/src/screens/Home/components/HomeOverview.tsx
+++ b/apps/mobile/src/screens/Home/components/HomeOverview.tsx
@@ -664,11 +664,8 @@ function HomeOverviewPostStartupGate({
   return <HomeOverviewPostStartupEffects triggerUpdate={triggerUpdate} />;
 }
 
-// Effect-only, deliberately NOT behind the startup gates: it only kicks off
-// the perps position WS subscription (network + store writes, renders
-// nothing), and every ms it waits behind postReady is added to the Home
-// position card's blank time. The account auto-fetch is single-flighted, so
-// racing the other Home consumers is free.
+// Deliberately outside the startup gates: every ms this waits behind
+// postReady is added to the position card's blank time.
 function HomeOverviewPerpsPositionSubscription() {
   const { accounts } = useMyAccounts();
   const sortedAccounts = useSortAddressList(accounts);

--- a/apps/mobile/src/screens/Home/components/HomeOverview.tsx
+++ b/apps/mobile/src/screens/Home/components/HomeOverview.tsx
@@ -664,16 +664,27 @@ function HomeOverviewPostStartupGate({
   return <HomeOverviewPostStartupEffects triggerUpdate={triggerUpdate} />;
 }
 
+// Effect-only, deliberately NOT behind the startup gates: it only kicks off
+// the perps position WS subscription (network + store writes, renders
+// nothing), and every ms it waits behind postReady is added to the Home
+// position card's blank time. The account auto-fetch is single-flighted, so
+// racing the other Home consumers is free.
+function HomeOverviewPerpsPositionSubscription() {
+  const { accounts } = useMyAccounts();
+  const sortedAccounts = useSortAddressList(accounts);
+
+  useSubscribePosition(sortedAccounts);
+
+  return null;
+}
+
 function HomeOverviewPostStartupEffects({
   triggerUpdate,
 }: {
   triggerUpdate: HomeOverviewTriggerUpdate;
 }) {
-  const { accounts } = useMyAccounts({ disableAutoFetch: true });
-  const sortedAccounts = useSortAddressList(accounts);
   const isFirstTriggerRef = useRef(true);
 
-  useSubscribePosition(sortedAccounts);
   useFetchCexInfo();
 
   useFocusEffect(
@@ -1258,6 +1269,7 @@ export const HomeOverview = React.memo(() => {
 
   return (
     <View style={styles.pullUpWrapper}>
+      <HomeOverviewPerpsPositionSubscription />
       <HomeOverviewDeferredStartupGate triggerUpdate={triggerUpdate} />
       <Animated.View style={[styles.main, mainStyle]}>
         <GestureDetector gesture={panGestureRef.current}>

--- a/apps/mobile/src/screens/Perps/components/PerpsHistorySection/PerpsHistoryAccountItem.tsx
+++ b/apps/mobile/src/screens/Perps/components/PerpsHistorySection/PerpsHistoryAccountItem.tsx
@@ -158,7 +158,9 @@ const getStyle = createGetStyles2024(({ colors2024, isLight }) => ({
     borderRadius: 16,
     paddingVertical: 14,
     paddingHorizontal: 12,
-    backgroundColor: colors2024['neutral-bg-2'],
+    backgroundColor: isLight
+      ? colors2024['neutral-bg-1']
+      : colors2024['neutral-bg-2'],
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',

--- a/apps/mobile/src/screens/Perps/components/PerpsMarketSection/PerpsMarketItem.tsx
+++ b/apps/mobile/src/screens/Perps/components/PerpsMarketSection/PerpsMarketItem.tsx
@@ -22,10 +22,16 @@ const PerpsMarketItemComponent: React.FC<{
   const { styles, colors2024 } = useTheme2024({ getStyle });
   const { t } = useTranslation();
 
+  // markPx/prevDayPx are '' until the first ticker lands (fresh fetch or
+  // hydrated cache) — render placeholders instead of $NaN.
+  const hasPrice = !!item.markPx && Number.isFinite(Number(item.markPx));
+  const hasChange = hasPrice && !!item.prevDayPx && Number(item.prevDayPx) > 0;
   const isUp = Number(item.markPx) - Number(item.prevDayPx) > 0;
   const absPnlUsd = Math.abs(Number(item.markPx) - Number(item.prevDayPx));
   const absPnlPct = Math.abs(absPnlUsd / Number(item.prevDayPx));
-  const pnlText = `${isUp ? '+' : '-'}${formatPct(absPnlPct)}`;
+  const pnlText = hasChange
+    ? `${isUp ? '+' : '-'}${formatPct(absPnlPct)}`
+    : '-';
 
   return (
     <TouchableOpacity onPress={onPress}>
@@ -40,7 +46,7 @@ const PerpsMarketItemComponent: React.FC<{
               <PerpsDisplayCoinName item={item} />
             </View>
             <Text style={styles.price}>
-              {`$${splitNumberByStep(item.markPx)}`}
+              {hasPrice ? `$${splitNumberByStep(item.markPx)}` : '-'}
             </Text>
           </View>
           <View style={styles.row}>
@@ -55,7 +61,11 @@ const PerpsMarketItemComponent: React.FC<{
             <Text
               style={[
                 styles.priceChange,
-                isUp ? null : styles.priceChangeDown,
+                hasChange
+                  ? isUp
+                    ? null
+                    : styles.priceChangeDown
+                  : styles.priceChangeMuted,
               ]}>
               {pnlText}
             </Text>
@@ -191,6 +201,9 @@ const getStyle = createGetStyles2024(({ colors2024, isLight }) => ({
   },
   priceChangeDown: {
     color: colors2024['red-default'],
+  },
+  priceChangeMuted: {
+    color: colors2024['neutral-secondary'],
   },
   favoriteTag: {
     position: 'absolute',

--- a/apps/mobile/src/screens/Perps/components/PerpsMultiAssetPosition/index.tsx
+++ b/apps/mobile/src/screens/Perps/components/PerpsMultiAssetPosition/index.tsx
@@ -31,7 +31,7 @@ import { PerpsRiskLevelPopup } from '../PerpsPositionSection/PerpsRiskLevelPopup
 import { RootNames } from '@/constant/layout';
 import { useRabbyAppNavigation } from '@/hooks/navigation';
 import { switchPerpsAccountBeforeNavigate } from '@/hooks/perps/usePerpsStore';
-import { formatPerpsCoin, getHyperliquidCoinLogoUrl } from '@/utils/perps';
+import { formatPerpsCoin, getFallbackCoinLogoUrl } from '@/utils/perps';
 import { SvgUri } from 'react-native-svg';
 import { matomoRequestEvent } from '@/utils/analytics';
 import { Text } from '@/components/Typography';
@@ -50,9 +50,8 @@ interface AssetPositionWithAccount {
   displayName: string;
 }
 
-// Hyperliquid's official coin icons are svg, which the shared AssetAvatar
-// deliberately renders as a placeholder (virtual-list constraint). This card
-// isn't virtualized, so render the svg fallback locally.
+// AssetAvatar deliberately won't render remote svg (virtual-list constraint);
+// this card isn't virtualized, so render the svg fallback locally.
 const CoinAvatar = ({ logo, size }: { logo: string; size: number }) => {
   const svgStyle = useMemo(
     () => ({
@@ -382,11 +381,11 @@ export const PerpsMultiAssetPosition: React.FC = () => {
           account,
           quoteAsset,
           assetPositions: assetPosition,
-          // Market meta can be missing (boot fetch still retrying) — fall
-          // back to Hyperliquid's official icon, which only needs the coin.
+          // Meta can be missing while the boot fetch retries — fall back to
+          // the bundled PNG, then HL's svg.
           logoUrl:
             marketDataMap[assetPosition.position.coin]?.logoUrl ||
-            getHyperliquidCoinLogoUrl(assetPosition.position.coin),
+            getFallbackCoinLogoUrl(assetPosition.position.coin),
           displayName:
             marketDataMap[assetPosition.position.coin]?.displayName ||
             assetPosition.position.coin,

--- a/apps/mobile/src/screens/Perps/components/PerpsMultiAssetPosition/index.tsx
+++ b/apps/mobile/src/screens/Perps/components/PerpsMultiAssetPosition/index.tsx
@@ -9,7 +9,7 @@ import { View, TouchableOpacity, StyleSheet, Platform } from 'react-native';
 import { useTheme2024, useThemeColors } from '@/hooks/theme';
 import { createGetStyles, createGetStyles2024 } from '@/utils/styles';
 import { useFindAccountByAddress } from '@/screens/Address/components/MultiAssets/hooks/share';
-import { fetchMarketData, perpsStore } from '@/hooks/perps/usePerpsStore';
+import { perpsStore } from '@/hooks/perps/usePerpsStore';
 import { useShallow } from 'zustand/react/shallow';
 import { Account } from '@/core/services/preference';
 import {
@@ -31,7 +31,8 @@ import { PerpsRiskLevelPopup } from '../PerpsPositionSection/PerpsRiskLevelPopup
 import { RootNames } from '@/constant/layout';
 import { useRabbyAppNavigation } from '@/hooks/navigation';
 import { switchPerpsAccountBeforeNavigate } from '@/hooks/perps/usePerpsStore';
-import { formatPerpsCoin } from '@/utils/perps';
+import { formatPerpsCoin, getHyperliquidCoinLogoUrl } from '@/utils/perps';
+import { SvgUri } from 'react-native-svg';
 import { matomoRequestEvent } from '@/utils/analytics';
 import { Text } from '@/components/Typography';
 
@@ -48,6 +49,34 @@ interface AssetPositionWithAccount {
   quoteAsset: string;
   displayName: string;
 }
+
+// Hyperliquid's official coin icons are svg, which the shared AssetAvatar
+// deliberately renders as a placeholder (virtual-list constraint). This card
+// isn't virtualized, so render the svg fallback locally.
+const CoinAvatar = ({ logo, size }: { logo: string; size: number }) => {
+  const svgStyle = useMemo(
+    () => ({
+      width: size,
+      height: size,
+      borderRadius: size / 2,
+      overflow: 'hidden' as const,
+    }),
+    [size],
+  );
+  if (!/\.svg(\?|$)/i.test(logo)) {
+    return <AssetAvatar logo={logo} size={size} />;
+  }
+  return (
+    <View style={svgStyle}>
+      <SvgUri
+        uri={logo}
+        width={size}
+        height={size}
+        fallback={<AssetAvatar logo="" size={size} />}
+      />
+    </View>
+  );
+};
 
 const AssetPositionItem = ({
   item,
@@ -111,7 +140,7 @@ const AssetPositionItem = ({
         {/* Left section: icon + coin info */}
         <View style={styles.leftSection}>
           <View style={styles.coinInfoRow}>
-            <AssetAvatar logo={logoUrl} size={28} />
+            <CoinAvatar logo={logoUrl} size={28} />
             <View style={styles.coinInfo}>
               <View style={styles.coinNameRow}>
                 <Text style={styles.coinName}>
@@ -321,11 +350,10 @@ const AssetPositionItem = ({
 
 export const PerpsMultiAssetPosition: React.FC = () => {
   const getAccountByAddress = useFindAccountByAddress();
-  const { clearinghouseStateMap, marketDataMap, marketDataStatus } = perpsStore(
+  const { clearinghouseStateMap, marketDataMap } = perpsStore(
     useShallow(s => ({
       clearinghouseStateMap: s.clearinghouseStateMap,
       marketDataMap: s.marketDataMap,
-      marketDataStatus: s.marketDataStatus,
     })),
   );
   const [selectedPositionKey, setSelectedPositionKey] = useState<{
@@ -354,7 +382,11 @@ export const PerpsMultiAssetPosition: React.FC = () => {
           account,
           quoteAsset,
           assetPositions: assetPosition,
-          logoUrl: marketDataMap[assetPosition.position.coin]?.logoUrl || '',
+          // Market meta can be missing (boot fetch still retrying) — fall
+          // back to Hyperliquid's official icon, which only needs the coin.
+          logoUrl:
+            marketDataMap[assetPosition.position.coin]?.logoUrl ||
+            getHyperliquidCoinLogoUrl(assetPosition.position.coin),
           displayName:
             marketDataMap[assetPosition.position.coin]?.displayName ||
             assetPosition.position.coin,
@@ -426,31 +458,6 @@ export const PerpsMultiAssetPosition: React.FC = () => {
   const hasLoggedEvent = useRef(false);
 
   const hasPosition = useMemo(() => dataList.length > 0, [dataList.length]);
-
-  // The boot-time fetchMarketData can fail before the network/VPN is ready,
-  // and nothing on Home retries it — positions would render with placeholder
-  // logos until the user navigates away. Retry with capped backoff while this
-  // card shows positions without market data.
-  const marketDataRetryCount = useRef(0);
-  useEffect(() => {
-    if (marketDataStatus === 'success') {
-      marketDataRetryCount.current = 0;
-      return;
-    }
-    if (!hasPosition) {
-      marketDataRetryCount.current = 0;
-      return;
-    }
-    if (marketDataStatus === 'loading') {
-      return;
-    }
-    const delay = Math.min(30_000, 2_000 * 2 ** marketDataRetryCount.current);
-    const timer = setTimeout(() => {
-      marketDataRetryCount.current += 1;
-      fetchMarketData();
-    }, delay);
-    return () => clearTimeout(timer);
-  }, [hasPosition, marketDataStatus]);
 
   useEffect(() => {
     if (hasPosition && !hasLoggedEvent.current) {

--- a/apps/mobile/src/screens/Perps/components/PerpsMultiAssetPosition/index.tsx
+++ b/apps/mobile/src/screens/Perps/components/PerpsMultiAssetPosition/index.tsx
@@ -437,7 +437,11 @@ export const PerpsMultiAssetPosition: React.FC = () => {
       marketDataRetryCount.current = 0;
       return;
     }
-    if (!hasPosition || marketDataStatus === 'loading') {
+    if (!hasPosition) {
+      marketDataRetryCount.current = 0;
+      return;
+    }
+    if (marketDataStatus === 'loading') {
       return;
     }
     const delay = Math.min(30_000, 2_000 * 2 ** marketDataRetryCount.current);

--- a/apps/mobile/src/screens/Perps/components/PerpsMultiAssetPosition/index.tsx
+++ b/apps/mobile/src/screens/Perps/components/PerpsMultiAssetPosition/index.tsx
@@ -9,7 +9,7 @@ import { View, TouchableOpacity, StyleSheet, Platform } from 'react-native';
 import { useTheme2024, useThemeColors } from '@/hooks/theme';
 import { createGetStyles, createGetStyles2024 } from '@/utils/styles';
 import { useFindAccountByAddress } from '@/screens/Address/components/MultiAssets/hooks/share';
-import { perpsStore } from '@/hooks/perps/usePerpsStore';
+import { fetchMarketData, perpsStore } from '@/hooks/perps/usePerpsStore';
 import { useShallow } from 'zustand/react/shallow';
 import { Account } from '@/core/services/preference';
 import {
@@ -321,10 +321,11 @@ const AssetPositionItem = ({
 
 export const PerpsMultiAssetPosition: React.FC = () => {
   const getAccountByAddress = useFindAccountByAddress();
-  const { clearinghouseStateMap, marketDataMap } = perpsStore(
+  const { clearinghouseStateMap, marketDataMap, marketDataStatus } = perpsStore(
     useShallow(s => ({
       clearinghouseStateMap: s.clearinghouseStateMap,
       marketDataMap: s.marketDataMap,
+      marketDataStatus: s.marketDataStatus,
     })),
   );
   const [selectedPositionKey, setSelectedPositionKey] = useState<{
@@ -425,6 +426,27 @@ export const PerpsMultiAssetPosition: React.FC = () => {
   const hasLoggedEvent = useRef(false);
 
   const hasPosition = useMemo(() => dataList.length > 0, [dataList.length]);
+
+  // The boot-time fetchMarketData can fail before the network/VPN is ready,
+  // and nothing on Home retries it — positions would render with placeholder
+  // logos until the user navigates away. Retry with capped backoff while this
+  // card shows positions without market data.
+  const marketDataRetryCount = useRef(0);
+  useEffect(() => {
+    if (marketDataStatus === 'success') {
+      marketDataRetryCount.current = 0;
+      return;
+    }
+    if (!hasPosition || marketDataStatus === 'loading') {
+      return;
+    }
+    const delay = Math.min(30_000, 2_000 * 2 ** marketDataRetryCount.current);
+    const timer = setTimeout(() => {
+      marketDataRetryCount.current += 1;
+      fetchMarketData();
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [hasPosition, marketDataStatus]);
 
   useEffect(() => {
     if (hasPosition && !hasLoggedEvent.current) {

--- a/apps/mobile/src/screens/PerpsHistory/index.tsx
+++ b/apps/mobile/src/screens/PerpsHistory/index.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable react-native/no-inline-styles */
 import NormalScreenContainer2024 from '@/components2024/ScreenContainer/NormalScreenContainer';
+import { IS_ANDROID } from '@/core/native/utils';
+import { useSafeSizes } from '@/hooks/useAppLayout';
 import { useRabbyAppNavigation } from '@/hooks/navigation';
 import { perpsStore } from '@/hooks/perps/usePerpsStore';
 import { useShallow } from 'zustand/react/shallow';
@@ -18,6 +20,7 @@ export const PerpsHistoryScreen = () => {
   const { styles, colors2024, isLight } = useTheme2024({ getStyle: getStyles });
 
   const navigation = useRabbyAppNavigation();
+  const { safeOffHeader } = useSafeSizes();
   const { userFills, localLoadingHistory, userAccountHistory } = perpsStore(
     useShallow(s => ({
       userFills: s.userFills,
@@ -50,7 +53,14 @@ export const PerpsHistoryScreen = () => {
   }, [coin, coinHistoryList, homeHistoryList]);
 
   return (
-    <NormalScreenContainer2024 type={isLight ? 'bg0' : 'bg1'}>
+    <NormalScreenContainer2024
+      type={isLight ? 'bg0' : 'bg1'}
+      // safeOffHeader assumes a 56-tall header: on iOS the native bar is only
+      // 44pt so the list gets 12pt of breathing room for free, while Android's
+      // is exactly 56dp and the list hugs the header — add the same gap.
+      overwriteStyle={
+        IS_ANDROID ? { paddingTop: safeOffHeader + 12 } : undefined
+      }>
       <View style={styles.container}>
         <PerpsHistoryList historyList={list} />
       </View>

--- a/apps/mobile/src/utils/perps.test.ts
+++ b/apps/mobile/src/utils/perps.test.ts
@@ -1,0 +1,72 @@
+// perps.ts pulls the SDK singleton and services barrel at module level —
+// irrelevant to the pure helpers under test.
+jest.mock('@/core/apis/perps', () => ({ apisPerps: {} }));
+jest.mock('@/core/services', () => ({ perpsService: {} }));
+
+import { getPxDecimals } from './perps';
+
+describe('getPxDecimals', () => {
+  // decimals = clamp(4 - floor(log10(0.95 * px)), 0, 6 - szDecimals)
+  describe('5-significant-figures rule from the price magnitude', () => {
+    it('BTC-like: szDecimals=5, px=64000 → whole numbers', () => {
+      expect(getPxDecimals(5, 64000)).toBe(0);
+    });
+
+    it('sub-dollar price: szDecimals=0, px=0.12345 → 5 decimals', () => {
+      expect(getPxDecimals(0, 0.12345)).toBe(5);
+    });
+
+    it('ETH-like: szDecimals=4, px=3500 → tick bound (2) beats sig-figs? no — sig-figs (1) is tighter', () => {
+      expect(getPxDecimals(4, 3500)).toBe(1);
+    });
+
+    it('accepts a numeric string reference price', () => {
+      expect(getPxDecimals(5, '64000')).toBe(0);
+    });
+
+    it('uses the magnitude of a negative price (defensive abs)', () => {
+      expect(getPxDecimals(0, -0.12345)).toBe(5);
+    });
+  });
+
+  describe('×0.95 hysteresis at magnitude boundaries', () => {
+    it('keeps the finer precision just above a power of ten', () => {
+      expect(getPxDecimals(0, 1.05)).toBe(5); // 0.95*1.05 < 1 → still 5 decimals
+    });
+
+    it('steps down once past the hysteresis band', () => {
+      expect(getPxDecimals(0, 1.06)).toBe(4); // 0.95*1.06 > 1 → 4 decimals
+    });
+  });
+
+  describe('clamping', () => {
+    it('never returns negative decimals for very large prices', () => {
+      expect(getPxDecimals(0, 1_000_000)).toBe(0);
+    });
+
+    it('caps tiny prices by the perp tick bound (6 - szDecimals)', () => {
+      expect(getPxDecimals(0, 0.0001234)).toBe(6);
+      expect(getPxDecimals(2, 0.0001234)).toBe(4);
+    });
+
+    it('szDecimals ≥ 6 pins the result to 0 regardless of price', () => {
+      expect(getPxDecimals(7, 0.001)).toBe(0);
+    });
+  });
+
+  describe('fallback to the tick bound without a usable reference price', () => {
+    it.each([
+      [5, undefined, 1],
+      [0, undefined, 6],
+      [0, '', 6], // Number('') === 0
+      [0, 'abc', 6], // NaN
+      [0, 0, 6],
+    ] as const)('szDecimals=%p, refPx=%p → %p', (sz, px, expected) => {
+      expect(getPxDecimals(sz, px)).toBe(expected);
+    });
+
+    it('coerces a runtime-undefined szDecimals to 0 (defensive ?? path)', () => {
+      expect(getPxDecimals(undefined as unknown as number, 100)).toBe(3);
+    });
+  });
+});

--- a/apps/mobile/src/utils/perps.ts
+++ b/apps/mobile/src/utils/perps.ts
@@ -22,13 +22,24 @@ import { perpsService } from '@/core/services';
 import { PerpTopTokenV3 } from '@rabby-wallet/rabby-api/dist/types';
 import BigNumber from 'bignumber.js';
 
-export const getPxDecimals = (markPx: string) => {
-  const parts = markPx.split('.');
-  if (!parts[1]) {
-    return 2;
+// Hyperliquid price-axis precision, ported from the official app bundle:
+// decimals = clamp(4 - floor(log10(0.95 * px)), 0, cap) — i.e. 5
+// significant figures derived from the price magnitude (BTC at 64,026 →
+// whole numbers; 0.123456 → 5 decimals). The ×0.95 is HL's hysteresis:
+// prices just above a power of ten keep the finer precision, so the axis
+// doesn't flap when hovering around a boundary (it also keeps log10 away
+// from exact powers of ten where floats have edges). We cap by
+// 6 - szDecimals (the perp tick bound) where HL's chart caps by a flat 6;
+// ours is never looser. Recomputed per tick but only changes when the
+// price crosses a magnitude.
+export const getPxDecimals = (szDecimals: number, refPx?: string | number) => {
+  const maxBySz = Math.max(0, 6 - Number(szDecimals ?? 0));
+  const px = Math.abs(Number(refPx));
+  if (!Number.isFinite(px) || px === 0) {
+    return maxBySz;
   }
-  const decimalPart = parts[1];
-  return decimalPart.length;
+  const sigDecimals = 4 - Math.floor(Math.log10(0.95 * px));
+  return Math.max(0, Math.min(sigDecimals, maxBySz));
 };
 
 export const normalizeHyperliquidCoinForLogo = (coin: string) => {
@@ -129,7 +140,7 @@ export const formatMarkData = (
           maxUsdValueSize: String(nextTier?.lowerBound ?? PERPS_MAX_NTL_VALUE),
           szDecimals: Number(hlDataAsset.szDecimals ?? 0),
           onlyIsolated: hlDataAsset.onlyIsolated,
-          pxDecimals: 2, // Will be updated by WebSocket AssetCtx
+          pxDecimals: getPxDecimals(Number(hlDataAsset.szDecimals ?? 0)),
           dayBaseVlm: '0',
           dayNtlVlm: '0',
           funding: '0',

--- a/apps/mobile/src/utils/perps.ts
+++ b/apps/mobile/src/utils/perps.ts
@@ -6,6 +6,7 @@ import {
   PERPS_MAX_NTL_VALUE,
   PerpsQuoteAsset,
   COLLATERAL_TOKEN_TO_QUOTE,
+  DEFAULT_TOP_ASSET,
 } from '@/constant/perps';
 import {
   Meta,
@@ -59,6 +60,23 @@ export const getHyperliquidCoinLogoUrl = (coin: string) => {
     return '';
   }
   return `https://app.hyperliquid.xyz/coins/${iconKey}.svg`;
+};
+
+// Logo fallback when marketDataMap hasn't loaded: bundled DeBank PNG first
+// (reachable in degraded networks where HL's domain isn't), HL svg last.
+let defaultTopAssetLogoMap: Record<string, string> | null = null;
+
+export const getFallbackCoinLogoUrl = (coin: string) => {
+  if (!defaultTopAssetLogoMap) {
+    const map: Record<string, string> = {};
+    DEFAULT_TOP_ASSET.forEach(asset => {
+      if (asset.full_logo_url) {
+        map[asset.name] = asset.full_logo_url;
+      }
+    });
+    defaultTopAssetLogoMap = map;
+  }
+  return defaultTopAssetLogoMap[coin] || getHyperliquidCoinLogoUrl(coin);
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -9534,9 +9534,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rabby-wallet/hyperliquid-sdk@npm:1.1.10":
-  version: 1.1.10
-  resolution: "@rabby-wallet/hyperliquid-sdk@npm:1.1.10"
+"@rabby-wallet/hyperliquid-sdk@npm:1.1.15-beta.0":
+  version: 1.1.15-beta.0
+  resolution: "@rabby-wallet/hyperliquid-sdk@npm:1.1.15-beta.0"
   dependencies:
     "@ethereumjs/util": "npm:9.0.0"
     "@metamask/eth-sig-util": "npm:5.1.0"
@@ -9544,7 +9544,7 @@ __metadata:
     "@noble/hashes": "npm:1.8.0"
     ethereum-cryptography: "npm:2.2.1"
     fflate: "npm:0.8.2"
-  checksum: 10/6e8f96411057ec5a5de69b63f3009b6d74683bde788b049ae4bde58019833ec77fa818b74a2f8e655a845c861145a71153587ef95fb6dece05197dfb350ab670
+  checksum: 10/7ad5669b491371f5bc86bc3a37e956a6a8fde371fb9ce04b702440c9eaa01f71e2e88114ad36745a4b1bac4608448aaa79de4f0726ecebc560c28d6a013ddc17
   languageName: node
   linkType: hard
 
@@ -38804,7 +38804,7 @@ __metadata:
     "@rabby-wallet/eth-keyring-watch": "npm:*"
     "@rabby-wallet/eth-simple-keyring": "npm:5.1.2"
     "@rabby-wallet/gnosis-sdk": "npm:1.4.9"
-    "@rabby-wallet/hyperliquid-sdk": "npm:1.1.10"
+    "@rabby-wallet/hyperliquid-sdk": "npm:1.1.15-beta.0"
     "@rabby-wallet/object-multiplex": "workspace:^"
     "@rabby-wallet/persist-store": "workspace:^"
     "@rabby-wallet/rabby-action": "npm:0.1.14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9534,9 +9534,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rabby-wallet/hyperliquid-sdk@npm:1.1.15-beta.1":
-  version: 1.1.15-beta.1
-  resolution: "@rabby-wallet/hyperliquid-sdk@npm:1.1.15-beta.1"
+"@rabby-wallet/hyperliquid-sdk@npm:1.1.15":
+  version: 1.1.15
+  resolution: "@rabby-wallet/hyperliquid-sdk@npm:1.1.15"
   dependencies:
     "@ethereumjs/util": "npm:9.0.0"
     "@metamask/eth-sig-util": "npm:5.1.0"
@@ -9544,7 +9544,7 @@ __metadata:
     "@noble/hashes": "npm:1.8.0"
     ethereum-cryptography: "npm:2.2.1"
     fflate: "npm:0.8.2"
-  checksum: 10/7781b746343eba6af8c46884ce414bbe4a91998feb99446ec45e5b1e8ff75a8b19a84e3214b0e3c633753e3673fb44e065002e1516e6c883d0525f90ae92fac6
+  checksum: 10/1104728872785f19dbe24f4a2b62b2bc076b951a6856fccd0083bee3b4b2d11da2ede22eeba871a6e564c14c87e3f12e68ac2abef640dbe30b7bcfc06d88006a
   languageName: node
   linkType: hard
 
@@ -38804,7 +38804,7 @@ __metadata:
     "@rabby-wallet/eth-keyring-watch": "npm:*"
     "@rabby-wallet/eth-simple-keyring": "npm:5.1.2"
     "@rabby-wallet/gnosis-sdk": "npm:1.4.9"
-    "@rabby-wallet/hyperliquid-sdk": "npm:1.1.15-beta.1"
+    "@rabby-wallet/hyperliquid-sdk": "npm:1.1.15"
     "@rabby-wallet/object-multiplex": "workspace:^"
     "@rabby-wallet/persist-store": "workspace:^"
     "@rabby-wallet/rabby-action": "npm:0.1.14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9534,9 +9534,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rabby-wallet/hyperliquid-sdk@npm:1.1.15-beta.0":
-  version: 1.1.15-beta.0
-  resolution: "@rabby-wallet/hyperliquid-sdk@npm:1.1.15-beta.0"
+"@rabby-wallet/hyperliquid-sdk@npm:1.1.15-beta.1":
+  version: 1.1.15-beta.1
+  resolution: "@rabby-wallet/hyperliquid-sdk@npm:1.1.15-beta.1"
   dependencies:
     "@ethereumjs/util": "npm:9.0.0"
     "@metamask/eth-sig-util": "npm:5.1.0"
@@ -9544,7 +9544,7 @@ __metadata:
     "@noble/hashes": "npm:1.8.0"
     ethereum-cryptography: "npm:2.2.1"
     fflate: "npm:0.8.2"
-  checksum: 10/7ad5669b491371f5bc86bc3a37e956a6a8fde371fb9ce04b702440c9eaa01f71e2e88114ad36745a4b1bac4608448aaa79de4f0726ecebc560c28d6a013ddc17
+  checksum: 10/7781b746343eba6af8c46884ce414bbe4a91998feb99446ec45e5b1e8ff75a8b19a84e3214b0e3c633753e3673fb44e065002e1516e6c883d0525f90ae92fac6
   languageName: node
   linkType: hard
 
@@ -38804,7 +38804,7 @@ __metadata:
     "@rabby-wallet/eth-keyring-watch": "npm:*"
     "@rabby-wallet/eth-simple-keyring": "npm:5.1.2"
     "@rabby-wallet/gnosis-sdk": "npm:1.4.9"
-    "@rabby-wallet/hyperliquid-sdk": "npm:1.1.15-beta.0"
+    "@rabby-wallet/hyperliquid-sdk": "npm:1.1.15-beta.1"
     "@rabby-wallet/object-multiplex": "workspace:^"
     "@rabby-wallet/persist-store": "workspace:^"
     "@rabby-wallet/rabby-action": "npm:0.1.14"


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the perpetuals (perps) trading store and related mobile app code, focusing on data caching, account switching safety, user fills management, and resiliency in market data fetching. The changes aim to improve performance, prevent stale or incorrect data from being shown, and ensure correct behavior when switching accounts or handling network errors.

**Key improvements and fixes:**

### Market Data Caching and Fetch Resiliency

* Added a persistent cache for market data (`perpsMarketCache`) with versioning and TTL, storing only non-price-sensitive fields to avoid displaying stale prices. Boot-time fetches now automatically retry with exponential backoff if they fail, improving reliability on app start. [[1]](diffhunk://#diff-fb4212e39860cdce2b4623b2d2b8dbe15d9f9adcdc16c7ac76abca68c36ac9ffR68-R80) [[2]](diffhunk://#diff-fb4212e39860cdce2b4623b2d2b8dbe15d9f9adcdc16c7ac76abca68c36ac9ffR114-R136) [[3]](diffhunk://#diff-064c94b04705cbe37f08c01250f0adbf8542c7e22407151131bc08056b60763aR34) [[4]](diffhunk://#diff-d6664caaa9a1477f8dcd84edb94c6d59acea90931cf2d08dae6f43331eb809beR56-R71) [[5]](diffhunk://#diff-d6664caaa9a1477f8dcd84edb94c6d59acea90931cf2d08dae6f43331eb809beL599-R660) [[6]](diffhunk://#diff-d6664caaa9a1477f8dcd84edb94c6d59acea90931cf2d08dae6f43331eb809beR671-R679) [[7]](diffhunk://#diff-d6664caaa9a1477f8dcd84edb94c6d59acea90931cf2d08dae6f43331eb809beR690-R699)

### Account Switching and User Fills Management

* Refactored account switching logic to explicitly clear or preserve user fills and readiness flags only when switching to a different account, preventing data leakage between accounts. Unsubscribes are now immediate on switch to avoid race conditions. [[1]](diffhunk://#diff-d6664caaa9a1477f8dcd84edb94c6d59acea90931cf2d08dae6f43331eb809beR395-R414) [[2]](diffhunk://#diff-d6664caaa9a1477f8dcd84edb94c6d59acea90931cf2d08dae6f43331eb809beR428-R431) [[3]](diffhunk://#diff-d6664caaa9a1477f8dcd84edb94c6d59acea90931cf2d08dae6f43331eb809beR444-R446) [[4]](diffhunk://#diff-d6664caaa9a1477f8dcd84edb94c6d59acea90931cf2d08dae6f43331eb809beR1597-R1599)
* Improved user fills handling: added deduplication and merging logic for fills from both HTTP and WebSocket sources, ensuring a consistent, capped-length, and non-overlapping fills list. [[1]](diffhunk://#diff-d6664caaa9a1477f8dcd84edb94c6d59acea90931cf2d08dae6f43331eb809beR858-R925) [[2]](diffhunk://#diff-d6664caaa9a1477f8dcd84edb94c6d59acea90931cf2d08dae6f43331eb809beR934-R947)

### Price and Precision Handling

* Refined logic for price decimal calculation (`pxDecimals`) to consistently use price magnitude and asset size, ensuring correct tick precision display. [[1]](diffhunk://#diff-d6664caaa9a1477f8dcd84edb94c6d59acea90931cf2d08dae6f43331eb809beL451-R472) [[2]](diffhunk://#diff-d6664caaa9a1477f8dcd84edb94c6d59acea90931cf2d08dae6f43331eb809beL1027-R1170)

### Early Position Subscription

* Implemented an early subscription mechanism for perps positions to allow the Home screen to render position data immediately after boot, with safe teardown to prevent zombie subscriptions.

### Miscellaneous

* Upgraded `@rabby-wallet/hyperliquid-sdk` dependency to a beta version.
* Minor: In `AssetAvatar`, added logic to clear load failure state when the logo URL changes, improving avatar reliability. [[1]](diffhunk://#diff-7192c91a91183cd97374ef79a2ebacf5ad5e84e6d48d64e63267a3f6655a909eL6-R6) [[2]](diffhunk://#diff-7192c91a91183cd97374ef79a2ebacf5ad5e84e6d48d64e63267a3f6655a909eL62-R68)

These changes collectively improve data integrity, user experience, and robustness of the perps trading features in the mobile app.