### PR TITLE
perf: optimize multi-address home asset rendering

### DIFF
--- a/apps/mobile/src/components/Token/hooks/useTokenListAsyncResource.ts
+++ b/apps/mobile/src/components/Token/hooks/useTokenListAsyncResource.ts
@@ -1,4 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
+import { LatestAsyncRequest } from '@/core/utils/latestAsyncRequest';
+
+export { LatestAsyncRequest } from '@/core/utils/latestAsyncRequest';
 
 export type TokenListResourceStatus =
   | 'idle'
@@ -21,23 +24,6 @@ type UseTokenListAsyncResourceOptions<T> = {
 };
 
 const EMPTY_TOKEN_LIST: never[] = [];
-
-export class LatestAsyncRequest {
-  private sequence = 0;
-
-  next() {
-    this.sequence += 1;
-    return this.sequence;
-  }
-
-  invalidate() {
-    this.sequence += 1;
-  }
-
-  isCurrent(requestId: number) {
-    return requestId === this.sequence;
-  }
-}
 
 export const makeTokenListRequestKey = (
   parts: ReadonlyArray<string | null | undefined>,

--- a/apps/mobile/src/core/utils/assetDataLoadDiagnostics.ts
+++ b/apps/mobile/src/core/utils/assetDataLoadDiagnostics.ts
@@ -3,7 +3,10 @@ import { isNonProductionDiagnosticsEnabled } from './diagnosticEnv';
 export type AssetDataLoadDiagnosticDomain =
   | 'single-address-token'
   | 'single-address-nft'
-  | 'single-address-warmup';
+  | 'single-address-warmup'
+  | 'multi-address-token'
+  | 'multi-address-protocol'
+  | 'multi-address-nft';
 
 type AssetDataLoadDiagnosticValue = string | number | boolean | null;
 

--- a/apps/mobile/src/core/utils/latestAsyncRequest.ts
+++ b/apps/mobile/src/core/utils/latestAsyncRequest.ts
@@ -1,0 +1,16 @@
+export class LatestAsyncRequest {
+  private sequence = 0;
+
+  next() {
+    this.sequence += 1;
+    return this.sequence;
+  }
+
+  invalidate() {
+    this.sequence += 1;
+  }
+
+  isCurrent(requestId: number) {
+    return requestId === this.sequence;
+  }
+}

--- a/apps/mobile/src/screens/Address/components/MultiAssets/NFTList.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/NFTList.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, type ViewStyle } from 'react-native';
 
 import {
   ASSETS_ITEM_HEIGHT_NEW,
@@ -18,7 +18,7 @@ import {
   NftRow,
   TokenRowSectionHeader,
 } from '@/screens/Home/components/AssetRenderItems';
-import { ActionItem, DisplayNftItem } from '@/screens/Home/types';
+import { DisplayNftItem } from '@/screens/Home/types';
 import { createGetStyles2024 } from '@/utils/styles';
 import { ItemLoader } from '@/screens/Search/components/Skeleton';
 import { EmptyAssets } from '@/screens/Home/components/AssetRenderItems/EmptyAssets';
@@ -32,11 +32,7 @@ import {
   usePulldownRefreshStyles,
 } from '@/components/customized/ScrollViewLike/RefreshPlaceholderIOS';
 import { RNGHRefreshControl } from '@/components/customized/reexports';
-import { getItemId } from '@/screens/Home/utils/listRenderId';
-import {
-  NftItemWithCollection,
-  varyNftListByFold,
-} from '@/screens/Home/hooks/nft';
+import { NftItemWithCollection } from '@/screens/Home/hooks/nft';
 import { useCurrentTabScrollY } from 'react-native-collapsible-tab-view';
 import { useFocusedTab } from 'react-native-collapsible-tab-view';
 import { TabsFlatList } from '@/components/customized/react-native-collapsible-tab-view/FlatList';
@@ -54,7 +50,16 @@ import {
   useIsFocusedCurrentTab,
 } from './hooks/share';
 import { isTabsSwiping, useAccountInfo } from './hooks';
-import nftListStore, { combinedNfts, useOnNftRefresh } from '@/store/nfts';
+import nftListStore, {
+  EMPTY_NFT_ASSETS_INDEX_RESULT,
+  getMultiNftsCacheKey,
+  getNftAssetsIndexRowKey,
+  nftCollectionResourceStore,
+  nftEntityResourceStore,
+  type NftAssetsIndexRow,
+  useNftListComputedStore,
+  useOnNftRefresh,
+} from '@/store/nfts';
 import { useSelectedChainItem } from '@/screens/Home/useChainInfo';
 import {
   HOME_TOP_HEADER_SIZES,
@@ -65,6 +70,7 @@ import { IS_ANDROID } from '@/core/native/utils';
 import { useAppForeground } from '@/hooks/useAppForeground';
 import { useRegressionScenario } from '@/devtools/regressionScenarios/react';
 import { useActivityStore } from '@/hooks/storeActivity/useActivityStore';
+import type { KeyringAccountWithAlias } from '@/hooks/account';
 
 export const MemoizedNFTItemLoader = React.memo((props: RNViewProps) => {
   const { styles } = useTheme2024({ getStyle: getStyles });
@@ -74,6 +80,89 @@ export const MemoizedNFTItemLoader = React.memo((props: RNViewProps) => {
     </View>
   );
 });
+
+type NftListItem =
+  | NftAssetsIndexRow
+  | {
+      type: 'toggle_nft_fold';
+    }
+  | {
+      type: 'empty-nft' | 'loading-skeleton';
+      data: string;
+    };
+
+const NftResourceRow = React.memo(
+  ({
+    row,
+    rowStyle,
+    loaderStyle,
+    getAccountByAddress,
+    onPress,
+  }: {
+    row: NftAssetsIndexRow;
+    rowStyle: ViewStyle;
+    loaderStyle: ViewStyle;
+    getAccountByAddress(address: string): KeyringAccountWithAlias | undefined;
+    onPress: (item: NftItemWithCollection) => void;
+  }) => {
+    const nft = useActivityStore(
+      nftEntityResourceStore.useStore,
+      state => (row.type === 'nft' ? state.valueMap[row.nftId] : undefined),
+      Object.is,
+      { storeLabel: 'home-multi-assets-nft-entities' },
+    );
+    const collection = useActivityStore(
+      nftCollectionResourceStore.useStore,
+      state =>
+        row.type === 'collection'
+          ? state.valueMap[row.collectionId]
+          : undefined,
+      Object.is,
+      { storeLabel: 'home-multi-assets-nft-collections' },
+    );
+    const rawItem = row.type === 'collection' ? collection : nft;
+    const collectionAddress =
+      rawItem && 'address' in rawItem && typeof rawItem.address === 'string'
+        ? rawItem.address
+        : '';
+    const ownerAddress =
+      rawItem &&
+      'owner_addr' in rawItem &&
+      typeof rawItem.owner_addr === 'string'
+        ? rawItem.owner_addr
+        : '';
+    const address = collectionAddress || ownerAddress;
+    const item = useMemo(
+      () =>
+        rawItem && address && (!('address' in rawItem) || !rawItem.address)
+          ? ({ ...rawItem, address } as NftItemWithCollection)
+          : rawItem,
+      [address, rawItem],
+    );
+
+    if (!item) {
+      return <MemoizedNFTItemLoader style={loaderStyle} />;
+    }
+
+    return (
+      <NftRow
+        style={rowStyle}
+        logoSize={40}
+        chainLogoSize={16}
+        item={item}
+        account={address ? getAccountByAddress(address) : undefined}
+        onPress={() => onPress(item)}
+      />
+    );
+  },
+);
+
+const getNftListItemId = (item: NftListItem) => {
+  if (item.type === 'nft' || item.type === 'collection') {
+    return `nft-row/${getNftAssetsIndexRowKey(item)}`;
+  }
+  return `${item.type}/${'data' in item ? item.data : ''}`;
+};
 
 const NFTListInner = () => {
   const { t } = useTranslation();
@@ -112,62 +201,46 @@ const NFTListInner = () => {
     Object.is,
     { storeLabel: 'home-multi-assets-nft-loading' },
   );
-  const nftsMap = useActivityStore(
-    nftListStore,
-    state => state.nftsMap,
-    Object.is,
-    { storeLabel: 'home-multi-assets-nft-list' },
-  );
   const batchGetNFTList = nftListStore.getState().batchGetNFTList;
 
-  const _rawNftList = useMemo(
-    () => combinedNfts(nftsMap, myTop10Addresses),
-    [nftsMap, myTop10Addresses],
+  const multiNftsKey = useMemo(
+    () => getMultiNftsCacheKey(myTop10Addresses, chain),
+    [chain, myTop10Addresses],
   );
-
-  const nftList = useMemo(() => {
-    return _rawNftList?.filter(item =>
-      chain && item?.chain ? item.chain === chain : true,
-    );
-  }, [_rawNftList, chain]);
-
-  const { foldNftList, unFoldNftList } = useMemo(() => {
-    const result = varyNftListByFold<ActionItem>(
-      nftList,
-      (collection, item) => ({
-        type: item._isFold ? 'fold_nft' : 'unfold_nft',
-        data: collection,
-      }),
-    );
-
-    return {
-      foldNftList: result.foldList,
-      unFoldNftList: result.unFoldList,
-    };
-  }, [nftList]);
+  const nftIndex = useActivityStore(
+    useNftListComputedStore,
+    state =>
+      state.multiNftsIndexCache[multiNftsKey] || EMPTY_NFT_ASSETS_INDEX_RESULT,
+    Object.is,
+    { storeLabel: 'home-multi-assets-nft-computed-index' },
+  );
+  const nftRowCount = nftIndex.unFoldRows.length + nftIndex.foldRows.length;
 
   const dataList = useMemo(() => {
     const itemData: Array<{
       show: boolean;
-      data: ActionItem[];
+      data: NftListItem[];
     }> = [
       {
         show: true,
-        data: [...unFoldNftList],
+        data: nftIndex.unFoldRows,
       },
       {
-        show: !!foldNftList.length,
-        data: [{ type: 'toggle_nft_fold' }, ...(foldNft ? [] : foldNftList)],
+        show: !!nftIndex.foldRows.length,
+        data: [
+          { type: 'toggle_nft_fold' },
+          ...(foldNft ? [] : nftIndex.foldRows),
+        ],
       },
       {
-        show: !!isLoading && !nftList.length,
+        show: !!isLoading && nftRowCount === 0,
         data: Array.from({ length: 5 }, (_, index) => ({
           type: 'loading-skeleton',
           data: 'index-nft' + index.toString(),
         })),
       },
       {
-        show: !isLoading && nftList?.length === 0,
+        show: !isLoading && nftRowCount === 0,
         data: [
           {
             type: 'empty-nft',
@@ -182,11 +255,18 @@ const NFTListInner = () => {
       .filter(item => item.show)
       .map(item => item.data)
       .flat();
-  }, [foldNft, foldNftList, isLoading, nftList.length, t, unFoldNftList]);
+  }, [
+    foldNft,
+    isLoading,
+    nftIndex.foldRows,
+    nftIndex.unFoldRows,
+    nftRowCount,
+    t,
+  ]);
 
   const hasNotAssets = useMemo(() => {
-    return nftList.length === 0 && !isLoading && isFocused;
-  }, [nftList.length, isLoading, isFocused]);
+    return nftRowCount === 0 && !isLoading && isFocused;
+  }, [nftRowCount, isLoading, isFocused]);
 
   const [scenarioReadyCheckTick, setScenarioReadyCheckTick] = useState(0);
   useEffect(() => {
@@ -225,8 +305,8 @@ const NFTListInner = () => {
       return;
     }
 
-    const visibleCount = unFoldNftList.length;
-    const foldedCount = foldNftList.length;
+    const visibleCount = nftIndex.unFoldRows.length;
+    const foldedCount = nftIndex.foldRows.length;
     const readyKey = [
       regressionScenarioRunId,
       myTop10Addresses.join(','),
@@ -250,7 +330,7 @@ const NFTListInner = () => {
     });
   }, [
     chain,
-    foldNftList.length,
+    nftIndex.foldRows.length,
     isFocused,
     isLoading,
     myTop10Addresses,
@@ -259,8 +339,14 @@ const NFTListInner = () => {
     regressionScenarioReport,
     regressionScenarioRunId,
     scenarioReadyCheckTick,
-    unFoldNftList.length,
+    nftIndex.unFoldRows.length,
   ]);
+
+  useEffect(() => {
+    useNftListComputedStore
+      .getState()
+      .registerMultiNfts(myTop10Addresses, chain);
+  }, [chain, myTop10Addresses]);
 
   const handlePressNft = useCallback(
     (item: NftItemWithCollection) => {
@@ -309,29 +395,28 @@ const NFTListInner = () => {
 
   const renderItem = useCallback(
     ({ item }) => {
-      const { type, data } = item;
+      const { type } = item as NftListItem;
       switch (type) {
-        case 'unfold_nft':
-        case 'fold_nft':
+        case 'nft':
+        case 'collection':
           return (
             <View style={styles.rowWrap}>
-              <NftRow
-                style={StyleSheet.flatten([
+              <NftResourceRow
+                row={item as NftAssetsIndexRow}
+                rowStyle={StyleSheet.flatten([
                   styles.renderItemWrapper,
                   !isLight && styles.bg2,
                 ])}
-                logoSize={40}
-                chainLogoSize={16}
-                item={data}
-                account={getAccountByAddress(data.address)}
-                onPress={() => handlePressNft(data)}
+                loaderStyle={styles.loadingItem}
+                getAccountByAddress={getAccountByAddress}
+                onPress={handlePressNft}
               />
             </View>
           );
         case 'toggle_nft_fold':
           return (
             <TokenRowSectionHeader
-              str={'' + foldNftList.length}
+              str={'' + nftIndex.foldRows.length}
               fold={foldNft}
               style={styles.sectionHeader}
               buttonStyle={StyleSheet.flatten([
@@ -343,7 +428,11 @@ const NFTListInner = () => {
           );
         case 'empty-nft':
           return (
-            <EmptyAssets style={styles.emptyAssets} desc={data} type={type} />
+            <EmptyAssets
+              style={styles.emptyAssets}
+              desc={'data' in item ? item.data : ''}
+              type={type}
+            />
           );
         case 'loading-skeleton':
           return <MemoizedNFTItemLoader style={styles.loadingItem} />;
@@ -353,7 +442,7 @@ const NFTListInner = () => {
     },
     [
       foldNft,
-      foldNftList.length,
+      nftIndex.foldRows.length,
       getAccountByAddress,
       handlePressNft,
       isLight,
@@ -427,7 +516,7 @@ const NFTListInner = () => {
   return (
     <GestureDetector gesture={panGestureRef.current}>
       <TabsFlatList
-        keyExtractor={getItemId}
+        keyExtractor={getNftListItemId}
         data={
           hasNotAssets
             ? [

--- a/apps/mobile/src/screens/Address/components/MultiAssets/NFTList.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/NFTList.tsx
@@ -72,6 +72,11 @@ import { useRegressionScenario } from '@/devtools/regressionScenarios/react';
 import { useActivityStore } from '@/hooks/storeActivity/useActivityStore';
 import type { KeyringAccountWithAlias } from '@/hooks/account';
 
+const NFT_LIST_INITIAL_RENDER_COUNT = 10;
+const NFT_LIST_RENDER_BATCH_SIZE = 8;
+const NFT_LIST_WINDOW_SIZE = 7;
+const NFT_LIST_BATCHING_PERIOD_MS = 32;
+
 export const MemoizedNFTItemLoader = React.memo((props: RNViewProps) => {
   const { styles } = useTheme2024({ getStyle: getStyles });
   return (
@@ -530,10 +535,11 @@ const NFTListInner = () => {
             : dataList
         }
         renderItem={renderItem}
-        initialNumToRender={15}
-        windowSize={15}
+        initialNumToRender={NFT_LIST_INITIAL_RENDER_COUNT}
+        windowSize={NFT_LIST_WINDOW_SIZE}
         key={isFocused ? 'nft-focused' : 'nft-unfocused'}
-        maxToRenderPerBatch={15}
+        maxToRenderPerBatch={NFT_LIST_RENDER_BATCH_SIZE}
+        updateCellsBatchingPeriod={NFT_LIST_BATCHING_PERIOD_MS}
         removeClippedSubviews={IS_ANDROID}
         ItemSeparatorComponent={ListRenderSeparator}
         ListHeaderComponent={

--- a/apps/mobile/src/screens/Address/components/MultiAssets/ProtocolList.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/ProtocolList.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import type { ListRenderItem, ViewStyle } from 'react-native';
 import { useCurrentTabScrollY } from 'react-native-collapsible-tab-view';
 
 import { useTheme2024 } from '@/hooks/theme';
@@ -13,22 +14,20 @@ import {
   FullDefiRenderItem,
   TokenRowSectionHeader,
 } from '@/screens/Home/components/AssetRenderItems';
-import { ActionItem } from '@/screens/Home/types';
 import { createGetStyles2024 } from '@/utils/styles';
 import { EmptyAssets } from '@/screens/Home/components/AssetRenderItems/EmptyAssets';
 import { DefiItemLoader } from '@/screens/Home/components/Skeleton';
 import { GestureDetector } from 'react-native-gesture-handler';
-import { getItemId } from '@/screens/Home/utils/listRenderId';
 import { KeyringAccountWithAlias } from '@/hooks/account';
-import useLoadMoreData from './hooks/useLoadMoreData';
 import { HomeTabName as TabName } from '@/hooks/navigation';
 import { ListRenderSeparator } from './RenderRow/Common';
 import { useFindAccountByAddress, useIsFocusedCurrentTab } from './hooks/share';
-import { getAllDefiCount } from '@/screens/Home/utils/converAssets';
 import { useSelectedChainItem } from '@/screens/Home/useChainInfo';
 import useProtocols, {
+  EMPTY_PROTOCOL_ASSETS_INDEX_RESULT,
   getMultiProtocolsCacheKey,
-  ICacheProtocolItem,
+  protocolEntityResourceStore,
+  type ProtocolEntityId,
   useProtocolListComputedStore,
 } from '@/store/protocols';
 import { useShallow } from 'zustand/react/shallow';
@@ -53,17 +52,71 @@ import { withAnimatedTickerRefreshNudge } from '@/components/Animated/RefreshNud
 import { useRegressionScenario } from '@/devtools/regressionScenarios/react';
 import { useActivityStore } from '@/hooks/storeActivity/useActivityStore';
 
-const emptyCacheProtocolItem: ICacheProtocolItem = {
-  fold: [],
-  unFold: [],
-};
-
 const MemoizedFullDefiRenderItem = React.memo(FullDefiRenderItem);
 const MemoizedEmptyAssets = React.memo(EmptyAssets);
 
 export const MemoizedDefiItemLoader = React.memo(DefiItemLoader);
 
 const { batchGetProtocols } = useProtocols.getState();
+
+type ProtocolListItem =
+  | {
+      type: 'unfold_defi' | 'fold_defi';
+      protocolId: ProtocolEntityId;
+    }
+  | {
+      type: 'toggle_defi_fold';
+      data: string;
+    }
+  | {
+      type: 'empty-defi' | 'loading-defi-skeleton';
+      data: string;
+    };
+
+const ProtocolResourceRow = React.memo(
+  ({
+    protocolId,
+    getAccountByAddress,
+    style,
+    disableAction,
+    defaultExpand,
+  }: {
+    protocolId: ProtocolEntityId;
+    getAccountByAddress(address: string): KeyringAccountWithAlias | undefined;
+    style: ViewStyle;
+    disableAction: boolean;
+    defaultExpand: boolean;
+  }) => {
+    const protocol = useActivityStore(
+      protocolEntityResourceStore.useStore,
+      state => state.valueMap[protocolId],
+      Object.is,
+      { storeLabel: 'home-multi-assets-defi-entities' },
+    );
+
+    if (!protocol) {
+      return <MemoizedDefiItemLoader />;
+    }
+
+    return (
+      <MemoizedFullDefiRenderItem
+        data={protocol}
+        showAccount
+        style={style}
+        disableAction={disableAction}
+        defaultExpand={defaultExpand}
+        account={getAccountByAddress(protocol.owner_addr)}
+      />
+    );
+  },
+);
+
+const getProtocolListItemId = (item: ProtocolListItem) => {
+  if ('protocolId' in item) {
+    return `${item.type}/${item.protocolId}`;
+  }
+  return `${item.type}/${item.data}`;
+};
 
 export const ProtocolList = () => {
   const { t } = useTranslation();
@@ -96,14 +149,15 @@ export const ProtocolList = () => {
   const registerMultiAssets =
     useProtocolListComputedStore.getState().registerMultiProtocols;
 
-  const multiProtocols = useActivityStore(
+  const protocolIndex = useActivityStore(
     useProtocolListComputedStore,
     useShallow(
       state =>
-        state.multiProtocolsCache[multiProtocolsKey] || emptyCacheProtocolItem,
+        state.multiProtocolsIndexCache[multiProtocolsKey] ||
+        EMPTY_PROTOCOL_ASSETS_INDEX_RESULT,
     ),
     Object.is,
-    { storeLabel: 'home-multi-assets-defi-computed-list' },
+    { storeLabel: 'home-multi-assets-defi-computed-index' },
   );
 
   const isLoading = useActivityStore(
@@ -113,41 +167,39 @@ export const ProtocolList = () => {
     { storeLabel: 'home-multi-assets-defi-loading' },
   );
 
-  const { data: portfoliosData, loadMore: loadMorePortfolios } =
-    useLoadMoreData(multiProtocols.unFold);
-
   const shouldDefaultExpand = useMemo(
-    () => multiProtocols.unFold.length <= 5,
-    [multiProtocols.unFold.length],
+    () => protocolIndex.unFoldIds.length <= 5,
+    [protocolIndex.unFoldIds.length],
   );
 
   const portfolioListData = useMemo(() => {
-    const foldDeFiList: ActionItem[] = multiProtocols.fold.map(item => ({
-      type: 'fold_defi',
-      data: item,
-    }));
-
-    const foldDeFiValue = getAllDefiCount(multiProtocols.fold);
+    const unfoldDeFiList: ProtocolListItem[] = protocolIndex.unFoldIds.map(
+      protocolId => ({
+        type: 'unfold_defi',
+        protocolId,
+      }),
+    );
+    const foldDeFiList: ProtocolListItem[] = protocolIndex.foldIds.map(
+      protocolId => ({
+        type: 'fold_defi',
+        protocolId,
+      }),
+    );
 
     const itemData: Array<{
       show: boolean;
-      data: ActionItem[];
+      data: ProtocolListItem[];
     }> = [
       {
         show: true,
-        data: [
-          ...portfoliosData.map(item => ({
-            type: 'unfold_defi' as const,
-            data: item,
-          })),
-        ],
+        data: unfoldDeFiList,
       },
       {
         show: !!foldDeFiList.length,
         data: [
           {
             type: 'toggle_defi_fold',
-            data: foldDeFiValue,
+            data: protocolIndex.foldDeFiValue,
           },
           ...(foldDefi ? [] : foldDeFiList),
         ],
@@ -155,8 +207,8 @@ export const ProtocolList = () => {
       {
         show:
           !!isLoading &&
-          !multiProtocols.unFold.length &&
-          !multiProtocols.fold.length,
+          !protocolIndex.unFoldIds.length &&
+          !protocolIndex.foldIds.length,
         data: Array.from({ length: 2 }, (_, index) => ({
           type: 'loading-defi-skeleton',
           data: index.toString(),
@@ -165,8 +217,8 @@ export const ProtocolList = () => {
       {
         show:
           !isLoading &&
-          multiProtocols.unFold.length === 0 &&
-          multiProtocols.fold.length === 0,
+          protocolIndex.unFoldIds.length === 0 &&
+          protocolIndex.foldIds.length === 0,
         data: [
           {
             type: 'empty-defi',
@@ -184,22 +236,22 @@ export const ProtocolList = () => {
   }, [
     foldDefi,
     isLoading,
+    protocolIndex.foldDeFiValue,
+    protocolIndex.foldIds,
+    protocolIndex.unFoldIds,
     t,
-    multiProtocols.fold,
-    multiProtocols.unFold.length,
-    portfoliosData,
   ]);
 
   const hasNotAssets = useMemo(() => {
     return (
-      multiProtocols.unFold.length === 0 &&
-      multiProtocols.fold.length === 0 &&
+      protocolIndex.unFoldIds.length === 0 &&
+      protocolIndex.foldIds.length === 0 &&
       !isLoading &&
       isFocused
     );
   }, [
-    multiProtocols.fold.length,
-    multiProtocols.unFold.length,
+    protocolIndex.foldIds.length,
+    protocolIndex.unFoldIds.length,
     isLoading,
     isFocused,
   ]);
@@ -240,8 +292,8 @@ export const ProtocolList = () => {
       return;
     }
 
-    const visibleCount = multiProtocols.unFold.length;
-    const foldedCount = multiProtocols.fold.length;
+    const visibleCount = protocolIndex.unFoldIds.length;
+    const foldedCount = protocolIndex.foldIds.length;
     const readyKey = [
       regressionScenarioRunId,
       multiProtocolsKey,
@@ -266,8 +318,8 @@ export const ProtocolList = () => {
     chain,
     isFocused,
     isLoading,
-    multiProtocols.fold.length,
-    multiProtocols.unFold.length,
+    protocolIndex.foldIds.length,
+    protocolIndex.unFoldIds.length,
     multiProtocolsKey,
     myTop10Addresses.length,
     regressionScenarioActive,
@@ -298,31 +350,26 @@ export const ProtocolList = () => {
     onForeground: handleForeground,
   });
 
-  const renderItem = useCallback(
+  const renderItem = useCallback<ListRenderItem<ProtocolListItem>>(
     ({ item }) => {
-      const { type, data } = item as ActionItem;
+      const { type } = item;
       switch (type) {
         case 'unfold_defi':
         case 'fold_defi':
           return (
-            <MemoizedFullDefiRenderItem
-              data={data}
-              showAccount
+            <ProtocolResourceRow
+              protocolId={item.protocolId}
+              getAccountByAddress={getAccountByAddress}
               style={styles.fullDefi}
               disableAction={isLoading}
               defaultExpand={type === 'fold_defi' ? false : shouldDefaultExpand}
-              account={
-                getAccountByAddress(
-                  data?.owner_addr,
-                ) as unknown as KeyringAccountWithAlias
-              }
             />
           );
         case 'toggle_defi_fold':
           return (
             <TokenRowSectionHeader
               style={styles.tokenSectionHeader}
-              str={data}
+              str={item.data}
               fold={foldDefi}
               onPressFold={() => setFoldDefi(pre => !pre)}
             />
@@ -331,7 +378,7 @@ export const ProtocolList = () => {
           return (
             <MemoizedEmptyAssets
               style={styles.emptyAssets}
-              desc={data}
+              desc={item.data}
               type={type}
             />
           );
@@ -409,7 +456,7 @@ export const ProtocolList = () => {
   return (
     <GestureDetector gesture={panGestureRef.current}>
       <TabsFlatList
-        keyExtractor={getItemId}
+        keyExtractor={getProtocolListItemId}
         data={
           hasNotAssets
             ? [
@@ -424,9 +471,10 @@ export const ProtocolList = () => {
         }
         key={isFocused ? 'defi-focused' : 'defi-unfocused'}
         renderItem={renderItem}
-        initialNumToRender={15}
+        initialNumToRender={10}
         windowSize={5}
-        maxToRenderPerBatch={15}
+        maxToRenderPerBatch={8}
+        updateCellsBatchingPeriod={32}
         removeClippedSubviews={IS_ANDROID}
         ItemSeparatorComponent={ListRenderSeparator}
         ListHeaderComponent={
@@ -448,8 +496,6 @@ export const ProtocolList = () => {
           styles.list,
           pulldownRefreshReturns.scrollableStyle.list,
         ]}
-        onEndReached={loadMorePortfolios}
-        onEndReachedThreshold={0.5}
         bounces={false}
         overScrollMode={'never'}
         scrollEventThrottle={16}

--- a/apps/mobile/src/screens/Address/components/MultiAssets/TokenList.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/TokenList.tsx
@@ -80,12 +80,17 @@ import { apiCustomTestnet } from '@/core/apis';
 import { toast } from '@/components2024/Toast';
 import { useRegressionScenario } from '@/devtools/regressionScenarios/react';
 import { useActivityStore } from '@/hooks/storeActivity/useActivityStore';
+import { IS_ANDROID } from '@/core/native/utils';
 
 const MemoizedTokenRow = React.memo(TokenRowV2);
 const MemoizedScamTokenHeader = React.memo(ScamTokenHeader);
 const MemoizedTokenRowSectionHeader = React.memo(TokenRowSectionLpTokenHeader);
 
 const MemoizedItemLoader = React.memo(ItemLoader);
+const TOKEN_LIST_INITIAL_RENDER_COUNT = 8;
+const TOKEN_LIST_RENDER_BATCH_SIZE = 6;
+const TOKEN_LIST_WINDOW_SIZE = 7;
+const TOKEN_LIST_BATCHING_PERIOD_MS = 32;
 
 const TokenResourceRow = React.memo(
   ({
@@ -1008,6 +1013,11 @@ export const TokenList = () => {
         data={dataList}
         keyExtractor={keyExtractor}
         renderItem={renderItem}
+        initialNumToRender={TOKEN_LIST_INITIAL_RENDER_COUNT}
+        windowSize={TOKEN_LIST_WINDOW_SIZE}
+        maxToRenderPerBatch={TOKEN_LIST_RENDER_BATCH_SIZE}
+        updateCellsBatchingPeriod={TOKEN_LIST_BATCHING_PERIOD_MS}
+        removeClippedSubviews={IS_ANDROID}
       />
     </GestureDetector>
   );

--- a/apps/mobile/src/store/nftAssetsIndex.test.ts
+++ b/apps/mobile/src/store/nftAssetsIndex.test.ts
@@ -9,12 +9,13 @@ const makeNft = (
   options?: {
     collectionId?: string;
     fold?: boolean;
+    ownerAddress?: string;
   },
 ): DisplayNftItem =>
   ({
     id,
     inner_id: `${id}-inner`,
-    owner_addr: '0xABC',
+    owner_addr: options?.ownerAddress || '0xABC',
     chain: 'eth',
     name: id,
     amount: 1,
@@ -49,6 +50,28 @@ describe('nft asset index', () => {
     expect(projection.result.unFoldRows).toHaveLength(1);
     expect(projection.result.unFoldRows[0]?.type).toBe('collection');
     expect(projection.collections[0]?.value.nft_list).toHaveLength(2);
+  });
+
+  it('keeps the same collection separate across owners', () => {
+    const projection = buildNftAssetsIndexProjection(
+      [
+        makeNft('one', {
+          collectionId: 'collection',
+          ownerAddress: '0xAAA',
+        }),
+        makeNft('two', {
+          collectionId: 'collection',
+          ownerAddress: '0xBBB',
+        }),
+      ],
+      'multi::0xaaa|0xbbb::eth',
+    );
+
+    expect(projection.result.unFoldRows).toHaveLength(2);
+    expect(projection.collections.map(item => item.value.address)).toEqual([
+      '0xaaa',
+      '0xbbb',
+    ]);
   });
 
   it('keeps folded and unfolded rows independent', () => {

--- a/apps/mobile/src/store/nftAssetsIndex.ts
+++ b/apps/mobile/src/store/nftAssetsIndex.ts
@@ -138,7 +138,9 @@ const buildRows = (
       return;
     }
 
-    const collectionKey = `${item.chain}-${item.collection.id}`;
+    const collectionKey = `${getNftOwnerAddress(item)}-${item.chain}-${
+      item.collection.id
+    }`;
     const existingCollection = collectionMap.get(collectionKey);
     if (existingCollection) {
       existingCollection.nft_list.push({ ...item, collection: null });

--- a/apps/mobile/src/store/nfts.ts
+++ b/apps/mobile/src/store/nfts.ts
@@ -18,6 +18,7 @@ import {
   type NftEntityId,
 } from './nftAssetsIndex';
 import { beginAssetDataLoadDiagnostic } from '@/core/utils/assetDataLoadDiagnostics';
+import { LatestAsyncRequest } from '@/core/utils/latestAsyncRequest';
 
 export {
   EMPTY_NFT_ASSETS_INDEX_RESULT,
@@ -591,6 +592,7 @@ export interface NFTListState {
     options?: {
       core?: boolean;
       maxLength?: number;
+      shouldApply?: () => boolean;
     },
   ): Promise<void>;
   getNFTList(
@@ -622,6 +624,21 @@ export interface NFTListState {
 
 const singleNftLoadRequests = new Map<string, Promise<void>>();
 const singleNftCacheLoadRequests = new Map<string, Promise<void>>();
+const multiAddressNftRequests = new LatestAsyncRequest();
+
+const loadTaggedNfts = async (
+  address: string,
+  force?: boolean,
+  updateReturn?: boolean,
+) => {
+  try {
+    const nfts = await syncNFTs(address, force, updateReturn ? false : !force);
+    return nfts.length ? tagNfts(nfts as DisplayNftItem[]) : null;
+  } catch (error) {
+    console.error('ServiceErrorType.NFT', error);
+    return null;
+  }
+};
 
 const nftListStore = zCreate<NFTListState>((set, get) => ({
   nftsMap: {},
@@ -702,6 +719,9 @@ const nftListStore = zCreate<NFTListState>((set, get) => ({
       options?.core,
       options?.maxLength,
     );
+    if (options?.shouldApply && !options.shouldApply()) {
+      return;
+    }
 
     const groupedMap = cacheNfts.reduce<Record<string, DisplayNftItem[]>>(
       (acc, item) => {
@@ -733,19 +753,9 @@ const nftListStore = zCreate<NFTListState>((set, get) => ({
       return;
     }
 
-    try {
-      const nfts = await syncNFTs(
-        address,
-        force,
-        updateReturn ? false : !force,
-      );
-      if (!nfts.length) {
-        return;
-      }
-
-      get().updateNFTListByAddress(address, tagNfts(nfts as DisplayNftItem[]));
-    } catch (e) {
-      console.error('ServiceErrorType.NFT', e);
+    const nfts = await loadTaggedNfts(address, force, updateReturn);
+    if (nfts) {
+      get().updateNFTListByAddress(address, nfts);
     }
   },
 
@@ -846,8 +856,25 @@ const nftListStore = zCreate<NFTListState>((set, get) => ({
   },
 
   async batchGetNFTList(force, options) {
-    const addresses =
-      options?.realTimeAddresses || (await getTop10MyAccounts()).top10Addresses;
+    const requestId = multiAddressNftRequests.next();
+    const isCurrentRequest = () => multiAddressNftRequests.isCurrent(requestId);
+    const addresses = normalizeAddresses(
+      options?.realTimeAddresses || (await getTop10MyAccounts()).top10Addresses,
+    );
+    const trace = beginAssetDataLoadDiagnostic(
+      'multi-address-nft',
+      addresses.join('|'),
+      {
+        addressCount: addresses.length,
+        force: !!force,
+        ignoreLoading: !!options?.ignoreLoading,
+      },
+    );
+
+    if (!isCurrentRequest()) {
+      trace.finish({ path: 'stale-before-hydrate' });
+      return;
+    }
 
     get().clearUnusedNFTs(addresses);
     if (!options?.ignoreLoading) {
@@ -855,16 +882,60 @@ const nftListStore = zCreate<NFTListState>((set, get) => ({
     }
 
     try {
+      const currentNftsMap = get().nftsMap;
+      const hasMemorySnapshot = addresses.every(address =>
+        Object.prototype.hasOwnProperty.call(currentNftsMap, address),
+      );
+      if (!force && !hasMemorySnapshot) {
+        await get().batchLoadCacheNFT(addresses, {
+          shouldApply: isCurrentRequest,
+        });
+        if (!isCurrentRequest()) {
+          trace.finish({ path: 'stale-after-hydrate' });
+          return;
+        }
+        trace.mark('local-store-published', {
+          itemCount: addresses.reduce(
+            (count, address) => count + (get().nftsMap[address]?.length || 0),
+            0,
+          ),
+        });
+      } else {
+        trace.mark('memory-snapshot-retained', {
+          hasMemorySnapshot,
+        });
+      }
+
       for (const address of addresses) {
-        await get().getNFTList(address, force, options?.updateReturn);
+        if (!isCurrentRequest()) {
+          trace.finish({ path: 'stale-before-remote' });
+          return;
+        }
+        const nfts = await loadTaggedNfts(
+          address,
+          force,
+          options?.updateReturn,
+        );
+        if (nfts && isCurrentRequest()) {
+          get().updateNFTListByAddress(address, nfts);
+          trace.mark('remote-address-published', {
+            itemCount: nfts.length,
+          });
+        }
       }
       await new Promise(resolve => setTimeout(resolve, 0));
+      trace.finish({ path: 'local-then-remote' });
+    } catch (error) {
+      trace.fail({ phase: 'load' });
+      throw error;
     } finally {
-      set(state => ({
-        ...state,
-        isLoading: false,
-        isFirstFetch: false,
-      }));
+      if (isCurrentRequest()) {
+        set(state => ({
+          ...state,
+          isLoading: false,
+          isFirstFetch: false,
+        }));
+      }
     }
   },
 

--- a/apps/mobile/src/store/nfts.ts
+++ b/apps/mobile/src/store/nfts.ts
@@ -36,7 +36,9 @@ const normalizeAddresses = (addresses: string[]) =>
 type CombinedNFTItem = DisplayNftItem & { address?: string };
 
 type NftListComputedState = {
+  multiNftsIndexCache: Record<string, NftAssetsIndexResult>;
   singleNftsIndexCache: Record<string, NftAssetsIndexResult>;
+  registerMultiNfts(addresses: string[], chainServerId?: string): string;
   registerSingleNfts(address: string, chainServerId?: string): string;
 };
 
@@ -48,6 +50,14 @@ export const getSingleNftsCacheKey = (
   address: string,
   chainServerId?: string,
 ) => `${address.toLowerCase()}::${chainServerId ?? ''}`;
+
+export const getMultiNftsCacheKey = (
+  addresses: string[],
+  chainServerId?: string,
+) =>
+  `multi::${normalizeAddresses(addresses).sort().join('|')}::${
+    chainServerId ?? ''
+  }`;
 
 const getNftEntityIdAddress = (nftId: string) => nftId.split(':', 1)[0];
 
@@ -289,8 +299,14 @@ const singleNftsCacheParams = new Map<
   string,
   { address: string; chainServerId?: string }
 >();
+const multiNftsCacheParams = new Map<
+  string,
+  { addresses: string[]; chainServerId?: string }
+>();
 const singleNftsCacheOrder: string[] = [];
+const multiNftsCacheOrder: string[] = [];
 const singleNftCollectionIds = new Map<string, Set<NftCollectionId>>();
+const multiNftCollectionIds = new Map<string, Set<NftCollectionId>>();
 
 const getSingleNftList = (
   nftsMap: Record<string, DisplayNftItem[]>,
@@ -303,13 +319,36 @@ const getSingleNftList = (
     : list;
 };
 
-const removeSingleNftsCacheKey = (key: string) => {
-  singleNftsCacheParams.delete(key);
-  const collectionIds = singleNftCollectionIds.get(key);
+const getMultiNftList = (
+  nftsMap: Record<string, DisplayNftItem[]>,
+  addresses: string[],
+  chainServerId?: string,
+) => {
+  const list = combinedNfts(nftsMap, addresses);
+  return chainServerId
+    ? list.filter(nft => !nft.chain || nft.chain === chainServerId)
+    : list;
+};
+
+const removeNftsCacheKey = <T>(
+  key: string,
+  params: Map<string, T>,
+  collectionIdsByKey: Map<string, Set<NftCollectionId>>,
+) => {
+  params.delete(key);
+  const collectionIds = collectionIdsByKey.get(key);
   if (collectionIds) {
     nftCollectionResourceStore.removeCollections(collectionIds);
-    singleNftCollectionIds.delete(key);
+    collectionIdsByKey.delete(key);
   }
+};
+
+const removeSingleNftsCacheKey = (key: string) => {
+  removeNftsCacheKey(key, singleNftsCacheParams, singleNftCollectionIds);
+};
+
+const removeMultiNftsCacheKey = (key: string) => {
+  removeNftsCacheKey(key, multiNftsCacheParams, multiNftCollectionIds);
 };
 
 const touchSingleNftsCache = (
@@ -329,6 +368,27 @@ const touchSingleNftsCache = (
   const removedKey = singleNftsCacheOrder.shift();
   if (removedKey) {
     removeSingleNftsCacheKey(removedKey);
+  }
+  return removedKey;
+};
+
+const touchMultiNftsCache = (
+  key: string,
+  params: { addresses: string[]; chainServerId?: string },
+) => {
+  multiNftsCacheParams.set(key, params);
+  const previousIndex = multiNftsCacheOrder.indexOf(key);
+  if (previousIndex > -1) {
+    multiNftsCacheOrder.splice(previousIndex, 1);
+  }
+  multiNftsCacheOrder.push(key);
+
+  if (multiNftsCacheOrder.length <= NFT_COMPUTED_CACHE_LIMIT) {
+    return undefined;
+  }
+  const removedKey = multiNftsCacheOrder.shift();
+  if (removedKey) {
+    removeMultiNftsCacheKey(removedKey);
   }
   return removedKey;
 };
@@ -384,8 +444,70 @@ const updateSingleNftsIndex = (
   }
 };
 
+const updateMultiNftsIndex = (
+  key: string,
+  nftsMap: Record<string, DisplayNftItem[]>,
+) => {
+  const params = multiNftsCacheParams.get(key);
+  if (!params) {
+    return;
+  }
+
+  const previousResult =
+    useNftListComputedStore.getState().multiNftsIndexCache[key];
+  const projection = buildNftAssetsIndexProjection(
+    getMultiNftList(nftsMap, params.addresses, params.chainServerId),
+    key,
+    previousResult,
+  );
+  const previousCollectionIds = multiNftCollectionIds.get(key) || new Set();
+  const nextCollectionIds = new Set(
+    projection.collections.map(item => item.collectionId),
+  );
+  const removedCollectionIds = Array.from(previousCollectionIds).filter(
+    collectionId => !nextCollectionIds.has(collectionId),
+  );
+
+  nftCollectionResourceStore.upsertCollections(projection.collections);
+  nftCollectionResourceStore.removeCollections(removedCollectionIds);
+  multiNftCollectionIds.set(key, nextCollectionIds);
+
+  if (previousResult !== projection.result) {
+    useNftListComputedStore.setState(state => ({
+      multiNftsIndexCache: {
+        ...state.multiNftsIndexCache,
+        [key]: projection.result,
+      },
+    }));
+  }
+};
+
 export const useNftListComputedStore = zCreate<NftListComputedState>(set => ({
+  multiNftsIndexCache: {},
   singleNftsIndexCache: {},
+  registerMultiNfts(addresses, chainServerId) {
+    const normalizedAddresses = normalizeAddresses(addresses);
+    const key = getMultiNftsCacheKey(normalizedAddresses, chainServerId);
+    const removedKey = touchMultiNftsCache(key, {
+      addresses: normalizedAddresses,
+      chainServerId,
+    });
+    const nftsMap = nftListStore.getState().nftsMap;
+    nftEntityResourceStore.syncAddressesFromNftsMap(
+      nftsMap,
+      normalizedAddresses,
+    );
+    updateMultiNftsIndex(key, nftsMap);
+
+    if (removedKey) {
+      set(state => {
+        const nextCache = { ...state.multiNftsIndexCache };
+        delete nextCache[removedKey];
+        return { multiNftsIndexCache: nextCache };
+      });
+    }
+    return key;
+  },
   registerSingleNfts(address, chainServerId) {
     const normalizedAddress = address.toLowerCase();
     const key = getSingleNftsCacheKey(normalizedAddress, chainServerId);
@@ -813,6 +935,9 @@ nftListStore.subscribe(state => {
     address =>
       Array.from(singleNftsCacheParams.values()).some(
         params => params.address === address,
+      ) ||
+      Array.from(multiNftsCacheParams.values()).some(params =>
+        params.addresses.includes(address),
       ),
   );
   if (!registeredChangedAddresses.length) {
@@ -826,6 +951,11 @@ nftListStore.subscribe(state => {
   singleNftsCacheParams.forEach((params, key) => {
     if (changedAddresses.has(params.address)) {
       updateSingleNftsIndex(key, state.nftsMap);
+    }
+  });
+  multiNftsCacheParams.forEach((params, key) => {
+    if (params.addresses.some(address => changedAddresses.has(address))) {
+      updateMultiNftsIndex(key, state.nftsMap);
     }
   });
 });

--- a/apps/mobile/src/store/protocols.ts
+++ b/apps/mobile/src/store/protocols.ts
@@ -14,6 +14,8 @@ import { markStartupPerf } from '@/core/utils/startupPerfMarks';
 import { getSelectedBalanceAddressesSnapshot } from './balance';
 import { ResourceBaseStore } from './_resourceBase';
 import type { ObservableResourceValueSource } from './_resourceFlow';
+import { beginAssetDataLoadDiagnostic } from '@/core/utils/assetDataLoadDiagnostics';
+import { LatestAsyncRequest } from '@/core/utils/latestAsyncRequest';
 import {
   buildProtocolAssetsIndexResult,
   buildProtocolEntityId,
@@ -63,6 +65,7 @@ type ProtocolListComputedState = {
 
 const COMPUTED_CACHE_LIMIT = 10;
 const PROTOCOL_ENTITY_RESOURCE_FAMILY = 'protocol.entity';
+const multiAddressProtocolRequests = new LatestAsyncRequest();
 
 const normalizeAddresses = (addresses: string[]) =>
   addresses.map(address => address.toLowerCase());
@@ -407,7 +410,7 @@ const mergeProtocolMaps = (
   return merged;
 };
 
-export const useProtocolListStore = zCreate<ProtocolListState>(set => ({
+export const useProtocolListStore = zCreate<ProtocolListState>((set, get) => ({
   protocolMap: {},
   isLoading: false,
   isLoadingByAddress: {},
@@ -443,46 +446,133 @@ export const useProtocolListStore = zCreate<ProtocolListState>(set => ({
     });
   },
   async batchGetProtocols(addresses, force = false) {
+    const requestId = multiAddressProtocolRequests.next();
+    const isCurrentRequest = () =>
+      multiAddressProtocolRequests.isCurrent(requestId);
     if (!addresses.length) {
       set(() => ({ isLoading: true }));
       await new Promise(resolve => setTimeout(resolve, 0));
-      set(() => ({ protocolMap: {}, isLoading: false }));
+      if (isCurrentRequest()) {
+        set(() => ({ protocolMap: {}, isLoading: false }));
+      }
       return;
     }
     const lowerAddresses = Array.from(
       new Set(addresses.map(item => item.toLowerCase())),
     );
+    const trace = beginAssetDataLoadDiagnostic(
+      'multi-address-protocol',
+      lowerAddresses.join('|'),
+      {
+        addressCount: lowerAddresses.length,
+        force,
+      },
+    );
 
-    if (!force) {
-      const isExpired = await isDataExpiredBatch(lowerAddresses);
-      if (!isExpired) {
-        const [protocolMap, appChainMap] = await Promise.all([
+    try {
+      if (!force) {
+        const isExpired = await isDataExpiredBatch(lowerAddresses);
+        trace.mark('expiry-resolved', { isExpired });
+        if (!isCurrentRequest()) {
+          trace.finish({ path: 'stale-before-hydrate' });
+          return;
+        }
+        if (!isExpired) {
+          const [protocolMap, appChainMap] = await Promise.all([
+            ProtocolItemEntity.getDefaultProtocolsByAddresses(lowerAddresses),
+            buildAppChainProtocolMap(lowerAddresses),
+          ]);
+          trace.mark('local-db-loaded', {
+            itemCount: Object.values(protocolMap).reduce(
+              (count, protocols) => count + protocols.length,
+              0,
+            ),
+          });
+          if (!isCurrentRequest()) {
+            trace.finish({ path: 'stale-after-hydrate' });
+            return;
+          }
+          const mergedProtocolMap = mergeProtocolMaps(protocolMap, appChainMap);
+          set(() => ({
+            protocolMap: mergedProtocolMap,
+            isLoading: false,
+          }));
+          reportLendingUserStatusOnce({
+            addresses: lowerAddresses,
+            protocolMap,
+          });
+          trace.finish({ path: 'local-db' });
+          return;
+        }
+      }
+
+      if (isCurrentRequest()) {
+        set(() => ({ isLoading: true }));
+      }
+
+      const remoteProtocolsPromise = syncProtocolsForAddresses(
+        lowerAddresses,
+        force,
+      ).then(
+        result => ({ status: 'fulfilled' as const, result }),
+        error => ({ status: 'rejected' as const, error }),
+      );
+      const currentProtocolMap = get().protocolMap;
+      const hasMemorySnapshot = lowerAddresses.every(address =>
+        Object.prototype.hasOwnProperty.call(currentProtocolMap, address),
+      );
+
+      if (!force && !hasMemorySnapshot) {
+        const [localProtocolMap, appChainMap] = await Promise.all([
           ProtocolItemEntity.getDefaultProtocolsByAddresses(lowerAddresses),
           buildAppChainProtocolMap(lowerAddresses),
         ]);
-        set(() => ({
-          protocolMap: mergeProtocolMaps(protocolMap, appChainMap),
-          isLoading: false,
-        }));
-        reportLendingUserStatusOnce({
-          addresses: lowerAddresses,
-          protocolMap,
+        trace.mark('stale-local-db-loaded', {
+          itemCount: Object.values(localProtocolMap).reduce(
+            (count, protocols) => count + protocols.length,
+            0,
+          ),
         });
-        // cache击中，不用走下面流程了
+        if (isCurrentRequest()) {
+          set(() => ({
+            protocolMap: mergeProtocolMaps(localProtocolMap, appChainMap),
+          }));
+          trace.mark('stale-local-store-published');
+        }
+      } else {
+        trace.mark('memory-snapshot-retained', {
+          hasMemorySnapshot,
+        });
+      }
+
+      const remoteProtocols = await remoteProtocolsPromise;
+      if (remoteProtocols.status === 'rejected') {
+        throw remoteProtocols.error;
+      }
+      const resultMap = remoteProtocols.result;
+      trace.mark('remote-response-completed', {
+        itemCount: Object.values(resultMap).reduce(
+          (count, protocols) => count + protocols.length,
+          0,
+        ),
+      });
+      if (!isCurrentRequest()) {
+        trace.finish({ path: 'stale-after-remote' });
         return;
       }
-    }
-
-    set(() => ({ isLoading: true }));
-    try {
-      const resultMap = await syncProtocolsForAddresses(lowerAddresses, force);
       set(() => ({ protocolMap: resultMap }));
       reportLendingUserStatusOnce({
         addresses: lowerAddresses,
         protocolMap: resultMap,
       });
+      trace.finish({ path: 'local-then-remote' });
+    } catch (error) {
+      trace.fail({ phase: 'load' });
+      throw error;
     } finally {
-      set(() => ({ isLoading: false }));
+      if (isCurrentRequest()) {
+        set(() => ({ isLoading: false }));
+      }
     }
   },
   async getProtocols(address, force = false) {

--- a/apps/mobile/src/store/protocols.ts
+++ b/apps/mobile/src/store/protocols.ts
@@ -52,7 +52,7 @@ interface ProtocolListState {
 }
 
 type ProtocolListComputedState = {
-  multiProtocolsCache: Record<string, ICacheProtocolItem>;
+  multiProtocolsIndexCache: Record<string, ProtocolAssetsIndexResult>;
   singleProtocolsIndexCache: Record<string, ProtocolAssetsIndexResult>;
   registerMultiProtocols: (
     addresses: string[],
@@ -288,6 +288,17 @@ const computeMultiProtocols = (
 
   return splitFoldAndUnfold(filtered);
 };
+
+const computeMultiProtocolsIndex = (
+  protocolMap: ProtocolListMap,
+  addresses: string[],
+  chainServerId?: string,
+  previousResult?: ProtocolAssetsIndexResult,
+) =>
+  buildProtocolAssetsIndexResult(
+    computeMultiProtocols(protocolMap, addresses, chainServerId),
+    previousResult,
+  );
 
 const multiProtocolsCacheParams = new Map<
   string,
@@ -583,7 +594,7 @@ export const useProtocolListStore = zCreate<ProtocolListState>(set => ({
 
 export const useProtocolListComputedStore = zCreate<ProtocolListComputedState>(
   set => ({
-    multiProtocolsCache: {},
+    multiProtocolsIndexCache: {},
     singleProtocolsIndexCache: {},
     registerMultiProtocols(addresses, chainServerId) {
       const key = getMultiProtocolsCacheKey(addresses, chainServerId);
@@ -597,11 +608,17 @@ export const useProtocolListComputedStore = zCreate<ProtocolListComputedState>(
         },
       );
       const protocolMap = useProtocolListStore.getState().protocolMap;
+      protocolEntityResourceStore.syncFromProtocolMap(protocolMap);
       set(state => ({
-        multiProtocolsCache: removeKeysFromCache(
+        multiProtocolsIndexCache: removeKeysFromCache(
           {
-            ...state.multiProtocolsCache,
-            [key]: computeMultiProtocols(protocolMap, addresses, chainServerId),
+            ...state.multiProtocolsIndexCache,
+            [key]: computeMultiProtocolsIndex(
+              protocolMap,
+              addresses,
+              chainServerId,
+              state.multiProtocolsIndexCache[key],
+            ),
           },
           removedKeys,
         ),
@@ -642,21 +659,22 @@ export const useProtocolListComputedStore = zCreate<ProtocolListComputedState>(
 );
 
 const rebuildComputedCaches = (protocolMap: ProtocolListMap) => {
-  if (singleProtocolsCacheParams.size) {
+  if (multiProtocolsCacheParams.size || singleProtocolsCacheParams.size) {
     protocolEntityResourceStore.syncFromProtocolMap(protocolMap);
   }
 
-  const multiProtocolsCache: Record<string, ICacheProtocolItem> = {};
+  const previousComputedState = useProtocolListComputedStore.getState();
+  const multiProtocolsIndexCache: Record<string, ProtocolAssetsIndexResult> =
+    {};
   multiProtocolsCacheParams.forEach((params, key) => {
-    multiProtocolsCache[key] = computeMultiProtocols(
+    multiProtocolsIndexCache[key] = computeMultiProtocolsIndex(
       protocolMap,
       params.addresses,
       params.chainServerId,
+      previousComputedState.multiProtocolsIndexCache[key],
     );
   });
 
-  const previousSingleProtocolsIndexCache =
-    useProtocolListComputedStore.getState().singleProtocolsIndexCache;
   const singleProtocolsIndexCache: Record<string, ProtocolAssetsIndexResult> =
     {};
   singleProtocolsCacheParams.forEach((params, key) => {
@@ -664,12 +682,12 @@ const rebuildComputedCaches = (protocolMap: ProtocolListMap) => {
       protocolMap,
       params.address.toLowerCase(),
       params.chainServerId,
-      previousSingleProtocolsIndexCache[key],
+      previousComputedState.singleProtocolsIndexCache[key],
     );
   });
 
   useProtocolListComputedStore.setState({
-    multiProtocolsCache,
+    multiProtocolsIndexCache,
     singleProtocolsIndexCache,
   });
 };

--- a/apps/mobile/src/store/tokens.ts
+++ b/apps/mobile/src/store/tokens.ts
@@ -1,4 +1,3 @@
-import { getTop10MyAccounts } from '@/core/apis/account';
 import { queryTokensCache } from '@/core/apis/tokenCache';
 import { openapi } from '@/core/request';
 import { zCreate, zMutative } from '@/core/utils/reexports';
@@ -36,15 +35,29 @@ import { markStartupPerf } from '@/core/utils/startupPerfMarks';
 import { getSelectedBalanceAddressesSnapshot } from './balance';
 import { uniqBy } from 'lodash';
 import { beginAssetDataLoadDiagnostic } from '@/core/utils/assetDataLoadDiagnostics';
+import { LatestAsyncRequest } from '@/core/utils/latestAsyncRequest';
 
 export type { ITokenItem, TokenAssetsResult } from '@/types/assets';
 
-const waitQueueFinished = (q: PQueue) => {
-  return new Promise(resolve => {
-    q.on('idle', () => {
-      resolve(null);
-    });
+const multiAddressTokenRequests = new LatestAsyncRequest();
+
+const buildTokenListMapFromEntities = (
+  addresses: string[],
+  tokens: TokenItemEntity[],
+) => {
+  const result = Object.fromEntries(
+    addresses.map(address => [address, [] as ITokenItem[]]),
+  );
+
+  tokens.forEach(token => {
+    const transformedToken = tokenItemEntityToTokenItem(token);
+    const address = transformedToken.owner_addr.toLowerCase();
+    if (result[address]) {
+      result[address].push(transformedToken);
+    }
   });
+
+  return result;
 };
 
 interface TokenListState {
@@ -1711,114 +1724,215 @@ const tokenListStore = zCreate<TokenListState>((set, get) => ({
   },
 
   async batchGetTokenList(addresses: string[], force = false) {
+    const requestId = multiAddressTokenRequests.next();
     const lowerAddresses = Array.from(
       new Set(addresses.map(item => item.toLowerCase())),
     );
+    const trace = beginAssetDataLoadDiagnostic(
+      'multi-address-token',
+      lowerAddresses.join('|'),
+      {
+        addressCount: lowerAddresses.length,
+        force,
+      },
+    );
+    const isCurrentRequest = () =>
+      multiAddressTokenRequests.isCurrent(requestId);
+
     if (!lowerAddresses.length) {
       set(() => ({ isLoading: true }));
       await new Promise(resolve => setTimeout(resolve, 0));
-      set(() => ({ tokenListMap: {}, isLoading: false }));
+      if (isCurrentRequest()) {
+        set(() => ({ tokenListMap: {}, isLoading: false }));
+      }
+      trace.finish({ path: 'empty-addresses' });
       return;
     }
-    if (!force) {
-      const isExpired = await isDataExpiredBatch(lowerAddresses);
-      if (!isExpired) {
-        const tokens = await TokenItemEntity.batchMultiAddressTokens(
+
+    try {
+      if (!force) {
+        const isExpired = await isDataExpiredBatch(lowerAddresses);
+        trace.mark('expiry-resolved', { isExpired });
+        if (!isCurrentRequest()) {
+          trace.finish({ path: 'stale-before-hydrate' });
+          return;
+        }
+        if (!isExpired) {
+          const tokens = await TokenItemEntity.batchMultiAddressTokens(
+            lowerAddresses,
+          );
+          const localTokenMap = buildTokenListMapFromEntities(
+            lowerAddresses,
+            tokens as TokenItemEntity[],
+          );
+          trace.mark('local-db-loaded', { itemCount: tokens.length });
+          if (!isCurrentRequest()) {
+            trace.finish({ path: 'stale-after-hydrate' });
+            return;
+          }
+          syncTokenRuntimeStoresFromTokenListMap(
+            localTokenMap,
+            lowerAddresses,
+            'hydrate',
+            {
+              markTokenListMapSynced: true,
+            },
+          );
+          set(() => ({ tokenListMap: localTokenMap, isLoading: false }));
+          trace.finish({ path: 'local-db', itemCount: tokens.length });
+          return;
+        }
+      }
+
+      if (isCurrentRequest()) {
+        set(() => ({ isLoading: true }));
+      }
+
+      const cacheTokenQueue = new PQueue({
+        concurrency: 5,
+      });
+      const cacheTokenMap: Record<string, ITokenItem[]> = {};
+      const cacheTokensPromise = Promise.allSettled(
+        lowerAddresses.map(address =>
+          cacheTokenQueue.add(async () => {
+            const list = await queryTokensCache(address);
+            cacheTokenMap[address] = filterInterfaceTokenList(
+              list.map(item => tokenItemToITokenItem(item, address)),
+            );
+          }),
+        ),
+      );
+
+      const currentTokenListMap = get().tokenListMap;
+      const hasMemorySnapshot = lowerAddresses.every(address =>
+        Object.prototype.hasOwnProperty.call(currentTokenListMap, address),
+      );
+      if (!force && !hasMemorySnapshot) {
+        const localTokens = await TokenItemEntity.batchMultiAddressTokens(
           lowerAddresses,
         );
-        const res: Record<string, ITokenItem[]> = {};
-        for (let i = 0; i < tokens.length; i++) {
-          const token = tokens[i] as TokenItemEntity;
-          const transformedToken = tokenItemEntityToTokenItem(token);
-          const key = transformedToken.owner_addr.toLowerCase();
-          if (res[key]) {
-            res[key].push(transformedToken);
-          } else {
-            res[key] = [transformedToken];
-          }
-        }
-        syncTokenRuntimeStoresFromTokenListMap(res, lowerAddresses, 'hydrate', {
-          markTokenListMapSynced: true,
+        trace.mark('stale-local-db-loaded', {
+          itemCount: localTokens.length,
         });
-        set(() => ({ tokenListMap: res, isLoading: false }));
+        if (isCurrentRequest()) {
+          const localTokenMap = buildTokenListMapFromEntities(
+            lowerAddresses,
+            localTokens as TokenItemEntity[],
+          );
+          syncTokenRuntimeStoresFromTokenListMap(
+            localTokenMap,
+            lowerAddresses,
+            'hydrate',
+            {
+              markTokenListMapSynced: true,
+            },
+          );
+          set(() => ({ tokenListMap: localTokenMap }));
+          trace.mark('stale-local-store-published', {
+            itemCount: localTokens.length,
+          });
+        }
+      } else {
+        trace.mark('memory-snapshot-retained', {
+          hasMemorySnapshot,
+        });
+      }
+
+      await cacheTokensPromise;
+      trace.mark('cache-responses-completed', {
+        itemCount: Object.values(cacheTokenMap).reduce(
+          (count, tokens) => count + tokens.length,
+          0,
+        ),
+      });
+      if (!isCurrentRequest()) {
+        trace.finish({ path: 'stale-after-cache' });
         return;
       }
-    }
-    set(() => ({ isLoading: true }));
-    const cacheTokenQueue = new PQueue({
-      concurrency: 5,
-    });
-    const cacheTokenMap: Record<string, ITokenItem[]> = {};
-    lowerAddresses.forEach(address => {
-      cacheTokenQueue.add(async () => {
-        const list = await queryTokensCache(address);
-        cacheTokenMap[address.toLowerCase()] = filterInterfaceTokenList(
-          list.map(item => tokenItemToITokenItem(item, address)),
+
+      const latestTokenListMap = get().tokenListMap;
+      const mergedCacheTokenMap = { ...latestTokenListMap };
+      lowerAddresses.forEach(address => {
+        const previousTokens = latestTokenListMap[address] || [];
+        const cacheTokens = cacheTokenMap[address] || [];
+        mergedCacheTokenMap[address] = replacePreviousCoreTokensWithCacheTokens(
+          previousTokens,
+          cacheTokens,
         );
       });
-    });
-    await waitQueueFinished(cacheTokenQueue);
-    const currentTokenListMap = get().tokenListMap;
-    const mergedCacheTokenMap = { ...currentTokenListMap };
-    lowerAddresses.forEach(address => {
-      const normalizedAddress = address.toLowerCase();
-      const previousTokens = currentTokenListMap[normalizedAddress] || [];
-      const cacheTokens = cacheTokenMap[normalizedAddress] || [];
-      mergedCacheTokenMap[normalizedAddress] =
-        replacePreviousCoreTokensWithCacheTokens(previousTokens, cacheTokens);
-    });
-    syncTokenRuntimeStoresFromTokenListMap(
-      mergedCacheTokenMap,
-      lowerAddresses,
-      'remote',
-      {
-        markTokenListMapSynced: true,
-      },
-    );
-    set(() => ({ tokenListMap: mergedCacheTokenMap }));
-    const realTimeTokenMap: Record<string, ITokenItem[]> = {};
-    const realTimeTokenQueue = new PQueue({
-      concurrency: 15,
-    });
-    await Promise.allSettled(
-      lowerAddresses.map(async address => {
-        const chains = await openapi.usedChainList(address);
-        const chainIdList = chains.map(item => item.id);
-        const res = await Promise.allSettled(
-          chainIdList.map(
-            async serverId =>
-              await realTimeTokenQueue.add(async () => {
-                const chainTokensRes = await requestOpenApiWithChainId(
-                  ({ openapi }) => openapi.listToken(address, serverId, true),
-                  {
-                    isTestnet: false,
-                  },
-                );
-                const tokenList = filterInterfaceTokenList(
-                  chainTokensRes.map(item =>
-                    tokenItemToITokenItem(item, address),
-                  ),
-                );
-                return tokenList;
-              }),
-          ),
-        );
-        const results = res
-          .map(result => (result.status === 'fulfilled' ? result.value : []))
-          .flat() as ITokenItem[];
-        realTimeTokenMap[address.toLowerCase()] = results;
-      }),
-    );
-    syncTokenRuntimeStoresFromTokenListMap(
-      realTimeTokenMap,
-      lowerAddresses,
-      'remote',
-      {
-        markTokenListMapSynced: true,
-      },
-    );
-    set(() => ({ tokenListMap: realTimeTokenMap, isLoading: false }));
-    syncRemoteTokensForAddresses(realTimeTokenMap);
+      syncTokenRuntimeStoresFromTokenListMap(
+        mergedCacheTokenMap,
+        lowerAddresses,
+        'remote',
+        {
+          markTokenListMapSynced: true,
+        },
+      );
+      set(() => ({ tokenListMap: mergedCacheTokenMap }));
+      trace.mark('cache-store-published');
+
+      const realTimeTokenMap: Record<string, ITokenItem[]> = {};
+      const realTimeTokenQueue = new PQueue({
+        concurrency: 15,
+      });
+      await Promise.allSettled(
+        lowerAddresses.map(async address => {
+          const chains = await openapi.usedChainList(address);
+          const chainIdList = chains.map(item => item.id);
+          const res = await Promise.allSettled(
+            chainIdList.map(
+              async serverId =>
+                await realTimeTokenQueue.add(async () => {
+                  const chainTokensRes = await requestOpenApiWithChainId(
+                    ({ openapi }) => openapi.listToken(address, serverId, true),
+                    {
+                      isTestnet: false,
+                    },
+                  );
+                  return filterInterfaceTokenList(
+                    chainTokensRes.map(item =>
+                      tokenItemToITokenItem(item, address),
+                    ),
+                  );
+                }),
+            ),
+          );
+          realTimeTokenMap[address] = res
+            .map(result => (result.status === 'fulfilled' ? result.value : []))
+            .flat() as ITokenItem[];
+        }),
+      );
+
+      syncRemoteTokensForAddresses(realTimeTokenMap);
+      trace.mark('remote-responses-completed', {
+        itemCount: Object.values(realTimeTokenMap).reduce(
+          (count, tokens) => count + tokens.length,
+          0,
+        ),
+      });
+      if (!isCurrentRequest()) {
+        trace.finish({ path: 'stale-after-remote' });
+        return;
+      }
+
+      syncTokenRuntimeStoresFromTokenListMap(
+        realTimeTokenMap,
+        lowerAddresses,
+        'remote',
+        {
+          markTokenListMapSynced: true,
+        },
+      );
+      set(() => ({ tokenListMap: realTimeTokenMap, isLoading: false }));
+      trace.finish({ path: 'cache-then-remote' });
+    } catch (error) {
+      trace.fail({ phase: 'load' });
+      throw error;
+    } finally {
+      if (isCurrentRequest() && get().isLoading) {
+        set(() => ({ isLoading: false }));
+      }
+    }
   },
 
   async getTokenList(address: string, force = false, chainServerId?: string) {


### PR DESCRIPTION
## Summary

- isolate Token, DeFi, and NFT list projections from row-level entity subscriptions
- suspend hidden Home asset tab subscriptions and tune list virtualization
- converge local, cached, and remote asset loading with latest-request ownership

## Why

Large Home asset datasets could cause broad React updates and stale requests could publish after a newer address selection or refresh. This keeps list structure stable, moves entity updates to visible rows, and prevents superseded requests from changing UI state.

## Validation

- `corepack yarn workspace rabby-mobile typecheck`
- focused Jest suites: 3 suites / 15 tests
- `corepack yarn workspace rabby-mobile lint:cycles`
- Android regression build, including 16 KB page-size check
- `home-assets` lifecycle scenario passed on ALN-AL80 and FOA-AL60
- hidden Home tabs reported zero source subscriptions
