### PR TITLE
fix： update history small tx filter

### DIFF
--- a/apps/mobile/src/databases/entities/historyItem.ts
+++ b/apps/mobile/src/databases/entities/historyItem.ts
@@ -240,14 +240,14 @@ export class HistoryItemEntity extends EntityAddressAssetBase {
       return false;
     }
 
-    const receives = item.receives;
+    const transfers = [...(item.receives || []), ...(item.sends || [])];
 
-    if (!receives || !receives.length) {
+    if (!transfers.length) {
       return true;
     }
     let allUsd = 0;
 
-    for (const i of receives) {
+    for (const i of transfers) {
       const token = i.token;
       const tokenIsNft = i.token_id?.length === 32;
       if (tokenIsNft) {

--- a/apps/mobile/src/databases/migrations/20260729.ts
+++ b/apps/mobile/src/databases/migrations/20260729.ts
@@ -81,6 +81,16 @@ export class UpdateHistoryRejudgeSmallTx1785297040800
       return;
     }
 
+    // upgrades from builds older than a6a7a5e99 have the table without the
+    // is_small_tx column (it is added by the post-migration schema sync), and
+    // their legacy rows were already wiped by UpdateHistoryTableRestart
+    const columns: { name: string }[] = await queryRunner.query(
+      `PRAGMA table_info('${historyTableName}')`,
+    );
+    if (!columns.some(c => c.name === 'is_small_tx')) {
+      return;
+    }
+
     const rows: {
       _db_id: string;
       tx_from_address: string | null;

--- a/apps/mobile/src/databases/migrations/20260729.ts
+++ b/apps/mobile/src/databases/migrations/20260729.ts
@@ -1,0 +1,126 @@
+import { MigrationInterface, QueryRunner } from 'typeorm/browser';
+import { APP_DB_PREFIX } from '../constant';
+
+const historyTableName = `${APP_DB_PREFIX}cache_historyitem`;
+
+async function checkIfTableExists(queryRunner: QueryRunner, tableName: string) {
+  const tableExists = await queryRunner.query(
+    `
+    SELECT 1 FROM sqlite_master WHERE type='table' AND name=?;
+  `,
+    [tableName],
+  );
+
+  return tableExists.length > 0;
+}
+
+type TransferItem = {
+  token_id: string;
+  amount: number;
+  price?: number;
+  token?: {
+    is_core?: boolean;
+    is_verified?: boolean;
+    price?: number;
+    collection?: unknown;
+  } | null;
+};
+
+// frozen copy of HistoryItemEntity.judgeIsSmallUsdTx at migration time,
+// minus the pinedQueue check: its absence only biases toward "small",
+// and this migration only flips rows from small to not-small
+function judgeIsSmallUsdTx(row: {
+  tx_from_address: string;
+  owner_addr: string;
+  receives: TransferItem[];
+  sends: TransferItem[];
+}) {
+  if (row.tx_from_address.toLowerCase() === row.owner_addr.toLowerCase()) {
+    return false;
+  }
+
+  const transfers = [...(row.receives || []), ...(row.sends || [])];
+
+  if (!transfers.length) {
+    return true;
+  }
+  let allUsd = 0;
+
+  for (const i of transfers) {
+    const token = i.token;
+    const tokenIsNft = i.token_id?.length === 32;
+    if (tokenIsNft) {
+      if (!token || !token.collection) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+    const isCore = token?.is_core || token?.is_verified;
+    const price = isCore ? i?.price || token?.price || 0 : 0;
+    allUsd += i.amount * price;
+  }
+
+  if (allUsd < 0.1) {
+    return true;
+  }
+
+  return false;
+}
+
+// re-judge is_small_tx after including sends in judgeIsSmallUsdTx:
+// only rows currently marked small and having sends can flip to not-small
+export class UpdateHistoryRejudgeSmallTx1785297040800
+  implements MigrationInterface
+{
+  transaction = false;
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    const tableExists = await checkIfTableExists(queryRunner, historyTableName);
+    if (!tableExists) {
+      return;
+    }
+
+    const rows: {
+      _db_id: string;
+      tx_from_address: string | null;
+      owner_addr: string | null;
+      receives: string | null;
+      sends: string | null;
+    }[] = await queryRunner.query(
+      `SELECT _db_id, tx_from_address, owner_addr, receives, sends FROM '${historyTableName}' WHERE is_small_tx = 1 AND sends IS NOT NULL AND sends != '[]'`,
+    );
+
+    const unhideIds: string[] = [];
+    for (const row of rows) {
+      try {
+        const isSmall = judgeIsSmallUsdTx({
+          tx_from_address: row.tx_from_address || '',
+          owner_addr: row.owner_addr || '',
+          receives: JSON.parse(row.receives || '[]'),
+          sends: JSON.parse(row.sends || '[]'),
+        });
+        if (!isSmall) {
+          unhideIds.push(row._db_id);
+        }
+      } catch (e) {
+        console.error('rejudge is_small_tx error', e, row._db_id);
+      }
+    }
+
+    const CHUNK_SIZE = 200;
+    for (let i = 0; i < unhideIds.length; i += CHUNK_SIZE) {
+      const chunk = unhideIds.slice(i, i + CHUNK_SIZE);
+      await queryRunner.query(
+        `UPDATE '${historyTableName}' SET is_small_tx = 0 WHERE _db_id IN (${chunk
+          .map(() => '?')
+          .join(',')})`,
+        chunk,
+      );
+    }
+  }
+
+  async down(): Promise<void> {
+    // previous is_small_tx values are not recoverable
+  }
+}

--- a/apps/mobile/src/databases/migrations/index.ts
+++ b/apps/mobile/src/databases/migrations/index.ts
@@ -11,6 +11,7 @@ import { UpdateTokenItemAddProtocolId1767166930239 } from './20251231';
 import { CleanupTables1768475805228 } from './20260115';
 import { ClearTokenItemForNullablePrice24hChange1773132444267 } from './20260306';
 import { UpdateTokenItemAddMarketMeta1774318632186 } from './20260323';
+import { UpdateHistoryRejudgeSmallTx1785297040800 } from './20260729';
 
 export function getMigrations() {
   return [
@@ -27,5 +28,6 @@ export function getMigrations() {
     CleanupTables1768475805228,
     ClearTokenItemForNullablePrice24hChange1773132444267,
     UpdateTokenItemAddMarketMeta1774318632186,
+    UpdateHistoryRejudgeSmallTx1785297040800,
   ];
 }

--- a/apps/mobile/src/screens/Transaction/components/utils.ts
+++ b/apps/mobile/src/screens/Transaction/components/utils.ts
@@ -42,13 +42,13 @@ export const judgeIsSmallUsdTx = (
     return false;
   }
 
-  const receives = item.receives;
-  if (!receives || !receives.length) {
+  const transfers = [...(item.receives || []), ...(item.sends || [])];
+  if (!transfers.length) {
     return true;
   }
   let allUsd = new BigNumber(0);
 
-  for (const i of receives) {
+  for (const i of transfers) {
     const token = i.token;
     const tokenIsNft = i.token_id?.length === 32;
     if (tokenIsNft) {
@@ -87,13 +87,13 @@ export const judgeIsSmallUsdTxInApi = (
     return false;
   }
 
-  const receives = item.receives;
-  if (!receives || !receives.length) {
+  const transfers = [...(item.receives || []), ...(item.sends || [])];
+  if (!transfers.length) {
     return false;
   }
   let allUsd = new BigNumber(0);
 
-  for (const i of receives) {
+  for (const i of transfers) {
     const token =
       tokenDict[fetchHistoryTokenUUId(i.token_id, item.chain)] ||
       tokenDict[i.token_id];


### PR DESCRIPTION
This pull request addresses a logic bug in how "small transaction" status is determined for history items, ensuring that both received and sent transfers are considered throughout the codebase and database. It also introduces a migration to retroactively correct previously misclassified transactions in the database.

**Bug Fixes and Logic Corrections:**

* Updated the `judgeIsSmallUsdTx` logic in `HistoryItemEntity` and utility functions to consider both `receives` and `sends` arrays, ensuring accurate classification of small transactions. [[1]](diffhunk://#diff-22297ea29e0a2c4e8b766db05d8640e425970da63ca8c87cb2d18736b6f5036eL243-R250) [[2]](diffhunk://#diff-67488ec1ab35a691cb362c6e3e3d52c6aa85b54c2ddf361456890c1b87cc7d9aL45-R51) [[3]](diffhunk://#diff-67488ec1ab35a691cb362c6e3e3d52c6aa85b54c2ddf361456890c1b87cc7d9aL90-R96)

**Database Migration:**

* Added a new migration (`20260729.ts`) that re-evaluates and updates the `is_small_tx` field in the `cache_historyitem` table, correcting rows that were previously marked as small transactions due to the old logic only considering `receives`.
* Registered the new migration in the migrations index, ensuring it will be applied in sequence. [[1]](diffhunk://#diff-8e49ae39146688c6da0be16e1f5dad32019f51d522f1f56a6d2e4ee44890d183R14) [[2]](diffhunk://#diff-8e49ae39146688c6da0be16e1f5dad32019f51d522f1f56a6d2e4ee44890d183R31)