### PR TITLE
fix(home): prevent stale balance selection after account removal

### DIFF
--- a/apps/mobile/src/store/balance.ts
+++ b/apps/mobile/src/store/balance.ts
@@ -1418,23 +1418,16 @@ function buildSelectedBalanceDerivedState(
   );
 }
 
-export async function applyAccountBalanceSelectionSnapshot(
+export function commitAccountBalanceSelectionSnapshot(
   {
     selectedAccounts,
     selectedAddresses,
     matteredAccountLength,
   }: AccountBalanceSelectionSnapshot,
   options: {
-    hydrate: boolean;
     source: AccountsBalanceChangeSource;
   },
 ) {
-  if (options.hydrate) {
-    await addressBalanceStore.hydrateCachedBalancesForAccounts(
-      selectedAccounts,
-    );
-  }
-
   const nextBalance = buildBalanceAccountsFromList(
     selectedAccounts,
     addressBalanceStore.getAddressValueMap(),
@@ -1456,6 +1449,22 @@ export async function applyAccountBalanceSelectionSnapshot(
   );
 
   return nextBalance;
+}
+
+export async function applyAccountBalanceSelectionSnapshot(
+  snapshot: AccountBalanceSelectionSnapshot,
+  options: {
+    hydrate: boolean;
+    source: AccountsBalanceChangeSource;
+  },
+) {
+  if (options.hydrate) {
+    await addressBalanceStore.hydrateCachedBalancesForAccounts(
+      snapshot.selectedAccounts,
+    );
+  }
+
+  return commitAccountBalanceSelectionSnapshot(snapshot, options);
 }
 
 export const syncBalanceAccountStore = () => {

--- a/apps/mobile/src/store/balanceAccountSelection.test.ts
+++ b/apps/mobile/src/store/balanceAccountSelection.test.ts
@@ -1,0 +1,195 @@
+type Deferred = {
+  promise: Promise<void>;
+  resolve: () => void;
+};
+
+const createDeferred = (): Deferred => {
+  let resolve!: () => void;
+  const promise = new Promise<void>(nextResolve => {
+    resolve = nextResolve;
+  });
+
+  return {
+    promise,
+    resolve,
+  };
+};
+
+const flushPromises = () =>
+  new Promise<void>(resolve => {
+    setImmediate(resolve);
+  });
+
+describe('account balance selection lifecycle', () => {
+  const mockHydrateCachedBalancesForAccounts = jest.fn();
+  const mockApplyAccountBalanceSelectionSnapshot = jest.fn();
+
+  let accountSubscriber:
+    | ((state: {
+        accounts: Array<{
+          address: string;
+          type: string;
+          brandName: string;
+        }>;
+        hasFetchedAccounts: boolean;
+        pinnedAddresses: Array<{
+          address: string;
+          brandName: string;
+        }>;
+      }) => void)
+    | undefined;
+  let committedAddresses: string[];
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    accountSubscriber = undefined;
+    committedAddresses = [];
+
+    jest.doMock('@/core/apis/account', () => ({
+      filterMyAccounts: (accounts: unknown[]) => accounts,
+      filterOutTop10Accounts: (
+        accounts: Array<{
+          address: string;
+        }>,
+      ) => ({
+        top10Accounts: accounts.slice(0, 10),
+        top10Addresses: accounts.slice(0, 10).map(account => account.address),
+      }),
+      getAccountList: jest.fn(),
+      sortAccountList: (accounts: unknown[]) => accounts,
+    }));
+    jest.doMock('@/core/serviceApi/keyring', () => ({
+      bindKeyringEventAfterRegistration: jest.fn(),
+      isKeyringUnlockedSnapshot: () => true,
+    }));
+    jest.doMock('@/core/utils/androidTrace', () => ({
+      traceAndroidInstant: jest.fn(),
+    }));
+    jest.doMock('./account', () => ({
+      __esModule: true,
+      default: {
+        getState: () => ({
+          accounts: [],
+          hasFetchedAccounts: false,
+          pinnedAddresses: [],
+        }),
+        subscribe: (subscriber: typeof accountSubscriber) => {
+          accountSubscriber = subscriber;
+          return jest.fn();
+        },
+      },
+    }));
+    jest.doMock('./balance', () => ({
+      __esModule: true,
+      default: {
+        hydrateCachedBalancesForAccounts: (...args: unknown[]): Promise<void> =>
+          mockHydrateCachedBalancesForAccounts(...args),
+      },
+      applyAccountBalanceSelectionSnapshot: async (
+        snapshot: {
+          selectedAccounts: unknown[];
+          selectedAddresses: string[];
+        },
+        options: {
+          hydrate: boolean;
+        },
+      ) => {
+        if (options.hydrate) {
+          await mockHydrateCachedBalancesForAccounts(snapshot.selectedAccounts);
+        }
+        committedAddresses = snapshot.selectedAddresses;
+        mockApplyAccountBalanceSelectionSnapshot(snapshot, options);
+        return {};
+      },
+      commitAccountBalanceSelectionSnapshot: (
+        snapshot: {
+          selectedAddresses: string[];
+        },
+        options: {
+          source: string;
+        },
+      ) => {
+        committedAddresses = snapshot.selectedAddresses;
+        mockApplyAccountBalanceSelectionSnapshot(snapshot, {
+          ...options,
+          hydrate: false,
+        });
+        return {};
+      },
+      setAccountBalanceSelectionSnapshotGetter: jest.fn(),
+      startProcessAddressBalanceEvents: jest.fn(),
+    }));
+  });
+
+  it('does not let a pre-delete hydrate overwrite the latest account selection', async () => {
+    const preDeleteHydrate = createDeferred();
+    const postDeleteHydrate = createDeferred();
+    mockHydrateCachedBalancesForAccounts
+      .mockReturnValueOnce(preDeleteHydrate.promise)
+      .mockReturnValueOnce(postDeleteHydrate.promise);
+
+    const stableAccounts = Array.from({ length: 9 }, (_, index) => ({
+      address: `0xstable${index}`,
+      type: 'SimpleKeyring',
+      brandName: 'Rabby',
+    }));
+    const deletedAccount = {
+      address: '0xdeleted',
+      type: 'SimpleKeyring',
+      brandName: 'Rabby',
+    };
+    const promotedAccount = {
+      address: '0xpromoted',
+      type: 'SimpleKeyring',
+      brandName: 'Rabby',
+    };
+    const preDeleteAccounts = [
+      deletedAccount,
+      ...stableAccounts,
+      promotedAccount,
+    ];
+    const postDeleteAccounts = [...stableAccounts, promotedAccount];
+
+    const { ensureAccountBalanceSelectionLifecycle } =
+      require('./balanceAccountSelection') as typeof import('./balanceAccountSelection');
+
+    await ensureAccountBalanceSelectionLifecycle();
+    expect(accountSubscriber).toBeDefined();
+
+    accountSubscriber?.({
+      accounts: preDeleteAccounts,
+      hasFetchedAccounts: true,
+      pinnedAddresses: [],
+    });
+    accountSubscriber?.({
+      accounts: postDeleteAccounts,
+      hasFetchedAccounts: true,
+      pinnedAddresses: [],
+    });
+
+    expect(mockHydrateCachedBalancesForAccounts).toHaveBeenCalledTimes(2);
+    expect(mockHydrateCachedBalancesForAccounts.mock.calls[1][0]).toEqual(
+      postDeleteAccounts,
+    );
+    expect(committedAddresses).toEqual(
+      postDeleteAccounts.map(account => account.address),
+    );
+
+    postDeleteHydrate.resolve();
+    await flushPromises();
+    expect(committedAddresses).toEqual(
+      postDeleteAccounts.map(account => account.address),
+    );
+
+    preDeleteHydrate.resolve();
+    await flushPromises();
+
+    expect(committedAddresses).toEqual(
+      postDeleteAccounts.map(account => account.address),
+    );
+    expect(mockApplyAccountBalanceSelectionSnapshot).toHaveBeenCalledTimes(3);
+    expect(committedAddresses).not.toContain(deletedAccount.address);
+    expect(committedAddresses).toContain(promotedAccount.address);
+  });
+});

--- a/apps/mobile/src/store/balanceAccountSelection.ts
+++ b/apps/mobile/src/store/balanceAccountSelection.ts
@@ -13,9 +13,9 @@ import {
 import { traceAndroidInstant } from '@/core/utils/androidTrace';
 import type { Account, IPinAddress } from '@/types/account';
 import accountStore from './account';
-import {
+import addressBalanceStore, {
+  commitAccountBalanceSelectionSnapshot,
   type AccountBalanceSelectionSnapshot,
-  applyAccountBalanceSelectionSnapshot,
   setAccountBalanceSelectionSnapshotGetter,
   startProcessAddressBalanceEvents,
 } from './balance';
@@ -72,6 +72,7 @@ const accountBalanceSelectionLifecycleStateRef = {
   promise: null as Promise<void> | null,
   hasSubscribed: false,
   prevSelectionSignature: '',
+  syncGeneration: 0,
 };
 
 async function initAccountBalanceSelectionLifecycle() {
@@ -85,6 +86,8 @@ async function initAccountBalanceSelectionLifecycle() {
       accountState?: ReturnType<typeof accountStore.getState>;
       allowFetchFallback?: boolean;
     } = {}) => {
+      const syncGeneration =
+        ++accountBalanceSelectionLifecycleStateRef.syncGeneration;
       const canUseStoreSnapshot =
         accountState.hasFetchedAccounts || accountState.accounts.length > 0;
       if (!canUseStoreSnapshot && !allowFetchFallback) {
@@ -98,8 +101,29 @@ async function initAccountBalanceSelectionLifecycle() {
           )
         : await getMatteredAccountsSnapshot();
 
-      await applyAccountBalanceSelectionSnapshot(snapshot, {
-        hydrate: true,
+      if (
+        syncGeneration !==
+        accountBalanceSelectionLifecycleStateRef.syncGeneration
+      ) {
+        return;
+      }
+
+      commitAccountBalanceSelectionSnapshot(snapshot, {
+        source: 'accounts_changed',
+      });
+
+      await addressBalanceStore.hydrateCachedBalancesForAccounts(
+        snapshot.selectedAccounts,
+      );
+
+      if (
+        syncGeneration !==
+        accountBalanceSelectionLifecycleStateRef.syncGeneration
+      ) {
+        return;
+      }
+
+      commitAccountBalanceSelectionSnapshot(snapshot, {
         source: 'accounts_changed',
       });
     };


### PR DESCRIPTION
## Summary
- commit the newest account selection before cached balance hydration
- ignore stale hydrate completions with a latest-wins generation guard
- preserve existing deletion and balance hydration behavior

## Regression coverage
- add a deterministic race test where post-delete hydration finishes before pre-delete hydration
- verified the test fails before the fix by restoring the deleted address
- verified the fixed path retains the promoted Top 10 account and never restores the deleted address

## Verification
- related balance suites: 17 tests passed
- typecheck
- cycle checks
- staged ESLint and Prettier checks