### PR TITLE
fix(home): keep center banner stable during refresh

### DIFF
--- a/apps/mobile/src/screens/Home/components/HomeCenterArea.tsx
+++ b/apps/mobile/src/screens/Home/components/HomeCenterArea.tsx
@@ -24,6 +24,10 @@ import { ConvertDustBanner } from './ConvertDustBanner';
 import { useConvertDustBanner } from '../hooks/useConvertDustBanner';
 import { useRabbyAppNavigation } from '@/hooks/navigation';
 import { RootNames } from '@/constant/layout';
+import {
+  resolveHomeCenterAreaVisibility,
+  type HomeCenterAreaVisibility,
+} from './homeCenterAreaVisibility';
 
 export function HomeCenterArea() {
   const { styles } = useTheme2024({
@@ -42,6 +46,9 @@ export function HomeCenterArea() {
     useConvertDustBanner();
 
   const prevAccountToShowReceiveTipRef = useRef(accountToShowReceiveTip);
+  const previousResolvedVisibilityRef = useRef<HomeCenterAreaVisibility | null>(
+    null,
+  );
   if (!isLoadingAccountToShowReceiveTip) {
     prevAccountToShowReceiveTipRef.current = accountToShowReceiveTip;
   }
@@ -67,54 +74,24 @@ export function HomeCenterArea() {
       offlineChainData.displayWillClosedChain &&
       offlineChainData.offlineChainInfo
     );
-
     const hasCompletedTransaction = txCount > 0;
+    const visibility = resolveHomeCenterAreaVisibility({
+      previousResolvedVisibility: previousResolvedVisibilityRef.current,
+      isLoadingAccountToShowReceiveTip,
+      hasAccountToShowReceiveTip: !!accountToShowReceiveTip,
+      forceShowDepositAssetsCard: !!forceShowDepositAssetsCard,
+      shouldShowConvertDustBanner,
+      hasCompletedTransaction,
+      hasOfflineChainData,
+      viewedScreenShotReportTip,
+      shouldShowRateGuideOnHome,
+    });
 
-    const blocks = {
-      soloAccountToShowReceiveTip: false as boolean,
-      rateGuideOnHome: false as boolean,
-      offlineChainData: false as boolean,
-      tipScreenshot: false as boolean,
-      convertDustBanner: false as boolean,
-    };
-
-    // Preserve previous account tip during refresh to prevent flickering
-    if (isLoadingAccountToShowReceiveTip) {
-      const hasPreviousTip = !!prevAccountToShowReceiveTipRef.current;
-      return {
-        blocksVisibility: {
-          ...blocks,
-          soloAccountToShowReceiveTip: hasPreviousTip,
-        },
-        noBetweenContent: !hasPreviousTip,
-        onlyOneContent: hasPreviousTip,
-      };
+    if (!isLoadingAccountToShowReceiveTip) {
+      previousResolvedVisibilityRef.current = visibility;
     }
 
-    if (accountToShowReceiveTip || forceShowDepositAssetsCard) {
-      blocks.soloAccountToShowReceiveTip = true;
-    } else {
-      if (shouldShowConvertDustBanner) {
-        blocks.convertDustBanner = true;
-      } else {
-        if (hasCompletedTransaction && hasOfflineChainData) {
-          blocks.offlineChainData = true;
-        }
-        if (hasCompletedTransaction && !viewedScreenShotReportTip) {
-          blocks.tipScreenshot = true;
-        } else if (shouldShowRateGuideOnHome) {
-          blocks.rateGuideOnHome = true;
-        }
-      }
-    }
-
-    const visibleEls = Object.values(blocks);
-    const hasBetweenContent = visibleEls.some(Boolean);
-    return {
-      blocksVisibility: blocks,
-      noBetweenContent: !hasBetweenContent,
-      onlyOneContent: visibleEls.filter(Boolean).length === 1,
-    };
+    return visibility;
   }, [
     shouldShowRateGuideOnHome,
     shouldShowConvertDustBanner,

--- a/apps/mobile/src/screens/Home/components/homeCenterAreaVisibility.test.ts
+++ b/apps/mobile/src/screens/Home/components/homeCenterAreaVisibility.test.ts
@@ -1,0 +1,96 @@
+import {
+  resolveHomeCenterAreaVisibility,
+  type HomeCenterAreaVisibility,
+} from './homeCenterAreaVisibility';
+
+const defaultParams = {
+  previousResolvedVisibility: null,
+  isLoadingAccountToShowReceiveTip: false,
+  hasAccountToShowReceiveTip: false,
+  forceShowDepositAssetsCard: false,
+  shouldShowConvertDustBanner: false,
+  hasCompletedTransaction: false,
+  hasOfflineChainData: false,
+  viewedScreenShotReportTip: true,
+  shouldShowRateGuideOnHome: false,
+};
+
+describe('resolveHomeCenterAreaVisibility', () => {
+  it('keeps the center area empty before the first account-tip check resolves', () => {
+    const result = resolveHomeCenterAreaVisibility({
+      ...defaultParams,
+      isLoadingAccountToShowReceiveTip: true,
+    });
+
+    expect(result).toEqual({
+      blocksVisibility: {
+        soloAccountToShowReceiveTip: false,
+        rateGuideOnHome: false,
+        offlineChainData: false,
+        tipScreenshot: false,
+        convertDustBanner: false,
+      },
+      noBetweenContent: true,
+      onlyOneContent: false,
+    });
+  });
+
+  it('preserves the Convert Dust banner throughout a refresh', () => {
+    const resolved = resolveHomeCenterAreaVisibility({
+      ...defaultParams,
+      shouldShowConvertDustBanner: true,
+    });
+
+    const refreshing = resolveHomeCenterAreaVisibility({
+      ...defaultParams,
+      previousResolvedVisibility: resolved,
+      isLoadingAccountToShowReceiveTip: true,
+    });
+
+    expect(refreshing).toBe(resolved);
+    expect(refreshing.blocksVisibility.convertDustBanner).toBe(true);
+  });
+
+  it('preserves the resolved account tip and its layout throughout a refresh', () => {
+    const resolved = resolveHomeCenterAreaVisibility({
+      ...defaultParams,
+      hasAccountToShowReceiveTip: true,
+    });
+
+    const refreshing = resolveHomeCenterAreaVisibility({
+      ...defaultParams,
+      previousResolvedVisibility: resolved,
+      isLoadingAccountToShowReceiveTip: true,
+    });
+
+    expect(refreshing).toBe(resolved);
+    expect(refreshing.blocksVisibility.soloAccountToShowReceiveTip).toBe(true);
+    expect(refreshing.onlyOneContent).toBe(true);
+  });
+
+  it('recomputes the final state after refresh completes', () => {
+    const previousResolvedVisibility: HomeCenterAreaVisibility =
+      resolveHomeCenterAreaVisibility({
+        ...defaultParams,
+        shouldShowConvertDustBanner: true,
+      });
+
+    const result = resolveHomeCenterAreaVisibility({
+      ...defaultParams,
+      previousResolvedVisibility,
+      hasCompletedTransaction: true,
+      hasOfflineChainData: true,
+      viewedScreenShotReportTip: false,
+    });
+
+    expect(result.blocksVisibility).toEqual({
+      soloAccountToShowReceiveTip: false,
+      rateGuideOnHome: false,
+      offlineChainData: true,
+      tipScreenshot: true,
+      convertDustBanner: false,
+    });
+    expect(result.noBetweenContent).toBe(false);
+    expect(result.onlyOneContent).toBe(false);
+  });
+});

--- a/apps/mobile/src/screens/Home/components/homeCenterAreaVisibility.ts
+++ b/apps/mobile/src/screens/Home/components/homeCenterAreaVisibility.ts
@@ -1,0 +1,79 @@
+export type HomeCenterAreaBlocksVisibility = {
+  soloAccountToShowReceiveTip: boolean;
+  rateGuideOnHome: boolean;
+  offlineChainData: boolean;
+  tipScreenshot: boolean;
+  convertDustBanner: boolean;
+};
+
+export type HomeCenterAreaVisibility = {
+  blocksVisibility: HomeCenterAreaBlocksVisibility;
+  noBetweenContent: boolean;
+  onlyOneContent: boolean;
+};
+
+type ResolveHomeCenterAreaVisibilityParams = {
+  previousResolvedVisibility: HomeCenterAreaVisibility | null;
+  isLoadingAccountToShowReceiveTip: boolean;
+  hasAccountToShowReceiveTip: boolean;
+  forceShowDepositAssetsCard: boolean;
+  shouldShowConvertDustBanner: boolean;
+  hasCompletedTransaction: boolean;
+  hasOfflineChainData: boolean;
+  viewedScreenShotReportTip: boolean;
+  shouldShowRateGuideOnHome: boolean;
+};
+
+function createEmptyVisibility(): HomeCenterAreaVisibility {
+  return {
+    blocksVisibility: {
+      soloAccountToShowReceiveTip: false,
+      rateGuideOnHome: false,
+      offlineChainData: false,
+      tipScreenshot: false,
+      convertDustBanner: false,
+    },
+    noBetweenContent: true,
+    onlyOneContent: false,
+  };
+}
+
+export function resolveHomeCenterAreaVisibility({
+  previousResolvedVisibility,
+  isLoadingAccountToShowReceiveTip,
+  hasAccountToShowReceiveTip,
+  forceShowDepositAssetsCard,
+  shouldShowConvertDustBanner,
+  hasCompletedTransaction,
+  hasOfflineChainData,
+  viewedScreenShotReportTip,
+  shouldShowRateGuideOnHome,
+}: ResolveHomeCenterAreaVisibilityParams): HomeCenterAreaVisibility {
+  if (isLoadingAccountToShowReceiveTip) {
+    return previousResolvedVisibility ?? createEmptyVisibility();
+  }
+
+  const blocks = createEmptyVisibility().blocksVisibility;
+
+  if (hasAccountToShowReceiveTip || forceShowDepositAssetsCard) {
+    blocks.soloAccountToShowReceiveTip = true;
+  } else if (shouldShowConvertDustBanner) {
+    blocks.convertDustBanner = true;
+  } else {
+    if (hasCompletedTransaction && hasOfflineChainData) {
+      blocks.offlineChainData = true;
+    }
+    if (hasCompletedTransaction && !viewedScreenShotReportTip) {
+      blocks.tipScreenshot = true;
+    } else if (shouldShowRateGuideOnHome) {
+      blocks.rateGuideOnHome = true;
+    }
+  }
+
+  const visibleBlocks = Object.values(blocks);
+  return {
+    blocksVisibility: blocks,
+    noBetweenContent: !visibleBlocks.some(Boolean),
+    onlyOneContent: visibleBlocks.filter(Boolean).length === 1,
+  };
+}


### PR DESCRIPTION
## Summary
- preserve the last resolved Home center-area visibility while the receive-tip check refreshes
- keep the initial unresolved state unchanged
- recompute the final banner/card selection after refresh completes

## Issue
- Fixes QA issue 887: Android Convert Dust banner disappears and re-enters during Home refresh

## Verification
- targeted Jest: 4/4 passed
- apps/mobile typecheck passed
- targeted ESLint and diff checks passed

Runtime impact: runtime fix, review required