### PR TITLE
fix: disable unsupported RTL layouts

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
     android:icon="@mipmap/ic_launcher"
     android:roundIcon="@mipmap/ic_launcher_round"
     android:allowBackup="false"
-    tools:replace="android:allowBackup"
+    android:supportsRtl="false"
+    tools:replace="android:allowBackup,android:supportsRtl"
     android:pageSizeCompat="enabled"
     android:theme="@style/AppTheme"
     android:networkSecurityConfig="@xml/network_security_config">

--- a/apps/mobile/android/app/src/main/java/com/debank/rabbymobile/MainApplication.kt
+++ b/apps/mobile/android/app/src/main/java/com/debank/rabbymobile/MainApplication.kt
@@ -9,6 +9,7 @@ import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
+import com.facebook.react.modules.i18nmanager.I18nUtil
 
 import com.facebook.react.modules.network.OkHttpClientProvider;
 
@@ -45,6 +46,9 @@ class MainApplication : Application(), ReactApplication {
     try {
       super.onCreate()
       RabbyStartupTrace.instant("Application.super.onCreate")
+      // Rabby currently ships LTR locales only. Set this before React resolves layout direction.
+      I18nUtil.instance.allowRTL(this, false)
+      I18nUtil.instance.forceRTL(this, false)
       RabbyStartupTrace.beginSection("Application.loadReactNative")
       try {
         loadReactNative(this)

--- a/apps/mobile/ios/RabbyMobile/AppDelegate.mm
+++ b/apps/mobile/ios/RabbyMobile/AppDelegate.mm
@@ -3,6 +3,7 @@
 #import <Firebase.h>
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
+#import <React/RCTI18nUtil.h>
 #import <React/RCTRootView.h>
 #import <React/RCTLinkingManager.h>
 #import <React/RCTHTTPRequestHandler.h>
@@ -51,6 +52,11 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+  // Rabby currently ships LTR locales only. Set this before React resolves the root layout direction.
+  RCTI18nUtil *i18nUtil = [RCTI18nUtil sharedInstance];
+  [i18nUtil allowRTL:NO];
+  [i18nUtil forceRTL:NO];
+
   [FIRApp configure];
 
   self.moduleName = @"RabbyMobile";


### PR DESCRIPTION
## Summary

- disable RTL layout direction before React Native initializes on Android and iOS
- declare Android RTL support as disabled in the application manifest
- keep the application LTR because the shipped locales do not currently support RTL

## Impact

Prevents devices using an RTL system language from mirroring Rabby Mobile layouts while preserving the existing LTR product behavior.