### PR TITLE
perf(home): pause inactive overview subscriptions

### DIFF
--- a/apps/mobile/src/devtools/regressionScenarios/scenarios/coreNavigation.ts
+++ b/apps/mobile/src/devtools/regressionScenarios/scenarios/coreNavigation.ts
@@ -45,12 +45,13 @@ const HOME_TAB_READY_ASSERTIONS: Record<number, string | undefined> = {
   2: 'home-assets-defi-ready',
   3: 'home-assets-nft-ready',
 };
-const HOME_ASSET_ACTIVITY_SCOPE_LABELS = [
+const HOME_TAB_ACTIVITY_SCOPE_LABELS = [
+  'home-multi-assets-overview',
   'home-multi-assets-token',
   'home-multi-assets-defi',
   'home-multi-assets-nft',
 ] as const;
-const HOME_ASSET_ACTIVITY_VERIFICATION_TABS = [0, 1, 2, 3, 0] as const;
+const HOME_TAB_ACTIVITY_VERIFICATION_TABS = [0, 1, 2, 3, 0] as const;
 
 function formatSafeAddress(address: string) {
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
@@ -298,9 +299,9 @@ async function waitForHomeTabIndex(tabIndex: number, timeoutMs = 10_000) {
   throw new Error(`Timed out waiting for Home tab index: ${tabIndex}`);
 }
 
-function summarizeHomeAssetActivityScopes() {
+function summarizeHomeTabActivityScopes() {
   const snapshot = getStoreActivityDiagnosticsSnapshot();
-  const scopes = HOME_ASSET_ACTIVITY_SCOPE_LABELS.map(
+  const scopes = HOME_TAB_ACTIVITY_SCOPE_LABELS.map(
     getLatestStoreActivityScopeDiagnostics,
   );
 
@@ -308,7 +309,7 @@ function summarizeHomeAssetActivityScopes() {
     enabled: snapshot.enabled,
     scopes,
     report: scopes.map((scope, index) => ({
-      label: HOME_ASSET_ACTIVITY_SCOPE_LABELS[index],
+      label: HOME_TAB_ACTIVITY_SCOPE_LABELS[index],
       mounted: !!scope,
       active: scope?.active ?? false,
       consumerCount:
@@ -321,17 +322,16 @@ function summarizeHomeAssetActivityScopes() {
   };
 }
 
-async function assertHomeAssetActivity(
+async function assertHomeTabActivity(
   context: RegressionScenarioExecutionContext,
-  tabIndex: (typeof HOME_ASSET_ACTIVITY_VERIFICATION_TABS)[number],
+  tabIndex: (typeof HOME_TAB_ACTIVITY_VERIFICATION_TABS)[number],
 ) {
-  const expectedActiveLabel =
-    tabIndex === 0 ? null : HOME_ASSET_ACTIVITY_SCOPE_LABELS[tabIndex - 1];
+  const expectedActiveLabel = HOME_TAB_ACTIVITY_SCOPE_LABELS[tabIndex];
   const startedAt = Date.now();
-  let latest = summarizeHomeAssetActivityScopes();
+  let latest = summarizeHomeTabActivityScopes();
 
   while (Date.now() - startedAt < 10_000) {
-    latest = summarizeHomeAssetActivityScopes();
+    latest = summarizeHomeTabActivityScopes();
     const allScopesMounted = latest.scopes.every(Boolean);
     const activityMatches = latest.scopes.every(scope => {
       if (!scope) {
@@ -355,7 +355,7 @@ async function assertHomeAssetActivity(
 
     if (latest.enabled && allScopesMounted && activityMatches) {
       context.report('assertion', {
-        assertion: 'home-assets-store-activity',
+        assertion: 'home-tabs-store-activity',
         passed: true,
         tabIndex,
         expectedActiveLabel,
@@ -367,7 +367,7 @@ async function assertHomeAssetActivity(
   }
 
   context.report('assertion', {
-    assertion: 'home-assets-store-activity',
+    assertion: 'home-tabs-store-activity',
     passed: false,
     tabIndex,
     expectedActiveLabel,
@@ -401,10 +401,10 @@ async function openHomeAssets(context: RegressionScenarioExecutionContext) {
     }
   }
 
-  for (const tabIndex of HOME_ASSET_ACTIVITY_VERIFICATION_TABS) {
+  for (const tabIndex of HOME_TAB_ACTIVITY_VERIFICATION_TABS) {
     apisHomeTabIndex.setTabIndex(tabIndex, true);
     await waitForHomeTabIndex(tabIndex);
-    await assertHomeAssetActivity(context, tabIndex);
+    await assertHomeTabActivity(context, tabIndex);
   }
 }
 

--- a/apps/mobile/src/hooks/account.ts
+++ b/apps/mobile/src/hooks/account.ts
@@ -39,6 +39,8 @@ import { InteractionManager } from 'react-native';
 import { appServiceEvents } from '@/core/events/appServiceEvents';
 import { perfEvents } from '@/core/utils/perf';
 import { AccountInfoEntity } from '@/databases/entities/accountInfo';
+import { useActivityStore } from '@/hooks/storeActivity/useActivityStore';
+import { useShallow } from 'zustand/react/shallow';
 
 export type { KeyringAccountWithAlias as /** @deprecated */ KeyringAccountWithAlias } from '@/types/account';
 
@@ -318,8 +320,15 @@ export const usePinAddresses = (opts?: { disableAutoFetch?: boolean }) => {
 };
 
 export const usePinnedAccountList = () => {
-  const pinAddresses = useAccountStore(s => s.pinnedAddresses);
-  const accounts = useAccountStore(s => s.accounts);
+  const { pinAddresses, accounts } = useActivityStore(
+    accountStore.useStore,
+    useShallow(state => ({
+      pinAddresses: state.pinnedAddresses,
+      accounts: state.accounts,
+    })),
+    Object.is,
+    { storeLabel: 'home-pinned-accounts' },
+  );
 
   useEffect(() => {
     accountStore.ensurePinnedAddressesHydrated().catch(error => {
@@ -355,14 +364,21 @@ export const usePinnedAccountList = () => {
   const pinnedAddresses = useMemo(() => {
     return pinnedBaseAccounts.map(item => item.address.toLowerCase());
   }, [pinnedBaseAccounts]);
-  const balanceSnapshots =
-    addressBalanceStore.useAddressesSnapshot(pinnedAddresses);
+  const balanceValues = useActivityStore(
+    addressBalanceStore.useStore,
+    useShallow(state =>
+      pinnedAddresses.map(address => state.valueMap[address]),
+    ),
+    Object.is,
+    { storeLabel: 'home-pinned-account-balances' },
+  );
 
   const pinnedAccountList = useMemo(() => {
-    const balanceMap = balanceSnapshots.reduce(
-      (acc, snapshot) => {
-        if (snapshot.value) {
-          acc[snapshot.address] = snapshot.value;
+    const balanceMap = pinnedAddresses.reduce(
+      (acc, address, index) => {
+        const balance = balanceValues[index];
+        if (balance) {
+          acc[address] = balance;
         }
         return acc;
       },
@@ -384,7 +400,7 @@ export const usePinnedAccountList = () => {
         evmBalance: balance?.evmBalance || item.evmBalance || 0,
       };
     });
-  }, [balanceSnapshots, pinnedBaseAccounts]);
+  }, [balanceValues, pinnedAddresses, pinnedBaseAccounts]);
 
   return pinnedAccountList;
 };

--- a/apps/mobile/src/hooks/browser/useBrowser.ts
+++ b/apps/mobile/src/hooks/browser/useBrowser.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import { Platform } from 'react-native';
-import { useMemoizedFn } from 'ahooks';
 import { last, omit, sortBy } from 'lodash';
 import { v4 as uuid } from 'uuid';
 import type { ContentMode } from 'react-native-webview/lib/WebViewTypes';
@@ -35,6 +34,7 @@ import { resolveValFromUpdater } from '@/core/utils/store';
 import { runStartupTask } from '@/core/utils/startupScheduler';
 import { STARTUP_TASKS } from '@/core/utils/startupTaskManifest';
 import { perfEvents } from '@/core/utils/perf';
+import { useActivityStore } from '@/hooks/storeActivity/useActivityStore';
 
 type TabsState = {
   tabs: Tab[];
@@ -239,7 +239,9 @@ function useDisplayedTabs() {
 }
 
 export function useHomeDisplayedTabs() {
-  const tabs = tabsStore(s => s.tabs);
+  const tabs = useActivityStore(tabsStore, state => state.tabs, Object.is, {
+    storeLabel: 'home-overview-browser-tabs',
+  });
 
   const homeDisplayedTabs = useMemo(
     () =>

--- a/apps/mobile/src/hooks/perps/usePerpsAccount.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsAccount.ts
@@ -6,6 +6,7 @@ import { useCallback, useMemo } from 'react';
 import { perpsStore } from './usePerpsStore';
 import { useShallow } from 'zustand/react/shallow';
 import { getSpotBalanceKey } from '@/utils/perps';
+import { useActivityStore } from '@/hooks/storeActivity/useActivityStore';
 
 export const usePerpsAccount = () => {
   const {
@@ -18,7 +19,8 @@ export const usePerpsAccount = () => {
     spotBalances,
     spotBalancesMap,
     tokenToAvailableAfterMaintenance,
-  } = perpsStore(
+  } = useActivityStore(
+    perpsStore,
     useShallow(s => ({
       userAbstraction: s.userAbstraction,
       perpsAccountValue:
@@ -34,6 +36,8 @@ export const usePerpsAccount = () => {
       tokenToAvailableAfterMaintenance:
         s.spotState.tokenToAvailableAfterMaintenance,
     })),
+    Object.is,
+    { storeLabel: 'perps-account' },
   );
 
   const isUnifiedAccount = useMemo(() => {

--- a/apps/mobile/src/hooks/perps/usePerpsHomePnl.ts
+++ b/apps/mobile/src/hooks/perps/usePerpsHomePnl.ts
@@ -2,6 +2,7 @@ import { perpsStore } from './usePerpsStore';
 import { useShallow } from 'zustand/react/shallow';
 import { usePerpsAccount } from './usePerpsAccount';
 import { UserAbstractionResp } from '@rabby-wallet/hyperliquid-sdk';
+import { useActivityStore } from '@/hooks/storeActivity/useActivityStore';
 
 export const usePerpsHomePnl = () => {
   const {
@@ -12,7 +13,8 @@ export const usePerpsHomePnl = () => {
     isUserDataReady,
     userAbstraction,
     userAbstractionReady,
-  } = perpsStore(
+  } = useActivityStore(
+    perpsStore,
     useShallow(s => ({
       currentPerpsAccount: s.currentPerpsAccount,
       homePositionPnl: s.homePositionPnl,
@@ -22,6 +24,8 @@ export const usePerpsHomePnl = () => {
       userAbstraction: s.userAbstraction,
       userAbstractionReady: s.userAbstractionReady,
     })),
+    Object.is,
+    { storeLabel: 'home-overview-perps-pnl' },
   );
   const { availableBalance } = usePerpsAccount();
   const isSpotCollateralMode =

--- a/apps/mobile/src/hooks/useGasAccountEligibility.ts
+++ b/apps/mobile/src/hooks/useGasAccountEligibility.ts
@@ -8,6 +8,7 @@ import { makeAvoidParallelAsyncFunc, runDevIIFEFunc } from '@/core/utils/store';
 import * as apisAccount from '@/core/apis/account';
 import { storeApiGasAccount } from '@/screens/GasAccount/hooks/atom';
 import { useShallow } from 'zustand/react/shallow';
+import { useActivityStore } from '@/hooks/storeActivity/useActivityStore';
 
 runDevIIFEFunc(() => {
   // mock haven't claimed gift
@@ -74,11 +75,14 @@ export const checkGasAccountAddressesEligibility = makeAvoidParallelAsyncFunc(
 );
 
 export const useGasAccountGiftEligibility = () => {
-  return gasAccountState(
-    s =>
-      s.currentEligibleAddress !== undefined &&
-      !s.gasAccountSig?.sig &&
-      !s.hasClaimedGift,
+  return useActivityStore(
+    gasAccountState,
+    state =>
+      state.currentEligibleAddress !== undefined &&
+      !state.gasAccountSig?.sig &&
+      !state.hasClaimedGift,
+    Object.is,
+    { storeLabel: 'home-gas-account-badge' },
   );
 };
 

--- a/apps/mobile/src/screens/Address/components/MultiAssets/TabsMultiAssets.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/TabsMultiAssets.tsx
@@ -94,7 +94,7 @@ const onIndexChange = (idx: number) => {
   scheduleReadableAccountStoreWarmupForTab(idx);
 };
 
-const HomeAssetTabActivityBoundary = ({
+const HomeTabActivityBoundary = ({
   children,
   name,
 }: {
@@ -170,23 +170,25 @@ export const TabsMultiAssets: React.FC<TabMultiAssetsProps> = () => {
           key={TabName.overview}
           name={TabName.overview}
           label={() => null}>
-          <HomeOverview />
+          <HomeTabActivityBoundary name={TabName.overview}>
+            <HomeOverview />
+          </HomeTabActivityBoundary>
         </Tabs.Tab>
 
         <Tabs.Tab key={TabName.token} name={TabName.token} label={() => null}>
-          <HomeAssetTabActivityBoundary name={TabName.token}>
+          <HomeTabActivityBoundary name={TabName.token}>
             <TokenList />
-          </HomeAssetTabActivityBoundary>
+          </HomeTabActivityBoundary>
         </Tabs.Tab>
         <Tabs.Tab key={TabName.defi} name={TabName.defi} label={() => null}>
-          <HomeAssetTabActivityBoundary name={TabName.defi}>
+          <HomeTabActivityBoundary name={TabName.defi}>
             <ProtocolList />
-          </HomeAssetTabActivityBoundary>
+          </HomeTabActivityBoundary>
         </Tabs.Tab>
         <Tabs.Tab key={TabName.nft} name={TabName.nft} label={() => null}>
-          <HomeAssetTabActivityBoundary name={TabName.nft}>
+          <HomeTabActivityBoundary name={TabName.nft}>
             <NFTList />
-          </HomeAssetTabActivityBoundary>
+          </HomeTabActivityBoundary>
         </Tabs.Tab>
       </MultiAssetsContainer>
     </View>

--- a/apps/mobile/src/screens/Browser/components/BrowserSearchEntry.tsx
+++ b/apps/mobile/src/screens/Browser/components/BrowserSearchEntry.tsx
@@ -1,15 +1,11 @@
-import { useBrowser, useHomeDisplayedTabs } from '@/hooks/browser/useBrowser';
+import { browserApis, useHomeDisplayedTabs } from '@/hooks/browser/useBrowser';
 import { useTheme2024 } from '@/hooks/theme';
 import { matomoRequestEvent } from '@/utils/analytics';
 import { createGetStyles2024 } from '@/utils/styles';
 import { safeGetOrigin } from '@rabby-wallet/base-utils/dist/isomorphic/url';
 import { BlurView, BlurViewProps } from '@react-native-community/blur';
-import { useMemoizedFn } from 'ahooks';
-import { useAtom } from 'jotai';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { Platform, View } from 'react-native';
-import { activeTabAtom } from '../BrowserScreen/components/BrowserManage';
 import { BrowserTabCard } from '../BrowserScreen/components/BrowserManage/BrowserTabList/BrowserTabCard';
 
 const isAndroid = Platform.OS === 'android';
@@ -173,47 +169,9 @@ const BlurViewOnlyIOSWrapper = ({
 };
 
 export const BrowserSearchEntry: React.FC = () => {
-  const { styles, colors2024, isLight } = useTheme2024({ getStyle });
-  const {
-    browserState,
-    setPartialBrowserState,
-    displayedTabs,
-    forceShowBrowser,
-    forceShowBrowserManage,
-    closeTab,
-    switchToTab,
-    openTab,
-    setBrowserState,
-  } = useBrowser();
+  const { styles, isLight } = useTheme2024({ getStyle });
 
   const { homeDisplayedTabs: tabs } = useHomeDisplayedTabs();
-  const [, setActiveTab] = useAtom(activeTabAtom);
-
-  const { t } = useTranslation();
-  const handlePress = useMemoizedFn(() => {
-    setPartialBrowserState({
-      isShowBrowser: true,
-      isShowSearch: true,
-      searchText: '',
-      searchTabId: '',
-      trigger: 'home',
-    });
-    forceShowBrowser();
-  });
-
-  const handleTabPress = useMemoizedFn(() => {
-    if (!displayedTabs?.length) {
-      setActiveTab('favorites');
-    }
-    setPartialBrowserState({
-      isShowBrowser: false,
-      isShowSearch: false,
-      isShowManage: true,
-      searchText: '',
-      searchTabId: '',
-    });
-    forceShowBrowserManage();
-  });
 
   if (!tabs.length) {
     return null;
@@ -243,7 +201,7 @@ export const BrowserSearchEntry: React.FC = () => {
                     containerStyle={styles.tabItem}
                     tab={tab}
                     onPress={() => {
-                      switchToTab(tab.id);
+                      browserApis.switchToTab(tab.id);
                       const origin = safeGetOrigin(tab.url || tab.initialUrl);
                       if (origin) {
                         matomoRequestEvent({
@@ -254,7 +212,7 @@ export const BrowserSearchEntry: React.FC = () => {
                       }
                     }}
                     onPressClose={() => {
-                      closeTab(tab.id);
+                      browserApis.closeTab(tab.id);
                     }}
                   />
                 </View>

--- a/apps/mobile/src/screens/Home/components/MultiAddressHomeHeader.tsx
+++ b/apps/mobile/src/screens/Home/components/MultiAddressHomeHeader.tsx
@@ -29,6 +29,8 @@ import { apiGlobalModal } from '@/components2024/GlobalBottomSheetModal/apiGloba
 import { computeBalanceChange } from '@/core/apis/balance';
 import { balance24hStore } from '@/store/balance24h';
 import Animated, { Easing, FadeInUp } from 'react-native-reanimated';
+import { useActivityStore } from '@/hooks/storeActivity/useActivityStore';
+import { useShallow } from 'zustand/react/shallow';
 
 const PINNED_ADDRESS_LIST_ENTERING = FadeInUp.duration(460).easing(
   Easing.out(Easing.cubic),
@@ -45,14 +47,21 @@ function MultiPinnedAddressList({
   const pinnedAddresses = useMemo(() => {
     return pinnedAccountList.map(item => item.address.toLowerCase());
   }, [pinnedAccountList]);
-  const balance24hSnapshots =
-    balance24hStore.useAddresses24hBalanceSnapshots(pinnedAddresses);
+  const balance24hValues = useActivityStore(
+    balance24hStore.useStore,
+    useShallow(state =>
+      pinnedAddresses.map(address => state.valueMap[address]),
+    ),
+    Object.is,
+    { storeLabel: 'home-pinned-account-24h-balances' },
+  );
 
   const addressListData = useMemo(() => {
-    const multi24hBalance = balance24hSnapshots.reduce(
-      (acc, snapshot) => {
-        if (snapshot.value) {
-          acc[snapshot.address] = snapshot.value;
+    const multi24hBalance = pinnedAddresses.reduce(
+      (acc, address, index) => {
+        const balance24h = balance24hValues[index];
+        if (balance24h) {
+          acc[address] = balance24h;
         }
         return acc;
       },
@@ -88,7 +97,7 @@ function MultiPinnedAddressList({
       }),
       item => -(item.balance || 0),
     ).slice(0, 3);
-  }, [balance24hSnapshots, pinnedAccountList]);
+  }, [balance24hValues, pinnedAccountList, pinnedAddresses]);
 
   useEffect(() => {
     if (!addressListData?.length) {

--- a/apps/mobile/src/screens/Home/hooks/approvals.ts
+++ b/apps/mobile/src/screens/Home/hooks/approvals.ts
@@ -14,6 +14,7 @@ import { zCreate } from '@/core/utils/reexports';
 import type { UpdaterOrPartials } from '@/core/utils/store';
 import { resolveValFromUpdater } from '@/core/utils/store';
 import { useCreationWithShallowCompare } from '@/hooks/common/useMemozied';
+import { useActivityStore } from '@/hooks/storeActivity/useActivityStore';
 
 // const approvalStatusAtom = atom<ApprovalStatus[]>([]);
 const approvalStatusStore = zCreate<ApprovalStatus[]>(() => []);
@@ -230,7 +231,12 @@ async function refreshApprovalAlertCountsForAccounts(
 }
 
 export function useApprovalAlertTotal() {
-  return approvalsAlertStore(s => s.total);
+  return useActivityStore(
+    approvalsAlertStore,
+    state => state.total,
+    Object.is,
+    { storeLabel: 'home-approval-badge' },
+  );
 }
 
 export function triggerApprovalAlertCounts(cacheTime: number) {

--- a/apps/mobile/src/screens/Home/hooks/history.ts
+++ b/apps/mobile/src/screens/Home/hooks/history.ts
@@ -18,6 +18,8 @@ import {
   balanceAccountsStore,
   getSelectedBalanceAddressesSnapshot,
 } from '@/store/balance';
+import { useActivityStore } from '@/hooks/storeActivity/useActivityStore';
+import { useShallow } from 'zustand/react/shallow';
 
 type HomeHistoryState = {
   pendingTxCount: number;
@@ -36,18 +38,33 @@ const homeHistoryStore = zCreate<HomeHistoryState>(() => ({
 }));
 
 export function useHomeHistoryStore() {
-  return {
-    pendingTxCount: homeHistoryStore(s => s.pendingTxCount),
-    historyCount: homeHistoryStore(s => s.historyCount),
-  };
+  return useActivityStore(
+    homeHistoryStore,
+    useShallow(state => ({
+      pendingTxCount: state.pendingTxCount,
+      historyCount: state.historyCount,
+    })),
+    Object.is,
+    { storeLabel: 'home-history-badges' },
+  );
 }
 
 export function useHomePendingTxCount() {
-  return homeHistoryStore(s => s.pendingTxCount);
+  return useActivityStore(
+    homeHistoryStore,
+    state => state.pendingTxCount,
+    Object.is,
+    { storeLabel: 'home-history-badges' },
+  );
 }
 
 export function useHomeHistoryCount() {
-  return homeHistoryStore(s => s.historyCount);
+  return useActivityStore(
+    homeHistoryStore,
+    state => state.historyCount,
+    Object.is,
+    { storeLabel: 'home-history-badges' },
+  );
 }
 
 function setHistoryCount(

--- a/apps/mobile/src/screens/Home/hooks/useHomePortfolioSummary.ts
+++ b/apps/mobile/src/screens/Home/hooks/useHomePortfolioSummary.ts
@@ -11,6 +11,7 @@ import {
 import { makeDefaultSelectData } from '@/store/curveShared';
 import { sceneCurve24hStore } from '@/store/curve24h';
 import { useShallow } from 'zustand/react/shallow';
+import { useActivityStore } from '@/hooks/storeActivity/useActivityStore';
 import { markStartupPerf } from '@/core/utils/startupPerfMarks';
 
 type HomeChangeData = Pick<
@@ -380,7 +381,9 @@ export function useHomePortfolioStore<T>(
 ) {
   ensureHomePortfolioLifecycle();
 
-  return homePortfolioStore(selector);
+  return useActivityStore(homePortfolioStore, selector, Object.is, {
+    storeLabel: 'home-portfolio-summary',
+  });
 }
 
 export function useHomePortfolioSummary() {

--- a/apps/mobile/src/screens/Lending/hooks.ts
+++ b/apps/mobile/src/screens/Lending/hooks.ts
@@ -55,6 +55,7 @@ import { isValidAddress } from '@ethereumjs/util';
 import { nativeToWrapper } from './config/nativeToWrapper';
 import { useChainList } from '@/hooks/useChainList';
 import { ensureMainnetChainAvailable } from '@/core/serviceApi/syncChain';
+import { useActivityStore } from '@/hooks/storeActivity/useActivityStore';
 
 const marketAtom = atomByMMKV(
   APP_MMKV_WEAK_KEYS.LENDING_MARKET,
@@ -1284,7 +1285,8 @@ export function useHasUserSummary() {
 }
 export function useLendingHF() {
   const { lendingDataKey } = useCurrentLendingDataKey();
-  const lendingHf = computedInfoState(
+  const lendingHf = useActivityStore(
+    computedInfoState,
     useShallow(s => {
       const state: IndexedComputedInfo = getComputedInfoByKey(lendingDataKey);
       if (!state.iUserSummary) {
@@ -1295,6 +1297,8 @@ export function useLendingHF() {
         netWorthUSD: state.iUserSummary?.netWorthUSD || '0',
       };
     }),
+    Object.is,
+    { storeLabel: 'home-lending-health-factor' },
   );
 
   return {

--- a/apps/mobile/src/screens/Perps/components/PerpsMultiAssetPosition/index.tsx
+++ b/apps/mobile/src/screens/Perps/components/PerpsMultiAssetPosition/index.tsx
@@ -33,6 +33,7 @@ import { formatPerpsCoin, getFallbackCoinLogoUrl } from '@/utils/perps';
 import { SvgUri } from 'react-native-svg';
 import { matomoRequestEvent } from '@/utils/analytics';
 import { Text } from '@/components/Typography';
+import { useActivityStore } from '@/hooks/storeActivity/useActivityStore';
 
 const calculateMarkPrice = (position: AssetPosition['position']) => {
   const entryPxDecimals = position.entryPx?.split('.')[1]?.length || 2;
@@ -351,11 +352,14 @@ const AssetPositionItem = ({
 
 export const PerpsMultiAssetPosition: React.FC = () => {
   const getAccountByAddress = useFindAccountByAddress();
-  const { clearinghouseStateMap, marketDataMap } = perpsStore(
+  const { clearinghouseStateMap, marketDataMap } = useActivityStore(
+    perpsStore,
     useShallow(s => ({
       clearinghouseStateMap: s.clearinghouseStateMap,
       marketDataMap: s.marketDataMap,
     })),
+    Object.is,
+    { storeLabel: 'home-overview-perps-positions' },
   );
   const [selectedPositionKey, setSelectedPositionKey] = useState<{
     address: string;


### PR DESCRIPTION
## Summary

- extend the Home tab activity boundary to the overview page
- pause hidden React store notifications for positions, Perps PnL, balances, browser state, and Home badges
- keep background data updates running and catch up from the latest snapshot when the overview becomes active again
- extend non-production diagnostics to verify subscription ownership across all four Home tabs

## Validation

- NODE_ENV=test yarn typecheck
- StoreActivity unit and hook tests: 4 suites / 13 tests
- targeted ESLint
- NODE_ENV=test yarn workspace rabby-mobile lint:cycles
- lifecycle E2E passed on both high-spec and low-spec Huawei devices across Overview, Token, DeFi, NFT, and return-to-Overview

Depends on #2024.