### PR TITLE
fix: use -P option in resolve_fns_script_dir for correct path resolution

### DIFF
--- a/apps/mobile/scripts/fns.sh
+++ b/apps/mobile/scripts/fns.sh
@@ -12,7 +12,8 @@ resolve_fns_script_path() {
 resolve_fns_script_dir() {
   local self_path
   self_path=$(resolve_fns_script_path)
-  cd "$( dirname "$self_path" )" && pwd
+  # -P: yarn (Berry) exports a Windows-style PWD which MSYS bash would echo back verbatim
+  cd "$( dirname "$self_path" )" && pwd -P
 }
 
 RABBY_FNS_SCRIPT_DIR=$(resolve_fns_script_dir)


### PR DESCRIPTION
This pull request makes a small adjustment to the `resolve_fns_script_dir` function in the `apps/mobile/scripts/fns.sh` script. The change ensures that the script always returns the physical directory path, which improves compatibility with environments like MSYS bash and Yarn (Berry).

* Updated `resolve_fns_script_dir` to use `pwd -P` instead of `pwd` to ensure the returned path is always the physical directory, avoiding issues with Windows-style paths in certain environments.