### PR TITLE
build(android): target API 36

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -17,13 +17,15 @@
     android:roundIcon="@mipmap/ic_launcher_round"
     android:allowBackup="false"
     android:supportsRtl="false"
-    tools:replace="android:allowBackup,android:supportsRtl"
+    tools:replace="android:allowBackup,android:supportsRtl,android:enableOnBackInvokedCallback"
+    android:enableOnBackInvokedCallback="false"
     android:pageSizeCompat="enabled"
     android:theme="@style/AppTheme"
     android:networkSecurityConfig="@xml/network_security_config">
-    <!-- if set targetSdkVersion >= 36 (android 16) on build.gradle, you can uncomment lines below, disable predictive animation to avoid gesture issue before react-navigation support it -->
-    <!-- tools:replace="android:enableOnBackInvokedCallback"
-    android:enableOnBackInvokedCallback="false"> -->
+    <!-- Preserve the current portrait layout on large screens during the API 36 migration. -->
+    <property
+      android:name="android.window.PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY"
+      android:value="true" />
 
     <!-- android:windowSoftInputMode="adjustPan":https://github.com/APSL/react-native-keyboard-aware-scroll-view?tab=readme-ov-file#android-support -->
     <activity

--- a/apps/mobile/android/build.gradle
+++ b/apps/mobile/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 26
         compileSdkVersion = 36
-        targetSdkVersion = 35
+        targetSdkVersion = 36
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         // ndkVersion = "28.2.13676358" // 28 will enable 16kb support by default, but now we use 27 temporarily


### PR DESCRIPTION
## Summary

- target Android 16 / API level 36 for Google Play updates after August 31, 2026
- preserve existing back-navigation behavior by opting out of predictive back during the migration
- temporarily preserve the current portrait layout restrictions on large screens

## Verification

- local regression APK build succeeded
- APK manifest reports `compileSdkVersion=36` and `targetSdkVersion=36`
- 16 KB page-size validation passed
- installed and launched successfully on both connected Huawei Android 12 devices
- filtered AndroidRuntime and ReactNativeJS startup errors were empty