### PR TITLE
fix: release Home startup tasks after first wallet creation

### DIFF
--- a/apps/mobile/src/core/utils/homeStartupMilestones.test.ts
+++ b/apps/mobile/src/core/utils/homeStartupMilestones.test.ts
@@ -15,6 +15,7 @@ import {
   getHomeEntryReady,
   markHomeContentReady,
   markHomeEntryReady,
+  markHomeEntryReadyIfEligible,
   resetHomeStartupMilestonesForTests,
   runAfterHomeContentReady,
   runAfterHomeEntryReady,
@@ -63,6 +64,75 @@ describe('home startup milestones', () => {
     markHomeContentReady('portfolio_content_settled');
     expect(callback).toHaveBeenCalledTimes(1);
     expect(getHomeContentReady()).toBe(true);
+  });
+
+  it('releases Home entry tasks when the first account appears without a restart', () => {
+    const persistedPositionTask = jest.fn();
+    const homePositionTask = jest.fn();
+
+    runAfterHomeEntryReady(persistedPositionTask);
+    runAfterHomeEntryReady(homePositionTask);
+
+    expect(
+      markHomeEntryReadyIfEligible(
+        {
+          appUnlocked: true,
+          isUnlockSessionValid: true,
+          hasVisibleAccounts: false,
+        },
+        'initial_bootstrap_without_accounts',
+      ),
+    ).toBe(false);
+    expect(persistedPositionTask).not.toHaveBeenCalled();
+    expect(homePositionTask).not.toHaveBeenCalled();
+
+    expect(
+      markHomeEntryReadyIfEligible(
+        {
+          appUnlocked: true,
+          isUnlockSessionValid: true,
+          hasVisibleAccounts: true,
+        },
+        'account_added_in_current_process',
+      ),
+    ).toBe(true);
+    expect(persistedPositionTask).toHaveBeenCalledTimes(1);
+    expect(homePositionTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps Home entry locked until account and authentication are both ready', () => {
+    expect(
+      markHomeEntryReadyIfEligible(
+        {
+          appUnlocked: false,
+          isUnlockSessionValid: false,
+          hasVisibleAccounts: true,
+        },
+        'account_added_while_locked',
+      ),
+    ).toBe(false);
+
+    expect(
+      markHomeEntryReadyIfEligible(
+        {
+          appUnlocked: false,
+          isUnlockSessionValid: true,
+          hasVisibleAccounts: true,
+        },
+        'unlock_session_ready_after_account_added',
+      ),
+    ).toBe(true);
+  });
+
+  it('preserves the phase hierarchy when content settles first', () => {
+    markHomeContentReady('portfolio_content_settled');
+
+    expect(getHomeEntryReady()).toBe(true);
+    expect(getHomeContentReady()).toBe(true);
+    expect(mockMarkStartupRuntimePhase.mock.calls).toEqual([
+      ['home', 'entry-ready', 'home_content_ready_implies_entry'],
+      ['home', 'content-ready', 'portfolio_content_settled'],
+    ]);
   });
 
   it('runs a content task registered after the milestone immediately', () => {

--- a/apps/mobile/src/core/utils/homeStartupMilestones.ts
+++ b/apps/mobile/src/core/utils/homeStartupMilestones.ts
@@ -15,6 +15,12 @@ type RunAfterHomeMilestoneOptions = {
   label?: string;
 };
 
+type HomeEntryReadinessState = {
+  appUnlocked: boolean;
+  isUnlockSessionValid: boolean;
+  hasVisibleAccounts: boolean;
+};
+
 const milestones: Record<HomeStartupMilestone, HomeStartupMilestoneState> = {
   entryReady: {
     reached: false,
@@ -116,7 +122,25 @@ export function markHomeEntryReady(reason: string) {
   return markHomeMilestone('entryReady', reason);
 }
 
+export function markHomeEntryReadyIfEligible(
+  state: HomeEntryReadinessState,
+  reason: string,
+) {
+  if (
+    milestones.entryReady.reached ||
+    !state.hasVisibleAccounts ||
+    (!state.appUnlocked && !state.isUnlockSessionValid)
+  ) {
+    return false;
+  }
+
+  return markHomeEntryReady(reason);
+}
+
 export function markHomeContentReady(reason: string) {
+  if (!milestones.entryReady.reached) {
+    markHomeEntryReady('home_content_ready_implies_entry');
+  }
   return markHomeMilestone('contentReady', reason);
 }
 

--- a/apps/mobile/src/devtools/regressionScenarios/runtime.nonprod.ts
+++ b/apps/mobile/src/devtools/regressionScenarios/runtime.nonprod.ts
@@ -1,5 +1,4 @@
 import { isNonPublicProductionEnv } from '@/constant';
-import { shouldSuppressPerfCaptureConsoleNoise } from '@/core/utils/perfCaptureConsole';
 import { storeApiExpSettingData } from '@/hooks/appSettings';
 
 import {
@@ -54,10 +53,6 @@ function logScenarioResult(
   message: string,
   data?: Record<string, unknown>,
 ) {
-  if (level === 'info' && shouldSuppressPerfCaptureConsoleNoise()) {
-    return;
-  }
-
   const logger = console[level] || console.log;
   logger(
     '[RabbyRegressionScenario]',

--- a/apps/mobile/src/devtools/regressionScenarios/scenarios/wallet.ts
+++ b/apps/mobile/src/devtools/regressionScenarios/scenarios/wallet.ts
@@ -40,6 +40,10 @@ const MAX_REGRESSION_AUTO_LOCK_MINUTES = 24 * 60;
 const MILLISECONDS_PER_MINUTE = 60 * 1000;
 const MIN_BACKUP_WORD_COUNT = 12;
 const ACCOUNT_VISIBILITY_TIMEOUT_MS = 8_000;
+const HOME_SURFACE_ROUTES = new Set<string>([
+  RootNames.Home,
+  RootNames.SingleAddressHome,
+]);
 
 function isMnemonicAccount(
   account: Awaited<ReturnType<typeof getScenarioAccounts>>[number],
@@ -126,6 +130,20 @@ async function waitForCreatedAccountVisible(address: string) {
     ),
     elapsedMs: Date.now() - startedAt,
   };
+}
+
+async function waitForHomeSurface(timeoutMs = 15_000) {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const routeName = navigationRef.getCurrentRoute()?.name;
+    if (routeName && HOME_SURFACE_ROUTES.has(routeName)) {
+      return routeName;
+    }
+    await delay(50);
+  }
+
+  throw new Error('Timed out waiting for Home or SingleAddressHome');
 }
 
 async function assertHomeEntryReadyWithoutRestart(
@@ -268,7 +286,7 @@ async function runWalletCreate(context: RegressionScenarioExecutionContext) {
   }
 
   resetToHome();
-  await context.waitForRoute(RootNames.Home);
+  await waitForHomeSurface();
   const visibility = await waitForCreatedAccountVisible(prepared.address);
   context.report('assertion', {
     assertion: 'mnemonic-wallet-created',
@@ -622,7 +640,7 @@ export async function executeRegressionScenario(
     }
     await context.waitForNavigation();
     resetToHome();
-    await context.waitForRoute(RootNames.Home);
+    await waitForHomeSurface();
     const accounts = await getScenarioAccounts({ force: true });
     context.report('assertion', {
       assertion: 'home-has-visible-accounts',

--- a/apps/mobile/src/devtools/regressionScenarios/scenarios/wallet.ts
+++ b/apps/mobile/src/devtools/regressionScenarios/scenarios/wallet.ts
@@ -128,6 +128,26 @@ async function waitForCreatedAccountVisible(address: string) {
   };
 }
 
+async function assertHomeEntryReadyWithoutRestart(
+  context: RegressionScenarioExecutionContext,
+  source: 'wallet-create' | 'wallet-onboarding',
+) {
+  const { getHomeEntryReady } = await import(
+    '@/core/utils/homeStartupMilestones'
+  );
+  const passed = getHomeEntryReady();
+  context.report('assertion', {
+    assertion: 'fresh-wallet-home-entry-ready-without-restart',
+    passed,
+    source,
+  });
+  if (!passed) {
+    throw new Error(
+      `Fresh wallet ${source} did not release Home entry tasks before restart`,
+    );
+  }
+}
+
 async function prepareWalletFixture(
   context: RegressionScenarioExecutionContext,
 ) {
@@ -265,6 +285,9 @@ async function runWalletCreate(context: RegressionScenarioExecutionContext) {
 
   if (!visibility.runtimeVisible || !visibility.accountStoreVisible) {
     throw new Error('Created mnemonic wallet is not visible');
+  }
+  if (beforeAccounts.length === 0) {
+    await assertHomeEntryReadyWithoutRestart(context, 'wallet-create');
   }
 }
 
@@ -606,6 +629,7 @@ export async function executeRegressionScenario(
       passed: accounts.length > 0,
       visibleAccountCount: accounts.length,
     });
+    await assertHomeEntryReadyWithoutRestart(context, 'wallet-onboarding');
     return;
   }
 

--- a/apps/mobile/src/hooks/useBootstrap.ts
+++ b/apps/mobile/src/hooks/useBootstrap.ts
@@ -6,6 +6,7 @@ import { customTestnetServiceApi } from '@/core/serviceApi/customTestnet';
 import { initApis } from '@/core/apis/init';
 import { sendUserAddressEvent } from '@/core/apis/analytics';
 import { apisLock, apisPerps } from '@/core/apis';
+import { accountEvents } from '@/core/apis/account';
 import { loadSecurityChain } from './global';
 import {
   getBootstrapAccountFlags,
@@ -35,7 +36,7 @@ import {
   nextAndroidTraceCookie,
   traceAndroidInstant,
 } from '@/core/utils/androidTrace';
-import { markHomeEntryReady } from '@/core/utils/homeStartupMilestones';
+import { markHomeEntryReadyIfEligible } from '@/core/utils/homeStartupMilestones';
 
 const syncCustomTestChainList = () => {
   customTestnetServiceApi.syncChainList().catch(e => {
@@ -105,9 +106,10 @@ export function useInitializeAppOnTop() {
         appUnlocked: true,
         isUnlockSessionValid: apisLock.isUnlockSessionValid(),
       }));
-      if (getAppLockStateSnapshot().hasVisibleAccounts) {
-        markHomeEntryReady('wallet_auth_unlocked');
-      }
+      markHomeEntryReadyIfEligible(
+        getAppLockStateSnapshot(),
+        'wallet_auth_unlocked',
+      );
       traceAndroidInstant('global_task.wallet_auth_unlocked.end', {
         source: 'useBootstrap',
       });
@@ -174,11 +176,33 @@ export function useInitializeAppOnTop() {
       'lock',
       onLock,
     );
+    const accountAddedSubscription = accountEvents.subscribe(
+      'ACCOUNT_ADDED',
+      ({ accounts }) => {
+        if (accounts.length === 0) {
+          return;
+        }
+        storeApiLock.setAppLock(prev =>
+          prev.hasVisibleAccounts && prev.hasStoredKeyrings
+            ? prev
+            : {
+                ...prev,
+                hasVisibleAccounts: true,
+                hasStoredKeyrings: true,
+              },
+        );
+        markHomeEntryReadyIfEligible(
+          getAppLockStateSnapshot(),
+          'account_added_in_current_process',
+        );
+      },
+    );
 
     return () => {
       sub.remove();
       subUIReady.remove();
       removeLockListener();
+      accountAddedSubscription.remove();
     };
   }, []);
 
@@ -326,17 +350,12 @@ export function useBootstrapApp({ rabbitCode }: { rabbitCode: string }) {
           unlockStatus: unlockResult?.status ?? 'deferred',
           shouldWaitAutoUnlock,
         });
-        const appLockState = getAppLockStateSnapshot();
-        if (
-          appLockState.hasVisibleAccounts &&
-          (appLockState.appUnlocked || appLockState.isUnlockSessionValid)
-        ) {
-          markHomeEntryReady(
-            shouldWaitAutoUnlock
-              ? 'bootstrap_auto_unlock_ready'
-              : 'bootstrap_session_ready',
-          );
-        }
+        markHomeEntryReadyIfEligible(
+          getAppLockStateSnapshot(),
+          shouldWaitAutoUnlock
+            ? 'bootstrap_auto_unlock_ready'
+            : 'bootstrap_session_ready',
+        );
         setBootstrap({ couldRender: true });
 
         if (shouldWaitAutoUnlock) {


### PR DESCRIPTION
## Summary
- treat Home entry readiness as an account/authentication state join
- release Home-gated tasks when the first wallet is created or imported in the current process
- preserve existing bootstrap/unlock timing and enforce Home milestone ordering
- add deterministic milestone coverage and fresh-wallet regression assertions

## Validation
- `yarn workspace rabby-mobile test homeStartupMilestones.test.ts --runInBand`
- `yarn workspace rabby-mobile typecheck`
- `yarn workspace rabby-mobile lint:cycles`
- `node apps/mobile/scripts/check-startup-governance.cjs`
- `DISABLE_APP_TYPE_CHECK=true yarn lint-staged`