### PR TITLE
fix(navigation): clear wallet sheet before reset

### DIFF
--- a/apps/mobile/src/utils/navigation.test.ts
+++ b/apps/mobile/src/utils/navigation.test.ts
@@ -1,0 +1,88 @@
+describe('redirectToAddAddressEntry', () => {
+  const mockPerfEmit = jest.fn();
+  const mockResetRoot = jest.fn();
+  const mockNavigateDeprecated = jest.fn();
+  const mockDispatch = jest.fn();
+
+  let redirectToAddAddressEntry: typeof import('./navigation')['redirectToAddAddressEntry'];
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    jest.doMock('@/constant/layout', () => ({
+      RootNames: {
+        GetStarted: 'GetStarted',
+        Home: 'Home',
+        ImportNewAddress: 'ImportNewAddress',
+        StackAddress: 'StackAddress',
+        StackGetStarted: 'StackGetStarted',
+        StackRoot: 'StackRoot',
+      },
+    }));
+    jest.doMock('@/core/utils/perf', () => ({
+      perfEvents: {
+        emit: (...args: unknown[]) => mockPerfEmit(...args),
+      },
+    }));
+    jest.doMock('@react-navigation/native', () => ({
+      CommonActions: {
+        reset: jest.fn(),
+      },
+      StackActions: {
+        push: jest.fn(),
+        replace: jest.fn(),
+      },
+      createNavigationContainerRef: jest.fn(() => ({
+        current: {},
+        dispatch: (...args: unknown[]) => mockDispatch(...args),
+        isReady: jest.fn(() => true),
+        navigate: jest.fn(),
+        navigateDeprecated: (...args: unknown[]) =>
+          mockNavigateDeprecated(...args),
+        resetRoot: (...args: unknown[]) => mockResetRoot(...args),
+      })),
+    }));
+
+    ({ redirectToAddAddressEntry } = require('./navigation'));
+  });
+
+  it.each([
+    ['resetTo', 'StackGetStarted', 'GetStarted'],
+    ['classical:resetTo', 'Root', 'ImportNewAddress'],
+  ] as const)(
+    'clears covered components before handling %s',
+    (action, rootName, screenName) => {
+      redirectToAddAddressEntry({ action });
+
+      expect(mockPerfEmit).toHaveBeenCalledWith(
+        'GLOBAL_CLEAR_ALL_COVERED_COMPONENTS',
+      );
+      expect(mockResetRoot).toHaveBeenCalledWith({
+        index: 0,
+        routes: [
+          {
+            name: rootName,
+            state: {
+              index: 0,
+              routes: [{ name: screenName }],
+            },
+          },
+        ],
+      });
+      expect(mockPerfEmit.mock.invocationCallOrder[0]).toBeLessThan(
+        mockResetRoot.mock.invocationCallOrder[0],
+      );
+    },
+  );
+
+  it.each(['push', 'replace', 'classical:push', 'classical:replace'] as const)(
+    'does not clear covered components for %s',
+    action => {
+      redirectToAddAddressEntry({ action });
+
+      expect(mockPerfEmit).not.toHaveBeenCalled();
+      expect(mockResetRoot).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/apps/mobile/src/utils/navigation.ts
+++ b/apps/mobile/src/utils/navigation.ts
@@ -1,4 +1,5 @@
 import { RootNames } from '@/constant/layout';
+import { perfEvents } from '@/core/utils/perf';
 import { RootStackParamsList } from '@/navigation-type';
 import {
   CommonActions,
@@ -9,6 +10,13 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 
 export const navigationRef =
   createNavigationContainerRef<RootStackParamsList>();
+
+const resetRootAndClearCoveredComponents = (
+  state: Parameters<typeof navigationRef.resetRoot>[0],
+) => {
+  perfEvents.emit('GLOBAL_CLEAR_ALL_COVERED_COMPONENTS');
+  navigationRef.resetRoot(state);
+};
 
 export function getReadyNavigationInstance() {
   return navigationRef.isReady() ? navigationRef.current : null;
@@ -132,7 +140,7 @@ export function redirectToAddAddressEntry(options?: {
       break;
     }
     case 'classical:resetTo': {
-      navigationRef.resetRoot({
+      resetRootAndClearCoveredComponents({
         index: 0,
         routes: [
           {
@@ -152,7 +160,7 @@ export function redirectToAddAddressEntry(options?: {
       });
       break;
     case 'resetTo':
-      navigationRef.resetRoot({
+      resetRootAndClearCoveredComponents({
         index: 0,
         routes: [
           {


### PR DESCRIPTION
## Summary
- clear global covered components before wallet reset navigation
- keep push and replace navigation semantics unchanged
- add deterministic reset-order coverage for issue 388

## Validation
- focused Jest: 6 passed
- TypeScript typecheck
- circular dependency check
- Android regression build and 16KB check
- verified on Huawei: deleting the final test address reaches Get Started without a residual wallet sheet