### PR TITLE
fix(mobile): protect keyring persistence on d197 repro base

### DIFF
--- a/.yarn/patches/react-native-mmkv-patch-b5ece05891.patch
+++ b/.yarn/patches/react-native-mmkv-patch-b5ece05891.patch
@@ -1,35 +1,8 @@
 diff --git a/android/src/main/cpp/MmkvHostObject.cpp b/android/src/main/cpp/MmkvHostObject.cpp
-index 9ccc10fc28f5a4a0aebd9ded4c266592d000f781..18d96e9b96748f18bf19f1b655fc3699d661b792 100644
+index 9ccc10fc28f5a4a0aebd9ded4c266592d000f781..44efb8f76433e3b49c6c38b4262c9eb0ea1de385 100644
 --- a/android/src/main/cpp/MmkvHostObject.cpp
 +++ b/android/src/main/cpp/MmkvHostObject.cpp
-@@ -9,20 +9,23 @@
- #include "MmkvHostObject.h"
- #include "TypedArray.h"
- #include <MMKV.h>
-+#include <algorithm>
- #include <android/log.h>
- #include <string>
- #include <vector>
- 
- MmkvHostObject::MmkvHostObject(const std::string& instanceId, std::string path,
--                               std::string cryptKey) {
-+                               std::string cryptKey, size_t expectedCapacity) {
-   bool hasEncryptionKey = cryptKey.size() > 0;
-   __android_log_print(ANDROID_LOG_INFO, "RNMMKV",
-                       "Creating MMKV instance \"%s\"... (Path: %s, Encrypted: %b)",
-                       instanceId.c_str(), path.c_str(), hasEncryptionKey);
-   std::string* pathPtr = path.size() > 0 ? &path : nullptr;
-   std::string* cryptKeyPtr = cryptKey.size() > 0 ? &cryptKey : nullptr;
--  instance = MMKV::mmkvWithID(instanceId, mmkv::DEFAULT_MMAP_SIZE, MMKV_SINGLE_PROCESS, cryptKeyPtr,
--                              pathPtr);
-+  const auto capacity = static_cast<int>(std::max<size_t>(
-+      mmkv::DEFAULT_MMAP_SIZE, expectedCapacity));
-+  instance = MMKV::mmkvWithID(instanceId, capacity, MMKV_SINGLE_PROCESS, cryptKeyPtr, pathPtr,
-+                              expectedCapacity);
- 
-   if (instance == nullptr) {
-     // Check if instanceId is invalid
-@@ -52,6 +55,8 @@ std::vector<jsi::PropNameID> MmkvHostObject::getPropertyNames(jsi::Runtime& rt)
+@@ -52,6 +52,8 @@ std::vector<jsi::PropNameID> MmkvHostObject::getPropertyNames(jsi::Runtime& rt)
    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("getAllKeys")));
    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("deleteAll")));
    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("recrypt")));
@@ -38,7 +11,7 @@ index 9ccc10fc28f5a4a0aebd9ded4c266592d000f781..18d96e9b96748f18bf19f1b655fc3699
    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("trim")));
    return result;
  }
-@@ -287,6 +292,27 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
+@@ -300,5 +302,26 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
          });
    }
  
@@ -63,112 +36,13 @@ index 9ccc10fc28f5a4a0aebd9ded4c266592d000f781..18d96e9b96748f18bf19f1b655fc3699
 +        });
 +  }
 +
-   if (propName == "trim") {
-     // MMKV.trim()
-     return jsi::Function::createFromHostFunction(
-diff --git a/android/src/main/cpp/MmkvHostObject.h b/android/src/main/cpp/MmkvHostObject.h
-index b2c5573a8bd9a9e83370454984d93bd36fed8bed..865aa2ac07af81151120858e77f8ea142f4a2f7a 100644
---- a/android/src/main/cpp/MmkvHostObject.h
-+++ b/android/src/main/cpp/MmkvHostObject.h
-@@ -15,7 +15,8 @@ using namespace facebook;
- 
- class JSI_EXPORT MmkvHostObject : public jsi::HostObject {
- public:
--  MmkvHostObject(const std::string& instanceId, std::string path, std::string cryptKey);
-+  MmkvHostObject(const std::string& instanceId, std::string path, std::string cryptKey,
-+                 size_t expectedCapacity);
- 
- public:
-   jsi::Value get(jsi::Runtime&, const jsi::PropNameID& name) override;
-diff --git a/android/src/main/cpp/cpp-adapter.cpp b/android/src/main/cpp/cpp-adapter.cpp
-index d4a728b0bbc8f0fd3f8878409b100d23aad1afbf..f1c58fad5cd3ab3b0f73395fa3a862a5e23b49cd 100644
---- a/android/src/main/cpp/cpp-adapter.cpp
-+++ b/android/src/main/cpp/cpp-adapter.cpp
-@@ -1,6 +1,7 @@
- #include "MmkvHostObject.h"
- #include "TypedArray.h"
- #include <MMKV.h>
-+#include <cmath>
- #include <jni.h>
- #include <jsi/jsi.h>
- 
-@@ -13,6 +14,22 @@ std::string getPropertyAsStringOrEmptyFromObject(jsi::Object& object,
-   return value.isString() ? value.asString(runtime).utf8(runtime) : "";
+   return jsi::Value::undefined();
  }
- 
-+size_t getExpectedCapacityFromObject(jsi::Object& object, jsi::Runtime& runtime) {
-+  jsi::Value value = object.getProperty(runtime, "expectedCapacity");
-+  if (!value.isNumber()) {
-+    return 0;
-+  }
-+
-+  const auto capacity = value.getNumber();
-+  constexpr auto kMaxExpectedCapacity = 16 * 1024 * 1024;
-+  if (!std::isfinite(capacity) || std::floor(capacity) != capacity || capacity < 0 ||
-+      capacity > kMaxExpectedCapacity) {
-+    throw jsi::JSError(runtime,
-+                        "MMKV expectedCapacity must be a finite value between 0 and 16 MiB.");
-+  }
-+  return static_cast<size_t>(capacity);
-+}
-+
- void install(jsi::Runtime& jsiRuntime) {
-   // MMKV.createNewInstance()
-   auto mmkvCreateNewInstance = jsi::Function::createFromHostFunction(
-@@ -28,8 +45,10 @@ void install(jsi::Runtime& jsiRuntime) {
-         std::string path = getPropertyAsStringOrEmptyFromObject(config, "path", runtime);
-         std::string encryptionKey =
-             getPropertyAsStringOrEmptyFromObject(config, "encryptionKey", runtime);
-+        size_t expectedCapacity = getExpectedCapacityFromObject(config, runtime);
- 
--        auto instance = std::make_shared<MmkvHostObject>(instanceId, path, encryptionKey);
-+        auto instance = std::make_shared<MmkvHostObject>(instanceId, path, encryptionKey,
-+                                                         expectedCapacity);
-         return jsi::Object::createFromHostObject(runtime, instance);
-       });
-   jsiRuntime.global().setProperty(jsiRuntime, "mmkvCreateNewInstance",
-diff --git a/ios/MmkvHostObject.h b/ios/MmkvHostObject.h
-index 906156d98aa3dbf15d5e3b0e4fceb37f0315ad1a..33375cce7b73f3b2031af7d99e9b5e1a786c876b 100644
---- a/ios/MmkvHostObject.h
-+++ b/ios/MmkvHostObject.h
-@@ -16,7 +16,8 @@ using namespace facebook;
- 
- class JSI_EXPORT MmkvHostObject : public jsi::HostObject {
- public:
--  MmkvHostObject(NSString* instanceId, NSString* path, NSString* cryptKey);
-+  MmkvHostObject(NSString* instanceId, NSString* path, NSString* cryptKey,
-+                 size_t expectedCapacity);
- 
- public:
-   jsi::Value get(jsi::Runtime&, const jsi::PropNameID& name) override;
 diff --git a/ios/MmkvHostObject.mm b/ios/MmkvHostObject.mm
-index fb80fb9790f40669b6f4ee0bc48ba8798d0317e8..955cd47e43f04d58986721ffa4fffbefe186d971 100644
+index fb80fb9790f40669b6f4ee0bc48ba8798d0317e8..6961bb41ff593667fd5679c7c9d57f7c7ede75a9 100644
 --- a/ios/MmkvHostObject.mm
 +++ b/ios/MmkvHostObject.mm
-@@ -10,15 +10,20 @@
- #import "../cpp/TypedArray.h"
- #import "JSIUtils.h"
- #import <Foundation/Foundation.h>
-+#import <cmath>
- #import <vector>
- 
--MmkvHostObject::MmkvHostObject(NSString* instanceId, NSString* path, NSString* cryptKey) {
-+MmkvHostObject::MmkvHostObject(NSString* instanceId, NSString* path, NSString* cryptKey,
-+                               size_t expectedCapacity) {
-   NSData* cryptData = cryptKey == nil ? nil : [cryptKey dataUsingEncoding:NSUTF8StringEncoding];
- 
-   // Get appGroup value from info.plist using key "AppGroup"
-   NSString* appGroup = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"AppGroup"];
-   if (appGroup == nil) {
--    instance = [MMKV mmkvWithID:instanceId cryptKey:cryptData rootPath:path];
-+    instance = [MMKV mmkvWithID:instanceId
-+                        cryptKey:cryptData
-+                        rootPath:path
-+                expectedCapacity:expectedCapacity];
-   } else {
-     if (path != nil) {
-       NSLog(@"Warning: `path` is ignored when `appGroup` is set!");
-@@ -64,6 +69,9 @@
+@@ -64,6 +64,9 @@
    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("getAllKeys")));
    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("deleteAll")));
    result.push_back(jsi::PropNameID::forUtf8(rt, std::string("recrypt")));
@@ -178,7 +52,7 @@ index fb80fb9790f40669b6f4ee0bc48ba8798d0317e8..955cd47e43f04d58986721ffa4fffbef
    return result;
  }
  
-@@ -291,6 +299,27 @@
+@@ -303,5 +306,26 @@
          });
    }
  
@@ -203,57 +77,8 @@ index fb80fb9790f40669b6f4ee0bc48ba8798d0317e8..955cd47e43f04d58986721ffa4fffbef
 +        });
 +  }
 +
-   if (propName == "trim") {
-     // MMKV.trim()
-     return jsi::Function::createFromHostFunction(
-diff --git a/ios/MmkvModule.mm b/ios/MmkvModule.mm
-index b2974ac1b7df1ae2258b1fa2fcdea0333a3e0c95..e6690e13016ed99c8538301bd0f8797e9a0418d0 100644
---- a/ios/MmkvModule.mm
-+++ b/ios/MmkvModule.mm
-@@ -4,6 +4,7 @@
- #import <React/RCTBridge+Private.h>
- #import <React/RCTUtils.h>
- #import <jsi/jsi.h>
-+#import <cmath>
- 
- #import "../cpp/TypedArray.h"
- #import "MmkvHostObject.h"
-@@ -29,6 +30,23 @@ + (NSString*)getPropertyAsStringOrNilFromObject:(jsi::Object&)object
-   return string.length() > 0 ? [NSString stringWithUTF8String:string.c_str()] : nil;
+   return jsi::Value::undefined();
  }
- 
-++ (size_t)getExpectedCapacityFromObject:(jsi::Object&)object
-+                                 runtime:(jsi::Runtime&)runtime {
-+  jsi::Value value = object.getProperty(runtime, "expectedCapacity");
-+  if (!value.isNumber()) {
-+    return 0;
-+  }
-+
-+  const auto capacity = value.getNumber();
-+  constexpr auto kMaxExpectedCapacity = 16 * 1024 * 1024;
-+  if (!std::isfinite(capacity) || std::floor(capacity) != capacity || capacity < 0 ||
-+      capacity > kMaxExpectedCapacity) {
-+    throw jsi::JSError(runtime,
-+                        "MMKV expectedCapacity must be a finite value between 0 and 16 MiB.");
-+  }
-+  return static_cast<size_t>(capacity);
-+}
-+
- RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install : (nullable NSString*)storageDirectory) {
-   NSLog(@"Installing global.mmkvCreateNewInstance...");
-   RCTCxxBridge* cxxBridge = (RCTCxxBridge*)_bridge;
-@@ -82,8 +100,10 @@ + (NSString*)getPropertyAsStringOrNilFromObject:(jsi::Object&)object
-         NSString* encryptionKey = [MmkvModule getPropertyAsStringOrNilFromObject:config
-                                                                     propertyName:"encryptionKey"
-                                                                          runtime:runtime];
-+        size_t expectedCapacity = [MmkvModule getExpectedCapacityFromObject:config runtime:runtime];
- 
--        auto instance = std::make_shared<MmkvHostObject>(instanceId, path, encryptionKey);
-+        auto instance = std::make_shared<MmkvHostObject>(instanceId, path, encryptionKey,
-+                                                         expectedCapacity);
-         return jsi::Object::createFromHostObject(runtime, instance);
-       });
-   runtime.global().setProperty(runtime, "mmkvCreateNewInstance", std::move(mmkvCreateNewInstance));
 diff --git a/lib/commonjs/MMKV.js b/lib/commonjs/MMKV.js
 index 291f0ba4f08c10896ea1abbc82c1e631cbf1f53b..9a5b000d4981488a489b2467b80d157fb4e95a5a 100644
 --- a/lib/commonjs/MMKV.js
@@ -288,19 +113,6 @@ index f48545bb5c79e81c2686986f6cf51988919e9bbf..8f06a5534af4629d68f9666bc4b2635b
    };
  };
  exports.createMockMMKV = createMockMMKV;
-diff --git a/lib/commonjs/hooks.js b/lib/commonjs/hooks.js
-index 848a85356c9d093b4f766c038f1f53cb5647a735..fb1f341eaf3e5ff5257d99059145eae8fa0e9d17 100644
---- a/lib/commonjs/hooks.js
-+++ b/lib/commonjs/hooks.js
-@@ -13,7 +13,7 @@ var _react = require("react");
- var _MMKV = require("./MMKV");
- function isConfigurationEqual(left, right) {
-   if (left == null || right == null) return left == null && right == null;
--  return left.encryptionKey === right.encryptionKey && left.id === right.id && left.path === right.path;
-+  return left.encryptionKey === right.encryptionKey && left.expectedCapacity === right.expectedCapacity && left.id === right.id && left.path === right.path;
- }
- let defaultInstance = null;
- function getDefaultInstance() {
 diff --git a/lib/module/MMKV.js b/lib/module/MMKV.js
 index e6f28cedc4476859347b9b4df9c98ac72a026edf..87e298f03349c11fce3fa90c1a96e7782de3fe3b 100644
 --- a/lib/module/MMKV.js
@@ -335,33 +147,11 @@ index 31077a2e151b9d305dae5dc316f9c9b7057ca4a3..9a5f10e7dbaf82f382167406517df160
    };
  };
  //# sourceMappingURL=createMMKV.mock.js.map
-diff --git a/lib/module/hooks.js b/lib/module/hooks.js
-index 94297b07441c06a3952a9c1bf7e1d6a2a26ab647..d9d9983a5847357053b10d679a607e5a2636ca7c 100644
---- a/lib/module/hooks.js
-+++ b/lib/module/hooks.js
-@@ -2,7 +2,7 @@ import { useRef, useState, useMemo, useCallback, useEffect } from 'react';
- import { MMKV } from './MMKV';
- function isConfigurationEqual(left, right) {
-   if (left == null || right == null) return left == null && right == null;
--  return left.encryptionKey === right.encryptionKey && left.id === right.id && left.path === right.path;
-+  return left.encryptionKey === right.encryptionKey && left.expectedCapacity === right.expectedCapacity && left.id === right.id && left.path === right.path;
- }
- let defaultInstance = null;
- function getDefaultInstance() {
 diff --git a/lib/typescript/MMKV.d.ts b/lib/typescript/MMKV.d.ts
-index f2d0b4f2c9f1db500a431fe64472847dcd68ea83..46dd2889efa8f8381547bd6da07a198e421479a0 100644
+index f2d0b4f2c9f1db500a431fe64472847dcd68ea83..c37633d6c0008b1d5302d60da658351786103edf 100644
 --- a/lib/typescript/MMKV.d.ts
 +++ b/lib/typescript/MMKV.d.ts
-@@ -41,6 +41,8 @@ export interface MMKVConfiguration {
-      * ```
-      */
-     encryptionKey?: string;
-+    /** Minimum on-disk capacity reserved for this MMKV instance. */
-+    expectedCapacity?: number;
- }
- /**
-  * Represents a single MMKV instance.
-@@ -100,6 +102,10 @@ interface MMKVInterface {
+@@ -100,6 +100,10 @@ interface MMKVInterface {
       * Encryption keys can have a maximum length of 16 bytes.
       */
      recrypt: (key: string | undefined) => void;
@@ -372,7 +162,7 @@ index f2d0b4f2c9f1db500a431fe64472847dcd68ea83..46dd2889efa8f8381547bd6da07a198e
      /**
       * Trims the storage space and clears memory cache.
       *
-@@ -118,7 +124,7 @@ interface MMKVInterface {
+@@ -118,7 +122,7 @@ interface MMKVInterface {
       */
      addOnValueChangedListener: (onValueChanged: (key: string) => void) => Listener;
  }
@@ -381,7 +171,7 @@ index f2d0b4f2c9f1db500a431fe64472847dcd68ea83..46dd2889efa8f8381547bd6da07a198e
  /**
   * A single MMKV instance.
   */
-@@ -144,6 +150,8 @@ export declare class MMKV implements MMKVInterface {
+@@ -144,6 +148,8 @@ export declare class MMKV implements MMKVInterface {
      getAllKeys(): string[];
      clearAll(): void;
      recrypt(key: string | undefined): void;
@@ -391,19 +181,10 @@ index f2d0b4f2c9f1db500a431fe64472847dcd68ea83..46dd2889efa8f8381547bd6da07a198e
      toString(): string;
      toJSON(): object;
 diff --git a/src/MMKV.ts b/src/MMKV.ts
-index 5b32d703ff898c2ad732f011c54d259e1027fde0..e77937ab2afd2c3b448ec6cf8ec2539700068fcb 100644
+index 5b32d703ff898c2ad732f011c54d259e1027fde0..61cfe0851fb438fc1bacbbbb7bb75d8edf689c81 100644
 --- a/src/MMKV.ts
 +++ b/src/MMKV.ts
-@@ -46,6 +46,8 @@ export interface MMKVConfiguration {
-    * ```
-    */
-   encryptionKey?: string;
-+  /** Minimum on-disk capacity reserved for this MMKV instance. */
-+  expectedCapacity?: number;
- }
- 
- /**
-@@ -106,6 +108,10 @@ interface MMKVInterface {
+@@ -106,6 +106,10 @@ interface MMKVInterface {
     * Encryption keys can have a maximum length of 16 bytes.
     */
    recrypt: (key: string | undefined) => void;
@@ -414,7 +195,7 @@ index 5b32d703ff898c2ad732f011c54d259e1027fde0..e77937ab2afd2c3b448ec6cf8ec25397
    /**
     * Trims the storage space and clears memory cache.
     *
-@@ -139,6 +145,8 @@ export type NativeMMKV = Pick<
+@@ -139,6 +143,8 @@ export type NativeMMKV = Pick<
    | 'getBuffer'
    | 'set'
    | 'recrypt'
@@ -423,7 +204,7 @@ index 5b32d703ff898c2ad732f011c54d259e1027fde0..e77937ab2afd2c3b448ec6cf8ec25397
    | 'trim'
  >;
  
-@@ -238,6 +246,14 @@ export class MMKV implements MMKVInterface {
+@@ -238,6 +244,14 @@ export class MMKV implements MMKVInterface {
      const func = this.getFunctionFromCache('recrypt');
      return func(key);
    }
@@ -451,15 +232,3 @@ index 29ebc9168ef7a58dc11abeb4f3992e2b5c66d6f9..e3b1b7a0bd1e03adf97c39e05f1965d5
      trim: () => {
        console.warn('trim() is not supported in mocked MMKV instances!');
      }
-diff --git a/src/hooks.ts b/src/hooks.ts
-index fd5fdaa6b7bf13940aac970bec216b19c7869d21..5e9e9397a8eb7c8d38d613618cb16095a64a84b4 100644
---- a/src/hooks.ts
-+++ b/src/hooks.ts
-@@ -9,6 +9,7 @@ function isConfigurationEqual(
- 
-   return (
-     left.encryptionKey === right.encryptionKey &&
-+    left.expectedCapacity === right.expectedCapacity &&
-     left.id === right.id &&
-     left.path === right.path
-   );

--- a/.yarn/patches/react-native-mmkv-patch-b5ece05891.patch
+++ b/.yarn/patches/react-native-mmkv-patch-b5ece05891.patch
@@ -47,7 +47,7 @@ index 9ccc10fc28f5a4a0aebd9ded4c266592d000f781..18d96e9b96748f18bf19f1b655fc3699
 +        runtime, jsi::PropNameID::forAscii(runtime, propName), 0,
 +        [this](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments,
 +               size_t count) -> jsi::Value {
-+          instance->sync(mmkv::MMKV_SYNC);
++          instance->sync(MMKV_SYNC);
 +          return jsi::Value::undefined();
 +        });
 +  }

--- a/.yarn/patches/react-native-mmkv-patch-b5ece05891.patch
+++ b/.yarn/patches/react-native-mmkv-patch-b5ece05891.patch
@@ -1,0 +1,465 @@
+diff --git a/android/src/main/cpp/MmkvHostObject.cpp b/android/src/main/cpp/MmkvHostObject.cpp
+index 9ccc10fc28f5a4a0aebd9ded4c266592d000f781..18d96e9b96748f18bf19f1b655fc3699d661b792 100644
+--- a/android/src/main/cpp/MmkvHostObject.cpp
++++ b/android/src/main/cpp/MmkvHostObject.cpp
+@@ -9,20 +9,23 @@
+ #include "MmkvHostObject.h"
+ #include "TypedArray.h"
+ #include <MMKV.h>
++#include <algorithm>
+ #include <android/log.h>
+ #include <string>
+ #include <vector>
+ 
+ MmkvHostObject::MmkvHostObject(const std::string& instanceId, std::string path,
+-                               std::string cryptKey) {
++                               std::string cryptKey, size_t expectedCapacity) {
+   bool hasEncryptionKey = cryptKey.size() > 0;
+   __android_log_print(ANDROID_LOG_INFO, "RNMMKV",
+                       "Creating MMKV instance \"%s\"... (Path: %s, Encrypted: %b)",
+                       instanceId.c_str(), path.c_str(), hasEncryptionKey);
+   std::string* pathPtr = path.size() > 0 ? &path : nullptr;
+   std::string* cryptKeyPtr = cryptKey.size() > 0 ? &cryptKey : nullptr;
+-  instance = MMKV::mmkvWithID(instanceId, mmkv::DEFAULT_MMAP_SIZE, MMKV_SINGLE_PROCESS, cryptKeyPtr,
+-                              pathPtr);
++  const auto capacity = static_cast<int>(std::max<size_t>(
++      mmkv::DEFAULT_MMAP_SIZE, expectedCapacity));
++  instance = MMKV::mmkvWithID(instanceId, capacity, MMKV_SINGLE_PROCESS, cryptKeyPtr, pathPtr,
++                              expectedCapacity);
+ 
+   if (instance == nullptr) {
+     // Check if instanceId is invalid
+@@ -52,6 +55,8 @@ std::vector<jsi::PropNameID> MmkvHostObject::getPropertyNames(jsi::Runtime& rt)
+   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("getAllKeys")));
+   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("deleteAll")));
+   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("recrypt")));
++  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("sync")));
++  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("reload")));
+   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("trim")));
+   return result;
+ }
+@@ -287,6 +292,27 @@ jsi::Value MmkvHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pro
+         });
+   }
+ 
++  if (propName == "sync") {
++    return jsi::Function::createFromHostFunction(
++        runtime, jsi::PropNameID::forAscii(runtime, propName), 0,
++        [this](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments,
++               size_t count) -> jsi::Value {
++          instance->sync(mmkv::MMKV_SYNC);
++          return jsi::Value::undefined();
++        });
++  }
++
++  if (propName == "reload") {
++    return jsi::Function::createFromHostFunction(
++        runtime, jsi::PropNameID::forAscii(runtime, propName), 0,
++        [this](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments,
++               size_t count) -> jsi::Value {
++          instance->clearMemoryCache();
++          instance->allKeys();
++          return jsi::Value::undefined();
++        });
++  }
++
+   if (propName == "trim") {
+     // MMKV.trim()
+     return jsi::Function::createFromHostFunction(
+diff --git a/android/src/main/cpp/MmkvHostObject.h b/android/src/main/cpp/MmkvHostObject.h
+index b2c5573a8bd9a9e83370454984d93bd36fed8bed..865aa2ac07af81151120858e77f8ea142f4a2f7a 100644
+--- a/android/src/main/cpp/MmkvHostObject.h
++++ b/android/src/main/cpp/MmkvHostObject.h
+@@ -15,7 +15,8 @@ using namespace facebook;
+ 
+ class JSI_EXPORT MmkvHostObject : public jsi::HostObject {
+ public:
+-  MmkvHostObject(const std::string& instanceId, std::string path, std::string cryptKey);
++  MmkvHostObject(const std::string& instanceId, std::string path, std::string cryptKey,
++                 size_t expectedCapacity);
+ 
+ public:
+   jsi::Value get(jsi::Runtime&, const jsi::PropNameID& name) override;
+diff --git a/android/src/main/cpp/cpp-adapter.cpp b/android/src/main/cpp/cpp-adapter.cpp
+index d4a728b0bbc8f0fd3f8878409b100d23aad1afbf..f1c58fad5cd3ab3b0f73395fa3a862a5e23b49cd 100644
+--- a/android/src/main/cpp/cpp-adapter.cpp
++++ b/android/src/main/cpp/cpp-adapter.cpp
+@@ -1,6 +1,7 @@
+ #include "MmkvHostObject.h"
+ #include "TypedArray.h"
+ #include <MMKV.h>
++#include <cmath>
+ #include <jni.h>
+ #include <jsi/jsi.h>
+ 
+@@ -13,6 +14,22 @@ std::string getPropertyAsStringOrEmptyFromObject(jsi::Object& object,
+   return value.isString() ? value.asString(runtime).utf8(runtime) : "";
+ }
+ 
++size_t getExpectedCapacityFromObject(jsi::Object& object, jsi::Runtime& runtime) {
++  jsi::Value value = object.getProperty(runtime, "expectedCapacity");
++  if (!value.isNumber()) {
++    return 0;
++  }
++
++  const auto capacity = value.getNumber();
++  constexpr auto kMaxExpectedCapacity = 16 * 1024 * 1024;
++  if (!std::isfinite(capacity) || std::floor(capacity) != capacity || capacity < 0 ||
++      capacity > kMaxExpectedCapacity) {
++    throw jsi::JSError(runtime,
++                        "MMKV expectedCapacity must be a finite value between 0 and 16 MiB.");
++  }
++  return static_cast<size_t>(capacity);
++}
++
+ void install(jsi::Runtime& jsiRuntime) {
+   // MMKV.createNewInstance()
+   auto mmkvCreateNewInstance = jsi::Function::createFromHostFunction(
+@@ -28,8 +45,10 @@ void install(jsi::Runtime& jsiRuntime) {
+         std::string path = getPropertyAsStringOrEmptyFromObject(config, "path", runtime);
+         std::string encryptionKey =
+             getPropertyAsStringOrEmptyFromObject(config, "encryptionKey", runtime);
++        size_t expectedCapacity = getExpectedCapacityFromObject(config, runtime);
+ 
+-        auto instance = std::make_shared<MmkvHostObject>(instanceId, path, encryptionKey);
++        auto instance = std::make_shared<MmkvHostObject>(instanceId, path, encryptionKey,
++                                                         expectedCapacity);
+         return jsi::Object::createFromHostObject(runtime, instance);
+       });
+   jsiRuntime.global().setProperty(jsiRuntime, "mmkvCreateNewInstance",
+diff --git a/ios/MmkvHostObject.h b/ios/MmkvHostObject.h
+index 906156d98aa3dbf15d5e3b0e4fceb37f0315ad1a..33375cce7b73f3b2031af7d99e9b5e1a786c876b 100644
+--- a/ios/MmkvHostObject.h
++++ b/ios/MmkvHostObject.h
+@@ -16,7 +16,8 @@ using namespace facebook;
+ 
+ class JSI_EXPORT MmkvHostObject : public jsi::HostObject {
+ public:
+-  MmkvHostObject(NSString* instanceId, NSString* path, NSString* cryptKey);
++  MmkvHostObject(NSString* instanceId, NSString* path, NSString* cryptKey,
++                 size_t expectedCapacity);
+ 
+ public:
+   jsi::Value get(jsi::Runtime&, const jsi::PropNameID& name) override;
+diff --git a/ios/MmkvHostObject.mm b/ios/MmkvHostObject.mm
+index fb80fb9790f40669b6f4ee0bc48ba8798d0317e8..955cd47e43f04d58986721ffa4fffbefe186d971 100644
+--- a/ios/MmkvHostObject.mm
++++ b/ios/MmkvHostObject.mm
+@@ -10,15 +10,20 @@
+ #import "../cpp/TypedArray.h"
+ #import "JSIUtils.h"
+ #import <Foundation/Foundation.h>
++#import <cmath>
+ #import <vector>
+ 
+-MmkvHostObject::MmkvHostObject(NSString* instanceId, NSString* path, NSString* cryptKey) {
++MmkvHostObject::MmkvHostObject(NSString* instanceId, NSString* path, NSString* cryptKey,
++                               size_t expectedCapacity) {
+   NSData* cryptData = cryptKey == nil ? nil : [cryptKey dataUsingEncoding:NSUTF8StringEncoding];
+ 
+   // Get appGroup value from info.plist using key "AppGroup"
+   NSString* appGroup = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"AppGroup"];
+   if (appGroup == nil) {
+-    instance = [MMKV mmkvWithID:instanceId cryptKey:cryptData rootPath:path];
++    instance = [MMKV mmkvWithID:instanceId
++                        cryptKey:cryptData
++                        rootPath:path
++                expectedCapacity:expectedCapacity];
+   } else {
+     if (path != nil) {
+       NSLog(@"Warning: `path` is ignored when `appGroup` is set!");
+@@ -64,6 +69,9 @@
+   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("getAllKeys")));
+   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("deleteAll")));
+   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("recrypt")));
++  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("sync")));
++  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("reload")));
++  result.push_back(jsi::PropNameID::forUtf8(rt, std::string("trim")));
+   return result;
+ }
+ 
+@@ -291,6 +299,27 @@
+         });
+   }
+ 
++  if (propName == "sync") {
++    return jsi::Function::createFromHostFunction(
++        runtime, jsi::PropNameID::forAscii(runtime, funcName), 0,
++        [this](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments,
++               size_t count) -> jsi::Value {
++          [instance sync];
++          return jsi::Value::undefined();
++        });
++  }
++
++  if (propName == "reload") {
++    return jsi::Function::createFromHostFunction(
++        runtime, jsi::PropNameID::forAscii(runtime, funcName), 0,
++        [this](jsi::Runtime& runtime, const jsi::Value& thisValue, const jsi::Value* arguments,
++               size_t count) -> jsi::Value {
++          [instance clearMemoryCache];
++          [instance allKeys];
++          return jsi::Value::undefined();
++        });
++  }
++
+   if (propName == "trim") {
+     // MMKV.trim()
+     return jsi::Function::createFromHostFunction(
+diff --git a/ios/MmkvModule.mm b/ios/MmkvModule.mm
+index b2974ac1b7df1ae2258b1fa2fcdea0333a3e0c95..e6690e13016ed99c8538301bd0f8797e9a0418d0 100644
+--- a/ios/MmkvModule.mm
++++ b/ios/MmkvModule.mm
+@@ -4,6 +4,7 @@
+ #import <React/RCTBridge+Private.h>
+ #import <React/RCTUtils.h>
+ #import <jsi/jsi.h>
++#import <cmath>
+ 
+ #import "../cpp/TypedArray.h"
+ #import "MmkvHostObject.h"
+@@ -29,6 +30,23 @@ + (NSString*)getPropertyAsStringOrNilFromObject:(jsi::Object&)object
+   return string.length() > 0 ? [NSString stringWithUTF8String:string.c_str()] : nil;
+ }
+ 
+++ (size_t)getExpectedCapacityFromObject:(jsi::Object&)object
++                                 runtime:(jsi::Runtime&)runtime {
++  jsi::Value value = object.getProperty(runtime, "expectedCapacity");
++  if (!value.isNumber()) {
++    return 0;
++  }
++
++  const auto capacity = value.getNumber();
++  constexpr auto kMaxExpectedCapacity = 16 * 1024 * 1024;
++  if (!std::isfinite(capacity) || std::floor(capacity) != capacity || capacity < 0 ||
++      capacity > kMaxExpectedCapacity) {
++    throw jsi::JSError(runtime,
++                        "MMKV expectedCapacity must be a finite value between 0 and 16 MiB.");
++  }
++  return static_cast<size_t>(capacity);
++}
++
+ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install : (nullable NSString*)storageDirectory) {
+   NSLog(@"Installing global.mmkvCreateNewInstance...");
+   RCTCxxBridge* cxxBridge = (RCTCxxBridge*)_bridge;
+@@ -82,8 +100,10 @@ + (NSString*)getPropertyAsStringOrNilFromObject:(jsi::Object&)object
+         NSString* encryptionKey = [MmkvModule getPropertyAsStringOrNilFromObject:config
+                                                                     propertyName:"encryptionKey"
+                                                                          runtime:runtime];
++        size_t expectedCapacity = [MmkvModule getExpectedCapacityFromObject:config runtime:runtime];
+ 
+-        auto instance = std::make_shared<MmkvHostObject>(instanceId, path, encryptionKey);
++        auto instance = std::make_shared<MmkvHostObject>(instanceId, path, encryptionKey,
++                                                         expectedCapacity);
+         return jsi::Object::createFromHostObject(runtime, instance);
+       });
+   runtime.global().setProperty(runtime, "mmkvCreateNewInstance", std::move(mmkvCreateNewInstance));
+diff --git a/lib/commonjs/MMKV.js b/lib/commonjs/MMKV.js
+index 291f0ba4f08c10896ea1abbc82c1e631cbf1f53b..9a5b000d4981488a489b2467b80d157fb4e95a5a 100644
+--- a/lib/commonjs/MMKV.js
++++ b/lib/commonjs/MMKV.js
+@@ -89,6 +89,14 @@ class MMKV {
+     const func = this.getFunctionFromCache('recrypt');
+     return func(key);
+   }
++  sync() {
++    const func = this.getFunctionFromCache('sync');
++    return func();
++  }
++  reload() {
++    const func = this.getFunctionFromCache('reload');
++    return func();
++  }
+   toString() {
+     return `MMKV (${this.id}): [${this.getAllKeys().join(', ')}]`;
+   }
+diff --git a/lib/commonjs/createMMKV.mock.js b/lib/commonjs/createMMKV.mock.js
+index f48545bb5c79e81c2686986f6cf51988919e9bbf..8f06a5534af4629d68f9666bc4b2635b053fd71e 100644
+--- a/lib/commonjs/createMMKV.mock.js
++++ b/lib/commonjs/createMMKV.mock.js
+@@ -31,7 +31,9 @@ const createMockMMKV = () => {
+     contains: key => storage.has(key),
+     recrypt: () => {
+       console.warn('Encryption is not supported in mocked MMKV instances!');
+-    }
++    },
++    sync: () => undefined,
++    reload: () => undefined
+   };
+ };
+ exports.createMockMMKV = createMockMMKV;
+diff --git a/lib/commonjs/hooks.js b/lib/commonjs/hooks.js
+index 848a85356c9d093b4f766c038f1f53cb5647a735..fb1f341eaf3e5ff5257d99059145eae8fa0e9d17 100644
+--- a/lib/commonjs/hooks.js
++++ b/lib/commonjs/hooks.js
+@@ -13,7 +13,7 @@ var _react = require("react");
+ var _MMKV = require("./MMKV");
+ function isConfigurationEqual(left, right) {
+   if (left == null || right == null) return left == null && right == null;
+-  return left.encryptionKey === right.encryptionKey && left.id === right.id && left.path === right.path;
++  return left.encryptionKey === right.encryptionKey && left.expectedCapacity === right.expectedCapacity && left.id === right.id && left.path === right.path;
+ }
+ let defaultInstance = null;
+ function getDefaultInstance() {
+diff --git a/lib/module/MMKV.js b/lib/module/MMKV.js
+index e6f28cedc4476859347b9b4df9c98ac72a026edf..87e298f03349c11fce3fa90c1a96e7782de3fe3b 100644
+--- a/lib/module/MMKV.js
++++ b/lib/module/MMKV.js
+@@ -83,6 +83,14 @@ export class MMKV {
+     const func = this.getFunctionFromCache('recrypt');
+     return func(key);
+   }
++  sync() {
++    const func = this.getFunctionFromCache('sync');
++    return func();
++  }
++  reload() {
++    const func = this.getFunctionFromCache('reload');
++    return func();
++  }
+   trim() {
+     const func = this.getFunctionFromCache('trim');
+     return func();
+diff --git a/lib/module/createMMKV.mock.js b/lib/module/createMMKV.mock.js
+index 31077a2e151b9d305dae5dc316f9c9b7057ca4a3..9a5f10e7dbaf82f382167406517df1608093e428 100644
+--- a/lib/module/createMMKV.mock.js
++++ b/lib/module/createMMKV.mock.js
+@@ -25,7 +25,9 @@ export const createMockMMKV = () => {
+     contains: key => storage.has(key),
+     recrypt: () => {
+       console.warn('Encryption is not supported in mocked MMKV instances!');
+-    }
++    },
++    sync: () => undefined,
++    reload: () => undefined
+   };
+ };
+ //# sourceMappingURL=createMMKV.mock.js.map
+diff --git a/lib/module/hooks.js b/lib/module/hooks.js
+index 94297b07441c06a3952a9c1bf7e1d6a2a26ab647..d9d9983a5847357053b10d679a607e5a2636ca7c 100644
+--- a/lib/module/hooks.js
++++ b/lib/module/hooks.js
+@@ -2,7 +2,7 @@ import { useRef, useState, useMemo, useCallback, useEffect } from 'react';
+ import { MMKV } from './MMKV';
+ function isConfigurationEqual(left, right) {
+   if (left == null || right == null) return left == null && right == null;
+-  return left.encryptionKey === right.encryptionKey && left.id === right.id && left.path === right.path;
++  return left.encryptionKey === right.encryptionKey && left.expectedCapacity === right.expectedCapacity && left.id === right.id && left.path === right.path;
+ }
+ let defaultInstance = null;
+ function getDefaultInstance() {
+diff --git a/lib/typescript/MMKV.d.ts b/lib/typescript/MMKV.d.ts
+index f2d0b4f2c9f1db500a431fe64472847dcd68ea83..46dd2889efa8f8381547bd6da07a198e421479a0 100644
+--- a/lib/typescript/MMKV.d.ts
++++ b/lib/typescript/MMKV.d.ts
+@@ -41,6 +41,8 @@ export interface MMKVConfiguration {
+      * ```
+      */
+     encryptionKey?: string;
++    /** Minimum on-disk capacity reserved for this MMKV instance. */
++    expectedCapacity?: number;
+ }
+ /**
+  * Represents a single MMKV instance.
+@@ -100,6 +102,10 @@ interface MMKVInterface {
+      * Encryption keys can have a maximum length of 16 bytes.
+      */
+     recrypt: (key: string | undefined) => void;
++    /** Flushes this MMKV instance to disk. */
++    sync: () => void;
++    /** Clears the native cache and forces the next read to decode the file. */
++    reload: () => void;
+     /**
+      * Trims the storage space and clears memory cache.
+      *
+@@ -118,7 +124,7 @@ interface MMKVInterface {
+      */
+     addOnValueChangedListener: (onValueChanged: (key: string) => void) => Listener;
+ }
+-export type NativeMMKV = Pick<MMKVInterface, 'clearAll' | 'contains' | 'delete' | 'getAllKeys' | 'getBoolean' | 'getNumber' | 'getString' | 'getBuffer' | 'set' | 'recrypt' | 'trim'>;
++export type NativeMMKV = Pick<MMKVInterface, 'clearAll' | 'contains' | 'delete' | 'getAllKeys' | 'getBoolean' | 'getNumber' | 'getString' | 'getBuffer' | 'set' | 'recrypt' | 'sync' | 'reload' | 'trim'>;
+ /**
+  * A single MMKV instance.
+  */
+@@ -144,6 +150,8 @@ export declare class MMKV implements MMKVInterface {
+     getAllKeys(): string[];
+     clearAll(): void;
+     recrypt(key: string | undefined): void;
++    sync(): void;
++    reload(): void;
+     trim(): void;
+     toString(): string;
+     toJSON(): object;
+diff --git a/src/MMKV.ts b/src/MMKV.ts
+index 5b32d703ff898c2ad732f011c54d259e1027fde0..e77937ab2afd2c3b448ec6cf8ec2539700068fcb 100644
+--- a/src/MMKV.ts
++++ b/src/MMKV.ts
+@@ -46,6 +46,8 @@ export interface MMKVConfiguration {
+    * ```
+    */
+   encryptionKey?: string;
++  /** Minimum on-disk capacity reserved for this MMKV instance. */
++  expectedCapacity?: number;
+ }
+ 
+ /**
+@@ -106,6 +108,10 @@ interface MMKVInterface {
+    * Encryption keys can have a maximum length of 16 bytes.
+    */
+   recrypt: (key: string | undefined) => void;
++  /** Flushes this MMKV instance to disk. */
++  sync: () => void;
++  /** Clears the native cache and forces the next read to decode the file. */
++  reload: () => void;
+   /**
+    * Trims the storage space and clears memory cache.
+    *
+@@ -139,6 +145,8 @@ export type NativeMMKV = Pick<
+   | 'getBuffer'
+   | 'set'
+   | 'recrypt'
++  | 'sync'
++  | 'reload'
+   | 'trim'
+ >;
+ 
+@@ -238,6 +246,14 @@ export class MMKV implements MMKVInterface {
+     const func = this.getFunctionFromCache('recrypt');
+     return func(key);
+   }
++  sync(): void {
++    const func = this.getFunctionFromCache('sync');
++    return func();
++  }
++  reload(): void {
++    const func = this.getFunctionFromCache('reload');
++    return func();
++  }
+   trim() {
+     const func = this.getFunctionFromCache('trim');
+     return func();
+diff --git a/src/createMMKV.mock.ts b/src/createMMKV.mock.ts
+index 29ebc9168ef7a58dc11abeb4f3992e2b5c66d6f9..e3b1b7a0bd1e03adf97c39e05f1965d50c8fff0d 100644
+--- a/src/createMMKV.mock.ts
++++ b/src/createMMKV.mock.ts
+@@ -29,6 +29,8 @@ export const createMockMMKV = (): NativeMMKV => {
+     recrypt: () => {
+       console.warn('Encryption is not supported in mocked MMKV instances!');
+     },
++    sync: () => undefined,
++    reload: () => undefined,
+     trim: () => {
+       console.warn('trim() is not supported in mocked MMKV instances!');
+     }
+diff --git a/src/hooks.ts b/src/hooks.ts
+index fd5fdaa6b7bf13940aac970bec216b19c7869d21..5e9e9397a8eb7c8d38d613618cb16095a64a84b4 100644
+--- a/src/hooks.ts
++++ b/src/hooks.ts
+@@ -9,6 +9,7 @@ function isConfigurationEqual(
+ 
+   return (
+     left.encryptionKey === right.encryptionKey &&
++    left.expectedCapacity === right.expectedCapacity &&
+     left.id === right.id &&
+     left.path === right.path
+   );

--- a/apps/mobile/android/app/src/main/java/com/debank/rabbymobile/KeyringStorageStartupDiagnostics.kt
+++ b/apps/mobile/android/app/src/main/java/com/debank/rabbymobile/KeyringStorageStartupDiagnostics.kt
@@ -1,0 +1,167 @@
+package com.debank.rabbymobile
+
+import android.content.Context
+import android.os.Process
+import android.util.Log
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Regression/debug-only evidence collection for a MMKV file that can be
+ * normalized away as soon as React Native opens it. This runs after
+ * Application.super.onCreate(), but before loadReactNative(), so no JavaScript
+ * MMKV instance has been created by this process yet.
+ */
+object KeyringStorageStartupDiagnostics {
+  private const val TAG = "RabbyKeyringDiagnostic"
+  private const val ROOT_DIRECTORY = "keyring-startup-diagnostics"
+  private const val SNAPSHOTS_DIRECTORY = "snapshots"
+  private const val MAX_SNAPSHOT_COUNT = 6
+  private val KEYRING_FILE_NAMES = arrayOf("mmkv.keyring", "mmkv.keyring.crc")
+
+  fun capture(context: Context) {
+    if (!RabbyStartupTrace.isEnabled()) {
+      return
+    }
+
+    RabbyStartupTrace.beginSection("KeyringDiagnostics.capture")
+    try {
+      val diagnosticsRoot = File(context.filesDir, ROOT_DIRECTORY)
+      val snapshotsRoot = File(diagnosticsRoot, SNAPSHOTS_DIRECTORY)
+      if (!snapshotsRoot.exists() && !snapshotsRoot.mkdirs()) {
+        Log.w(TAG, "capture skipped: unable to create diagnostics directory")
+        return
+      }
+
+      val capturedAtMillis = System.currentTimeMillis()
+      val captureId = "launch-$capturedAtMillis-${Process.myPid()}"
+      val captureDirectory = File(snapshotsRoot, captureId)
+      if (!captureDirectory.mkdirs()) {
+        Log.w(TAG, "capture skipped: unable to create snapshot directory")
+        return
+      }
+
+      val snapshot = JSONObject()
+        .put("schemaVersion", 1)
+        .put("captureId", captureId)
+        .put("capturedAtMillis", capturedAtMillis)
+        .put("applicationId", BuildConfig.APPLICATION_ID)
+        .put("buildType", BuildConfig.BUILD_TYPE)
+        .put("processId", Process.myPid())
+        .put("capturePoint", "application.onCreate.before-loadReactNative")
+      val files = JSONArray()
+      var copiedCount = 0
+      var errorCount = 0
+
+      for (fileName in KEYRING_FILE_NAMES) {
+        val source = File(File(context.filesDir, "mmkv"), fileName)
+        val target = File(captureDirectory, fileName)
+        val fileSnapshot = JSONObject()
+          .put("name", fileName)
+          .put("sourcePresent", source.isFile)
+          .put("sourceByteLength", if (source.isFile) source.length() else JSONObject.NULL)
+          .put("sourceLastModifiedMillis", if (source.isFile) source.lastModified() else JSONObject.NULL)
+
+        if (!source.isFile) {
+          fileSnapshot.put("copyStatus", "missing")
+          files.put(fileSnapshot)
+          continue
+        }
+
+        try {
+          copyFile(source, target)
+          copiedCount += 1
+          fileSnapshot
+            .put("copyStatus", "copied")
+            .put("snapshotByteLength", target.length())
+            .put("snapshotLastModifiedMillis", target.lastModified())
+        } catch (error: Throwable) {
+          errorCount += 1
+          fileSnapshot
+            .put("copyStatus", "error")
+            .put("errorType", error.javaClass.simpleName)
+        }
+
+        files.put(fileSnapshot)
+      }
+
+      snapshot
+        .put("files", files)
+        .put("copiedFileCount", copiedCount)
+        .put("errorCount", errorCount)
+        .put("status", if (errorCount == 0) "complete" else "partial")
+
+      writeJsonAtomically(File(captureDirectory, "metadata.json"), snapshot)
+      appendIndexEntry(File(diagnosticsRoot, "index.jsonl"), snapshot)
+      retainNewestSnapshots(snapshotsRoot, captureDirectory)
+
+      Log.i(
+        TAG,
+        "pre-RN capture id=$captureId copied=$copiedCount errors=$errorCount",
+      )
+      RabbyStartupTrace.instant("KeyringDiagnostics.capture.complete")
+    } catch (error: Throwable) {
+      Log.w(TAG, "pre-RN capture failed: ${error.javaClass.simpleName}")
+      RabbyStartupTrace.instant("KeyringDiagnostics.capture.error")
+    } finally {
+      RabbyStartupTrace.endSection()
+    }
+  }
+
+  private fun copyFile(source: File, target: File) {
+    FileInputStream(source).channel.use { input ->
+      FileOutputStream(target).channel.use { output ->
+        var position = 0L
+        val size = input.size()
+        while (position < size) {
+          val transferred = input.transferTo(position, size - position, output)
+          if (transferred <= 0) {
+            throw IllegalStateException("Unable to complete diagnostic file copy")
+          }
+          position += transferred
+        }
+      }
+    }
+  }
+
+  private fun writeJsonAtomically(target: File, payload: JSONObject) {
+    val temp = File(target.parentFile, "${target.name}.tmp")
+    FileOutputStream(temp).use { output ->
+      output.write(payload.toString().toByteArray(Charsets.UTF_8))
+    }
+
+    if (!temp.renameTo(target)) {
+      temp.delete()
+      throw IllegalStateException("Unable to publish diagnostic metadata")
+    }
+  }
+
+  private fun appendIndexEntry(index: File, payload: JSONObject) {
+    FileOutputStream(index, true).use { output ->
+      output.write((payload.toString() + "\n").toByteArray(Charsets.UTF_8))
+    }
+  }
+
+  private fun retainNewestSnapshots(snapshotsRoot: File, current: File) {
+    val snapshots = snapshotsRoot.listFiles()
+      ?.filter { it.isDirectory && it.name.startsWith("launch-") }
+      ?.sortedBy { it.lastModified() }
+      ?: return
+    val removableCount = (snapshots.size - MAX_SNAPSHOT_COUNT).coerceAtLeast(0)
+
+    snapshots
+      .filter { it != current }
+      .take(removableCount)
+      .forEach(::deleteRecursively)
+  }
+
+  private fun deleteRecursively(file: File) {
+    if (file.isDirectory) {
+      file.listFiles()?.forEach(::deleteRecursively)
+    }
+    file.delete()
+  }
+}

--- a/apps/mobile/android/app/src/main/java/com/debank/rabbymobile/KeyringStorageStartupDiagnostics.kt
+++ b/apps/mobile/android/app/src/main/java/com/debank/rabbymobile/KeyringStorageStartupDiagnostics.kt
@@ -20,7 +20,12 @@ object KeyringStorageStartupDiagnostics {
   private const val ROOT_DIRECTORY = "keyring-startup-diagnostics"
   private const val SNAPSHOTS_DIRECTORY = "snapshots"
   private const val MAX_SNAPSHOT_COUNT = 6
-  private val KEYRING_FILE_NAMES = arrayOf("mmkv.keyring", "mmkv.keyring.crc")
+  private val KEYRING_FILE_NAMES = arrayOf(
+    "mmkv.keyring",
+    "mmkv.keyring.crc",
+    "mmkv.keyring.checkpoint",
+    "mmkv.keyring.checkpoint.crc",
+  )
 
   fun capture(context: Context) {
     if (!RabbyStartupTrace.isEnabled()) {

--- a/apps/mobile/android/app/src/main/java/com/debank/rabbymobile/MainApplication.kt
+++ b/apps/mobile/android/app/src/main/java/com/debank/rabbymobile/MainApplication.kt
@@ -46,6 +46,7 @@ class MainApplication : Application(), ReactApplication {
     try {
       super.onCreate()
       RabbyStartupTrace.instant("Application.super.onCreate")
+      KeyringStorageStartupDiagnostics.capture(this)
       // Rabby currently ships LTR locales only. Set this before React resolves layout direction.
       I18nUtil.instance.allowRTL(this, false)
       I18nUtil.instance.forceRTL(this, false)

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -213,7 +213,7 @@
     "react-native-keychain": "patch:react-native-keychain@npm%3A10.0.0#../../.yarn/patches/react-native-keychain-npm-10.0.0-rabby.patch",
     "react-native-linear-gradient": "^2.8.3",
     "react-native-localize": "3.3.0",
-    "react-native-mmkv": "^2.12.2",
+    "react-native-mmkv": "patch:react-native-mmkv@patch%3Areact-native-mmkv@npm%253A2.12.2%23./.yarn/patches/react-native-mmkv-npm-2.12.2-9efa7abf70.patch%3A%3Aversion=2.12.2&hash=e0fc6c&locator=%2540rabby-wallet%252Fmobile-monorepo%2540workspace%253A.#~/.yarn/patches/react-native-mmkv-patch-b5ece05891.patch",
     "react-native-nitro-modules": "0.35.9",
     "react-native-pager-view": "6.7.0",
     "react-native-permissions": "5.3.0",

--- a/apps/mobile/src/core/services/startupCoreLoader.ts
+++ b/apps/mobile/src/core/services/startupCoreLoader.ts
@@ -23,11 +23,16 @@ import {
 import { logger } from '@/utils/logger';
 
 import {
+  appMMKVInstance,
   appStorage,
-  keyringStorage,
+  keyringCheckpointMMKV,
+  keyringMMKVInstance,
+  legacyKeyringMMKV,
   normalizeKeyringState,
+  persistKeyringState,
 } from '../storage/mmkv';
 import { APP_MMKV_KEYS } from '../storage/mmkvConstants';
+import { inspectPersistedKeyringState } from '../storage/keyringStateMigration';
 import { APP_STORE_NAMES } from '../storage/storeConstant';
 import { PreferenceService } from '../startupServices/preference';
 import { openapi } from '../request';
@@ -65,6 +70,46 @@ function capturePreferenceStorageIssue(
   }
 }
 
+function getKeyringStateSummary(value: unknown) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { valueType: Array.isArray(value) ? 'array' : typeof value };
+  }
+
+  const state = value as Record<string, unknown>;
+  const publicAccountSnapshot = state.publicAccountSnapshot;
+  const accounts =
+    publicAccountSnapshot &&
+    typeof publicAccountSnapshot === 'object' &&
+    !Array.isArray(publicAccountSnapshot)
+      ? (publicAccountSnapshot as Record<string, unknown>).accounts
+      : undefined;
+
+  return {
+    valueType: 'record',
+    hasBooted: typeof state.booted === 'string',
+    hasVault: typeof state.vault === 'string',
+    hasEncryptedKeyringData: state.hasEncryptedKeyringData === true,
+    hasPasswordState:
+      !!state.passwordState && typeof state.passwordState === 'object',
+    unencryptedKeyringCount: Array.isArray(state.unencryptedKeyringData)
+      ? state.unencryptedKeyringData.length
+      : null,
+    publicAccountCount: Array.isArray(accounts) ? accounts.length : null,
+  };
+}
+
+function recordKeyringStorageDiagnostic(
+  event: string,
+  data: Record<string, unknown>,
+) {
+  if (!isNonPublicProductionEnv) {
+    return;
+  }
+
+  logger.info(`[RabbyKeyringStorageDiagnostic] ${event}`, data);
+  traceAndroidInstant(`keyring.storage.${event}`, data);
+}
+
 const keyringClasses = [
   MockWalletConnectKeyring,
   WatchKeyring,
@@ -80,7 +125,49 @@ const keyringClasses = [
 export function loadStartupCoreServices() {
   migrateAppStorage(appStorage);
 
-  const keyringState = normalizeKeyringState().keyringData;
+  const normalizedKeyringState = normalizeKeyringState({
+    onKeyringStateWrite(event) {
+      recordKeyringStorageDiagnostic(`migration.${event.phase}`, {
+        source: event.source,
+        state: getKeyringStateSummary(event.value),
+        ...(event.error
+          ? {
+              error:
+                event.error instanceof Error
+                  ? event.error.message.slice(0, 160)
+                  : String(event.error).slice(0, 160),
+            }
+          : {}),
+      });
+    },
+  });
+  const keyringState = normalizedKeyringState.keyringData;
+
+  recordKeyringStorageDiagnostic('normalize.result', {
+    result: {
+      hasKeyringData: !!normalizedKeyringState.keyringData,
+      hasLegacyData: !!normalizedKeyringState.legacyData,
+      recoverySource: normalizedKeyringState.recoverySource,
+      persistenceBlocked: normalizedKeyringState.persistenceBlocked === true,
+      keyringState: getKeyringStateSummary(normalizedKeyringState.keyringData),
+    },
+    keyring: inspectPersistedKeyringState(
+      keyringMMKVInstance,
+      APP_MMKV_KEYS.LEGACY_KEYRING_STATE,
+    ),
+    checkpoint: inspectPersistedKeyringState(
+      keyringCheckpointMMKV,
+      APP_MMKV_KEYS.LEGACY_KEYRING_STATE,
+    ),
+    legacyKeyring: inspectPersistedKeyringState(
+      legacyKeyringMMKV,
+      APP_MMKV_KEYS.LEGACY_KEYRING_STATE,
+    ),
+    legacy: inspectPersistedKeyringState(
+      appMMKVInstance,
+      APP_MMKV_KEYS.LEGACY_KEYRING_STATE,
+    ),
+  });
   capturePreferenceStorageIssue('before_preference', keyringState);
 
   GnosisKeyring.setOpenapiService(openapi);
@@ -120,9 +207,57 @@ export function loadStartupCoreServices() {
       },
     },
   });
+  recordKeyringStorageDiagnostic('load-store', {
+    input: getKeyringStateSummary(keyringState || {}),
+  });
   keyringService.loadStore(keyringState || {});
+  recordKeyringStorageDiagnostic('load-store.complete', {
+    input: getKeyringStateSummary(keyringState || {}),
+  });
+
+  let keyringPersistSequence = 0;
+  let keyringPersistenceBlocked =
+    normalizedKeyringState.persistenceBlocked === true;
   keyringService.store.subscribe(value => {
-    keyringStorage.setItem(APP_MMKV_KEYS.LEGACY_KEYRING_STATE, value);
+    const sequence = ++keyringPersistSequence;
+    const summary = getKeyringStateSummary(value);
+    recordKeyringStorageDiagnostic('persist.request', {
+      sequence,
+      state: summary,
+    });
+
+    if (keyringPersistenceBlocked) {
+      recordKeyringStorageDiagnostic('persist.blocked', {
+        sequence,
+        state: summary,
+        reason: 'recovery-or-verification-required',
+      });
+      return;
+    }
+
+    try {
+      persistKeyringState({
+        key: APP_MMKV_KEYS.LEGACY_KEYRING_STATE,
+        keyringStorage: keyringMMKVInstance,
+        checkpointStorage: keyringCheckpointMMKV,
+        value,
+      });
+      recordKeyringStorageDiagnostic('persist.complete', {
+        sequence,
+        state: summary,
+      });
+    } catch (error) {
+      keyringPersistenceBlocked = true;
+      recordKeyringStorageDiagnostic('persist.error', {
+        sequence,
+        state: summary,
+        error:
+          error instanceof Error
+            ? error.message.slice(0, 160)
+            : String(error).slice(0, 160),
+      });
+      throw error;
+    }
   });
 
   const preferenceService = new PreferenceService({

--- a/apps/mobile/src/core/services/startupCoreLoader.ts
+++ b/apps/mobile/src/core/services/startupCoreLoader.ts
@@ -27,7 +27,6 @@ import {
   appStorage,
   keyringCheckpointMMKV,
   keyringMMKVInstance,
-  legacyKeyringMMKV,
   normalizeKeyringState,
   persistKeyringState,
 } from '../storage/mmkv';
@@ -157,10 +156,6 @@ export function loadStartupCoreServices() {
     ),
     checkpoint: inspectPersistedKeyringState(
       keyringCheckpointMMKV,
-      APP_MMKV_KEYS.LEGACY_KEYRING_STATE,
-    ),
-    legacyKeyring: inspectPersistedKeyringState(
-      legacyKeyringMMKV,
       APP_MMKV_KEYS.LEGACY_KEYRING_STATE,
     ),
     legacy: inspectPersistedKeyringState(

--- a/apps/mobile/src/core/storage/keyringStateMigration.ts
+++ b/apps/mobile/src/core/storage/keyringStateMigration.ts
@@ -4,11 +4,7 @@ type PersistedKeyringState = Record<string, unknown>;
 
 export type KeyringStateMigrationWriteEvent = {
   phase: 'request' | 'complete' | 'error';
-  source:
-    | 'keyring-v2'
-    | 'keyring-checkpoint'
-    | 'legacy-keyring-mmkv'
-    | 'legacy-default-mmkv';
+  source: 'keyring-primary' | 'keyring-checkpoint' | 'legacy-default-mmkv';
   value: PersistedKeyringState;
   error?: unknown;
 };
@@ -30,7 +26,6 @@ export type KeyringStateStorage = {
   set(key: string, value: string): void;
   sync(): void;
   reload(): void;
-  trim(): void;
 };
 
 type KeyringStateDiagnosticStorage = Pick<
@@ -350,7 +345,8 @@ function hasInvalidKeyringState(states: KeyringStateReadResult[]) {
 }
 
 /**
- * Persists a new primary keyring value with a one-generation rollback copy.
+ * Persists a new value in the established primary keyring file with a
+ * one-generation rollback copy.
  *
  * The checkpoint is intentionally written and verified before mutating the
  * primary file. It is a separate encrypted MMKV file, so a primary decode
@@ -436,19 +432,16 @@ export function normalizePersistedKeyringState({
   key,
   keyringStorage,
   checkpointStorage,
-  legacyKeyringStorage,
   legacyStorage,
   onKeyringStateWrite,
 }: {
   key: string;
   keyringStorage: KeyringStateStorage;
   checkpointStorage: KeyringStateStorage;
-  legacyKeyringStorage: KeyringStateStorage;
   legacyStorage: KeyringStateStorage;
   onKeyringStateWrite?(event: KeyringStateMigrationWriteEvent): void;
 }) {
   const legacy = readPersistedKeyringState(legacyStorage, key);
-  const legacyKeyring = readPersistedKeyringState(legacyKeyringStorage, key);
   const checkpoint = readPersistedKeyringState(checkpointStorage, key);
   const keyring = readPersistedKeyringState(keyringStorage, key);
 
@@ -479,14 +472,13 @@ export function normalizePersistedKeyringState({
     return {
       legacyData: legacy.value,
       keyringData: keyring.value,
-      recoverySource: 'keyring-v2' as const,
+      recoverySource: 'keyring-primary' as const,
       ...(persistenceBlocked ? { persistenceBlocked: true } : {}),
     };
   }
 
   const candidate = getFirstValidKeyringState([
     { source: 'keyring-checkpoint', state: checkpoint },
-    { source: 'legacy-keyring-mmkv', state: legacyKeyring },
     { source: 'legacy-default-mmkv', state: legacy },
   ]);
 
@@ -522,7 +514,7 @@ export function normalizePersistedKeyringState({
     }
 
     if (candidate.source === 'legacy-default-mmkv') {
-      // This is no longer an authority after the v2 primary and encrypted
+      // This is no longer an authority after the primary keyring state and encrypted
       // checkpoint have both been verified. Do not trim here: trim clears the
       // native cache and is not a durability primitive.
       legacyStorage.delete(key);
@@ -539,7 +531,7 @@ export function normalizePersistedKeyringState({
     legacyData: legacy.value,
     keyringData: null,
     recoverySource: null,
-    ...(hasInvalidKeyringState([keyring, checkpoint, legacyKeyring, legacy])
+    ...(hasInvalidKeyringState([keyring, checkpoint, legacy])
       ? { persistenceBlocked: true }
       : {}),
   };

--- a/apps/mobile/src/core/storage/keyringStateMigration.ts
+++ b/apps/mobile/src/core/storage/keyringStateMigration.ts
@@ -1,0 +1,546 @@
+import { stringUtils } from '@rabby-wallet/base-utils';
+
+type PersistedKeyringState = Record<string, unknown>;
+
+export type KeyringStateMigrationWriteEvent = {
+  phase: 'request' | 'complete' | 'error';
+  source:
+    | 'keyring-v2'
+    | 'keyring-checkpoint'
+    | 'legacy-keyring-mmkv'
+    | 'legacy-default-mmkv';
+  value: PersistedKeyringState;
+  error?: unknown;
+};
+
+type KeyringStateReadResult =
+  | {
+      status: 'missing' | 'invalid';
+      value: null;
+    }
+  | {
+      status: 'valid';
+      value: PersistedKeyringState;
+    };
+
+export type KeyringStateStorage = {
+  contains(key: string): boolean;
+  delete(key: string): void;
+  getString(key: string): string | null | undefined;
+  set(key: string, value: string): void;
+  sync(): void;
+  reload(): void;
+  trim(): void;
+};
+
+type KeyringStateDiagnosticStorage = Pick<
+  KeyringStateStorage,
+  'contains' | 'getString'
+> & {
+  getNumber?(key: string): number | null | undefined;
+  getBoolean?(key: string): boolean | null | undefined;
+  getBuffer?(key: string): ArrayBuffer | null | undefined;
+};
+
+type KeyringStateValueProbe = {
+  status: 'value' | 'missing' | 'unavailable' | 'error';
+  length?: number;
+  error?: string;
+};
+
+export type PersistedKeyringStateDiagnostic = {
+  status: KeyringStateReadResult['status'];
+  contains: boolean | 'error';
+  string: KeyringStateValueProbe;
+  parsedValueType?: string;
+  matchesPersistedStateShape?: boolean;
+  nativeFallback?: {
+    number: KeyringStateValueProbe;
+    boolean: KeyringStateValueProbe;
+    buffer: KeyringStateValueProbe;
+  };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getErrorMessage(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replace(/[\r\n]+/g, ' ').slice(0, 160);
+}
+
+function getValueType(value: unknown) {
+  if (value === null) {
+    return 'null';
+  }
+
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+
+  return typeof value;
+}
+
+function probeNativeValue(
+  read: (() => unknown) | undefined,
+): KeyringStateValueProbe {
+  if (!read) {
+    return { status: 'unavailable' };
+  }
+
+  try {
+    const value = read();
+    if (value === null || value === undefined) {
+      return { status: 'missing' };
+    }
+
+    return {
+      status: 'value',
+      ...(value instanceof ArrayBuffer ? { length: value.byteLength } : {}),
+    };
+  } catch (error) {
+    return {
+      status: 'error',
+      error: getErrorMessage(error),
+    };
+  }
+}
+
+/**
+ * This is intentionally a storage-boundary check, not a full keyring-service
+ * validator. It only accepts the persisted state shapes that can safely reach
+ * KeyringService.loadStore(), so an unrelated default-MMKV value cannot be
+ * copied into the encrypted keyring store during the legacy migration.
+ */
+function isPersistedKeyringState(
+  value: unknown,
+): value is PersistedKeyringState {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const hasStatePayload =
+    'booted' in value ||
+    'vault' in value ||
+    'unencryptedKeyringData' in value ||
+    'publicAccountSnapshot' in value;
+
+  if (!hasStatePayload) {
+    return false;
+  }
+
+  if (value.booted !== undefined && typeof value.booted !== 'string') {
+    return false;
+  }
+
+  if (value.vault !== undefined && typeof value.vault !== 'string') {
+    return false;
+  }
+
+  if (
+    value.unencryptedKeyringData !== undefined &&
+    !Array.isArray(value.unencryptedKeyringData)
+  ) {
+    return false;
+  }
+
+  if (
+    value.publicAccountSnapshot !== undefined &&
+    !isRecord(value.publicAccountSnapshot)
+  ) {
+    return false;
+  }
+
+  if (
+    value.hasEncryptedKeyringData !== undefined &&
+    typeof value.hasEncryptedKeyringData !== 'boolean'
+  ) {
+    return false;
+  }
+
+  return value.passwordState === undefined || isRecord(value.passwordState);
+}
+
+function readPersistedKeyringState(
+  storage: Pick<KeyringStateStorage, 'contains' | 'getString'>,
+  key: string,
+): KeyringStateReadResult {
+  let rawValue: string | null | undefined;
+
+  try {
+    rawValue = storage.getString(key);
+  } catch {
+    return { status: 'invalid', value: null };
+  }
+
+  if (!rawValue) {
+    try {
+      return {
+        status: storage.contains(key) ? 'invalid' : 'missing',
+        value: null,
+      };
+    } catch {
+      return { status: 'invalid', value: null };
+    }
+  }
+
+  const parsed = stringUtils.safeParseJSON(rawValue, {
+    defaultValue: null,
+  });
+  if (!isPersistedKeyringState(parsed)) {
+    return { status: 'invalid', value: null };
+  }
+
+  return { status: 'valid', value: parsed };
+}
+
+/**
+ * Non-sensitive native-MMKV read diagnostics for an already-known key.
+ * It deliberately records only getter availability, string length, parser
+ * shape, and bounded native error text; no persisted keyring value is logged.
+ */
+export function inspectPersistedKeyringState(
+  storage: KeyringStateDiagnosticStorage,
+  key: string,
+): PersistedKeyringStateDiagnostic {
+  let contains: boolean | 'error' = 'error';
+  try {
+    contains = storage.contains(key);
+  } catch {
+    // Keep the diagnostic path best-effort. The individual getter error below
+    // is usually more useful than an additional storage exception.
+  }
+
+  let rawValue: string | null | undefined;
+  try {
+    rawValue = storage.getString(key);
+  } catch (error) {
+    return {
+      status: 'invalid',
+      contains,
+      string: {
+        status: 'error',
+        error: getErrorMessage(error),
+      },
+      nativeFallback: {
+        number: probeNativeValue(
+          storage.getNumber ? () => storage.getNumber!(key) : undefined,
+        ),
+        boolean: probeNativeValue(
+          storage.getBoolean ? () => storage.getBoolean!(key) : undefined,
+        ),
+        buffer: probeNativeValue(
+          storage.getBuffer ? () => storage.getBuffer!(key) : undefined,
+        ),
+      },
+    };
+  }
+
+  if (!rawValue) {
+    const status = contains === true ? 'invalid' : 'missing';
+
+    return {
+      status,
+      contains,
+      string: { status: 'missing' },
+      ...(status === 'invalid'
+        ? {
+            nativeFallback: {
+              number: probeNativeValue(
+                storage.getNumber ? () => storage.getNumber!(key) : undefined,
+              ),
+              boolean: probeNativeValue(
+                storage.getBoolean ? () => storage.getBoolean!(key) : undefined,
+              ),
+              buffer: probeNativeValue(
+                storage.getBuffer ? () => storage.getBuffer!(key) : undefined,
+              ),
+            },
+          }
+        : {}),
+    };
+  }
+
+  const parsed = stringUtils.safeParseJSON(rawValue, {
+    defaultValue: null,
+  });
+  const matchesPersistedStateShape = isPersistedKeyringState(parsed);
+  const status = matchesPersistedStateShape ? 'valid' : 'invalid';
+
+  return {
+    status,
+    contains,
+    string: {
+      status: 'value',
+      length: rawValue.length,
+    },
+    parsedValueType: getValueType(parsed),
+    matchesPersistedStateShape,
+    ...(status === 'invalid'
+      ? {
+          nativeFallback: {
+            number: probeNativeValue(
+              storage.getNumber ? () => storage.getNumber!(key) : undefined,
+            ),
+            boolean: probeNativeValue(
+              storage.getBoolean ? () => storage.getBoolean!(key) : undefined,
+            ),
+            buffer: probeNativeValue(
+              storage.getBuffer ? () => storage.getBuffer!(key) : undefined,
+            ),
+          },
+        }
+      : {}),
+  };
+}
+
+export function hasValidPersistedKeyringState(
+  storage: Pick<KeyringStateStorage, 'contains' | 'getString'>,
+  key: string,
+) {
+  return readPersistedKeyringState(storage, key).status === 'valid';
+}
+
+type KeyringStateSource = KeyringStateMigrationWriteEvent['source'];
+
+function serializePersistedKeyringState(value: PersistedKeyringState) {
+  return JSON.stringify(value);
+}
+
+/**
+ * A write is accepted only after it has been flushed and reloaded through the
+ * native decoder. In particular, an MMKV CRC match alone is insufficient: the
+ * Huawei reproducer produced a CRC-valid payload that MiniPB could not parse.
+ */
+function writePersistedKeyringStateAndVerify({
+  storage,
+  key,
+  value,
+}: {
+  storage: KeyringStateStorage;
+  key: string;
+  value: PersistedKeyringState;
+}) {
+  const serializedValue = serializePersistedKeyringState(value);
+  storage.set(key, serializedValue);
+  storage.sync();
+  storage.reload();
+
+  const verified = readPersistedKeyringState(storage, key);
+  if (
+    verified.status !== 'valid' ||
+    serializePersistedKeyringState(verified.value) !== serializedValue
+  ) {
+    throw new Error('Keyring state persistence verification failed.');
+  }
+}
+
+function getFirstValidKeyringState(
+  candidates: Array<{
+    source: KeyringStateSource;
+    state: KeyringStateReadResult;
+  }>,
+) {
+  return candidates.find(candidate => candidate.state.status === 'valid');
+}
+
+function hasInvalidKeyringState(states: KeyringStateReadResult[]) {
+  return states.some(state => state.status === 'invalid');
+}
+
+/**
+ * Persists a new primary keyring value with a one-generation rollback copy.
+ *
+ * The checkpoint is intentionally written and verified before mutating the
+ * primary file. It is a separate encrypted MMKV file, so a primary decode
+ * failure cannot immediately turn into a blank keyring on the next launch.
+ * It is a recovery boundary, not a claim that two MMKV files are independent
+ * implementations of native persistence.
+ */
+export function persistKeyringState({
+  key,
+  keyringStorage,
+  checkpointStorage,
+  value,
+}: {
+  key: string;
+  keyringStorage: KeyringStateStorage;
+  checkpointStorage: KeyringStateStorage;
+  value: PersistedKeyringState;
+}) {
+  if (!isPersistedKeyringState(value)) {
+    throw new Error('Refusing to persist an invalid keyring state shape.');
+  }
+
+  const primary = readPersistedKeyringState(keyringStorage, key);
+  const checkpoint = readPersistedKeyringState(checkpointStorage, key);
+
+  if (primary.status === 'invalid' || checkpoint.status === 'invalid') {
+    throw new Error(
+      'Refusing to overwrite an invalid keyring persistence file.',
+    );
+  }
+
+  if (primary.status === 'valid') {
+    // Keep the last verified primary generation before applying the new state.
+    writePersistedKeyringStateAndVerify({
+      storage: checkpointStorage,
+      key,
+      value: primary.value,
+    });
+    writePersistedKeyringStateAndVerify({
+      storage: keyringStorage,
+      key,
+      value,
+    });
+    return;
+  }
+
+  if (checkpoint.status === 'valid') {
+    // A missing primary can be reconstructed from a verified checkpoint before
+    // it is advanced. An invalid primary is deliberately handled above.
+    writePersistedKeyringStateAndVerify({
+      storage: keyringStorage,
+      key,
+      value: checkpoint.value,
+    });
+    writePersistedKeyringStateAndVerify({
+      storage: checkpointStorage,
+      key,
+      value: checkpoint.value,
+    });
+    writePersistedKeyringStateAndVerify({
+      storage: keyringStorage,
+      key,
+      value,
+    });
+    return;
+  }
+
+  // First bootstrap: there is no prior state to checkpoint yet. Verify the
+  // primary before creating a matching initial checkpoint.
+  writePersistedKeyringStateAndVerify({
+    storage: keyringStorage,
+    key,
+    value,
+  });
+  writePersistedKeyringStateAndVerify({
+    storage: checkpointStorage,
+    key,
+    value,
+  });
+}
+
+export function normalizePersistedKeyringState({
+  key,
+  keyringStorage,
+  checkpointStorage,
+  legacyKeyringStorage,
+  legacyStorage,
+  onKeyringStateWrite,
+}: {
+  key: string;
+  keyringStorage: KeyringStateStorage;
+  checkpointStorage: KeyringStateStorage;
+  legacyKeyringStorage: KeyringStateStorage;
+  legacyStorage: KeyringStateStorage;
+  onKeyringStateWrite?(event: KeyringStateMigrationWriteEvent): void;
+}) {
+  const legacy = readPersistedKeyringState(legacyStorage, key);
+  const legacyKeyring = readPersistedKeyringState(legacyKeyringStorage, key);
+  const checkpoint = readPersistedKeyringState(checkpointStorage, key);
+  const keyring = readPersistedKeyringState(keyringStorage, key);
+
+  if (keyring.status === 'valid') {
+    let persistenceBlocked = false;
+
+    if (checkpoint.status !== 'valid') {
+      try {
+        writePersistedKeyringStateAndVerify({
+          storage: checkpointStorage,
+          key,
+          value: keyring.value,
+        });
+      } catch {
+        // Loading a known-good primary is still safe, but future updates must
+        // not run without a verified rollback point.
+        persistenceBlocked = true;
+      }
+    }
+
+    if (legacy.status === 'valid') {
+      // The encrypted keyring store is authoritative. Remove only a proven
+      // duplicate legacy record so an invalid legacy value remains available
+      // for diagnosis instead of being silently discarded.
+      legacyStorage.delete(key);
+    }
+
+    return {
+      legacyData: legacy.value,
+      keyringData: keyring.value,
+      recoverySource: 'keyring-v2' as const,
+      ...(persistenceBlocked ? { persistenceBlocked: true } : {}),
+    };
+  }
+
+  const candidate = getFirstValidKeyringState([
+    { source: 'keyring-checkpoint', state: checkpoint },
+    { source: 'legacy-keyring-mmkv', state: legacyKeyring },
+    { source: 'legacy-default-mmkv', state: legacy },
+  ]);
+
+  if (candidate?.state.status === 'valid') {
+    const writeEvent = {
+      source: candidate.source,
+      value: candidate.state.value,
+    };
+    onKeyringStateWrite?.({ phase: 'request', ...writeEvent });
+
+    try {
+      if (candidate.source !== 'keyring-checkpoint') {
+        writePersistedKeyringStateAndVerify({
+          storage: checkpointStorage,
+          key,
+          value: candidate.state.value,
+        });
+      }
+      writePersistedKeyringStateAndVerify({
+        storage: keyringStorage,
+        key,
+        value: candidate.state.value,
+      });
+      onKeyringStateWrite?.({ phase: 'complete', ...writeEvent });
+    } catch (error) {
+      onKeyringStateWrite?.({ phase: 'error', ...writeEvent, error });
+      return {
+        legacyData: legacy.value,
+        keyringData: candidate.state.value,
+        recoverySource: candidate.source,
+        persistenceBlocked: true,
+      };
+    }
+
+    if (candidate.source === 'legacy-default-mmkv') {
+      // This is no longer an authority after the v2 primary and encrypted
+      // checkpoint have both been verified. Do not trim here: trim clears the
+      // native cache and is not a durability primitive.
+      legacyStorage.delete(key);
+    }
+
+    return {
+      legacyData: legacy.value,
+      keyringData: candidate.state.value,
+      recoverySource: candidate.source,
+    };
+  }
+
+  return {
+    legacyData: legacy.value,
+    keyringData: null,
+    recoverySource: null,
+    ...(hasInvalidKeyringState([keyring, checkpoint, legacyKeyring, legacy])
+      ? { persistenceBlocked: true }
+      : {}),
+  };
+}

--- a/apps/mobile/src/core/storage/localStorageArchive.ts
+++ b/apps/mobile/src/core/storage/localStorageArchive.ts
@@ -1,0 +1,274 @@
+import RNFS from '@rabby-wallet/react-native-fs';
+
+import { isNonPublicProductionEnv } from '@/constant';
+import { getRabbyAppDbName, getRabbyAppDbPath } from '@/databases/constant';
+import { MMKV_ROOT_PATH } from '@/core/utils/appFS';
+import { shareLocalFile } from '@/utils/shareLocalFile';
+import { keyringMMKV } from './mmkvInstances';
+
+const ARCHIVE_ROOT_DIR_NAME = 'rabby-local-storage-export';
+const ARCHIVE_MIME_TYPE = 'application/zip';
+
+type ArchiveEntry = {
+  sourcePath: string;
+  archivePath: string;
+};
+
+type KeyringDumpEntry =
+  | { type: 'string'; value: string }
+  | { type: 'number'; value: number }
+  | { type: 'boolean'; value: boolean }
+  | { type: 'buffer'; value: number[] }
+  | { type: 'unreadable'; errors: string[] };
+
+function isSafeArchiveFileName(fileName: string) {
+  return /^[a-zA-Z0-9._-]+$/.test(fileName);
+}
+
+function getArchiveTempDir() {
+  return `${
+    RNFS.TemporaryDirectoryPath || RNFS.CachesDirectoryPath
+  }/${ARCHIVE_ROOT_DIR_NAME}`;
+}
+
+async function collectMMKVArchiveEntries(): Promise<ArchiveEntry[]> {
+  if (!(await RNFS.exists(MMKV_ROOT_PATH))) {
+    return [];
+  }
+
+  const files = await RNFS.readDir(MMKV_ROOT_PATH);
+
+  return files.flatMap(file => {
+    if (!file.isFile() || !isSafeArchiveFileName(file.name)) {
+      return [];
+    }
+
+    return [
+      {
+        sourcePath: file.path,
+        archivePath: `mmkv/${file.name}`,
+      },
+    ];
+  });
+}
+
+async function collectSQLiteArchiveEntries(): Promise<ArchiveEntry[]> {
+  const dbPath = getRabbyAppDbPath();
+  const dbName = getRabbyAppDbName();
+  const candidates = [
+    { path: dbPath, archiveName: dbName },
+    { path: `${dbPath}-shm`, archiveName: `${dbName}-shm` },
+    { path: `${dbPath}-wal`, archiveName: `${dbName}-wal` },
+  ];
+
+  const existing = await Promise.all(
+    candidates.map(async candidate => ({
+      ...candidate,
+      exists: await RNFS.exists(candidate.path),
+    })),
+  );
+
+  return existing.flatMap(candidate =>
+    candidate.exists
+      ? [
+          {
+            sourcePath: candidate.path,
+            archivePath: `sqlite/${candidate.archiveName}`,
+          },
+        ]
+      : [],
+  );
+}
+
+function isNativeZipArchiveAvailable() {
+  try {
+    return RNFS.isNativeZipArchiveAvailable();
+  } catch {
+    return false;
+  }
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function readRawKeyringEntry(key: string): KeyringDumpEntry {
+  const errors: string[] = [];
+
+  try {
+    const value = keyringMMKV.getString(key);
+    if (value !== undefined) {
+      return { type: 'string', value };
+    }
+  } catch (error) {
+    errors.push(`string: ${getErrorMessage(error)}`);
+  }
+
+  try {
+    const value = keyringMMKV.getNumber(key);
+    if (value !== undefined) {
+      return { type: 'number', value };
+    }
+  } catch (error) {
+    errors.push(`number: ${getErrorMessage(error)}`);
+  }
+
+  try {
+    const value = keyringMMKV.getBoolean(key);
+    if (value !== undefined) {
+      return { type: 'boolean', value };
+    }
+  } catch (error) {
+    errors.push(`boolean: ${getErrorMessage(error)}`);
+  }
+
+  try {
+    const value = keyringMMKV.getBuffer(key);
+    if (value !== undefined) {
+      return { type: 'buffer', value: Array.from(value) };
+    }
+  } catch (error) {
+    errors.push(`buffer: ${getErrorMessage(error)}`);
+  }
+
+  return { type: 'unreadable', errors };
+}
+
+function createRawKeyringDump() {
+  try {
+    const keys = keyringMMKV.getAllKeys().slice().sort();
+
+    return {
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      encoding: 'native-mmkv-raw-values',
+      keyCount: keys.length,
+      entries: Object.fromEntries(
+        keys.map(key => [key, readRawKeyringEntry(key)]),
+      ),
+    };
+  } catch (error) {
+    return {
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      encoding: 'native-mmkv-raw-values',
+      keyCount: 0,
+      entries: {},
+      error: getErrorMessage(error),
+    };
+  }
+}
+
+async function writeRawKeyringDump({
+  archiveDir,
+  timestamp,
+}: {
+  archiveDir: string;
+  timestamp: number;
+}) {
+  const name = `rabby-keyring-mmkv-${timestamp}.json`;
+  const path = `${archiveDir}/${name}`;
+  const dump = createRawKeyringDump();
+
+  await RNFS.writeFile(path, JSON.stringify(dump, null, 2), 'utf8');
+
+  return {
+    path,
+    name,
+    keyCount: dump.keyCount,
+  };
+}
+
+export type LocalStorageArchiveShareResult = {
+  archive: {
+    dismissed: boolean;
+    fileCount: number;
+  };
+  keyringDump: {
+    dismissed: boolean;
+    keyCount: number;
+  };
+};
+
+/**
+ * Non-production, user-confirmed export of the raw MMKV and SQLite files.
+ * The archive intentionally includes SQLite WAL companions and every current
+ * MMKV-root file so native storage type corruption can be inspected offline.
+ */
+export async function shareCurrentLocalStorageArchive(): Promise<LocalStorageArchiveShareResult> {
+  if (!isNonPublicProductionEnv) {
+    throw new Error(
+      'Local storage export is unavailable in production builds.',
+    );
+  }
+
+  if (!isNativeZipArchiveAvailable()) {
+    throw new Error('Native ZIP export is unavailable in this build.');
+  }
+
+  const [mmkvEntries, sqliteEntries] = await Promise.all([
+    collectMMKVArchiveEntries(),
+    collectSQLiteArchiveEntries(),
+  ]);
+  const entries = [...mmkvEntries, ...sqliteEntries];
+
+  if (entries.length === 0) {
+    throw new Error('No local MMKV or SQLite files are available to export.');
+  }
+
+  const archiveDir = getArchiveTempDir();
+  const timestamp = Date.now();
+  const fileName = `rabby-local-storage-${timestamp}.zip`;
+  const archivePath = `${archiveDir}/${fileName}`;
+
+  await RNFS.mkdir(archiveDir, {
+    NSURLIsExcludedFromBackupKey: true,
+  });
+
+  try {
+    await RNFS.createZipArchive(archivePath, entries);
+    const keyringDump = await writeRawKeyringDump({ archiveDir, timestamp });
+
+    const archiveResult = await shareLocalFile({
+      path: archivePath,
+      name: fileName,
+      mimeType: ARCHIVE_MIME_TYPE,
+      title: 'Share local storage archive',
+      subject: fileName,
+      message: 'Rabby local MMKV and SQLite diagnostic archive',
+      cleanupPaths: [archivePath],
+    });
+    const keyringDumpResult = await shareLocalFile({
+      path: keyringDump.path,
+      name: keyringDump.name,
+      mimeType: 'application/json',
+      title: 'Share raw keyring MMKV dump',
+      subject: keyringDump.name,
+      message: 'Rabby raw keyring MMKV diagnostic dump',
+      cleanupPaths: [keyringDump.path],
+    });
+
+    return {
+      archive: {
+        ...archiveResult,
+        fileCount: entries.length,
+      },
+      keyringDump: {
+        ...keyringDumpResult,
+        keyCount: keyringDump.keyCount,
+      },
+    };
+  } catch (error) {
+    await Promise.allSettled(
+      [archivePath, `${archiveDir}/rabby-keyring-mmkv-${timestamp}.json`].map(
+        async path => {
+          if (await RNFS.exists(path)) {
+            await RNFS.unlink(path);
+          }
+        },
+      ),
+    );
+
+    throw error;
+  }
+}

--- a/apps/mobile/src/core/storage/localStorageArchive.ts
+++ b/apps/mobile/src/core/storage/localStorageArchive.ts
@@ -2,24 +2,35 @@ import RNFS from '@rabby-wallet/react-native-fs';
 
 import { isNonPublicProductionEnv } from '@/constant';
 import { getRabbyAppDbName, getRabbyAppDbPath } from '@/databases/constant';
-import { MMKV_ROOT_PATH } from '@/core/utils/appFS';
+import { APP_DOCUMENT_LIKE_PATH, MMKV_ROOT_PATH } from '@/core/utils/appFS';
 import { shareLocalFile } from '@/utils/shareLocalFile';
-import { keyringMMKV } from './mmkvInstances';
+import { ALL_KNOWN_MMKV_INSTANCES, keyringMMKV } from './mmkvInstances';
 
 const ARCHIVE_ROOT_DIR_NAME = 'rabby-local-storage-export';
 const ARCHIVE_MIME_TYPE = 'application/zip';
+const KEYRING_STARTUP_DIAGNOSTICS_PATH = `${APP_DOCUMENT_LIKE_PATH}/keyring-startup-diagnostics`;
 
 type ArchiveEntry = {
   sourcePath: string;
   archivePath: string;
 };
 
-type KeyringDumpEntry =
+type RawMMKVDumpEntry =
   | { type: 'string'; value: string }
   | { type: 'number'; value: number }
   | { type: 'boolean'; value: boolean }
   | { type: 'buffer'; value: number[] }
   | { type: 'unreadable'; errors: string[] };
+
+type RawMMKVDump = {
+  schemaVersion: 1;
+  generatedAt: string;
+  storageId: string;
+  encoding: 'native-mmkv-raw-values';
+  keyCount: number;
+  entries: Record<string, RawMMKVDumpEntry>;
+  error?: string;
+};
 
 function isSafeArchiveFileName(fileName: string) {
   return /^[a-zA-Z0-9._-]+$/.test(fileName);
@@ -80,6 +91,48 @@ async function collectSQLiteArchiveEntries(): Promise<ArchiveEntry[]> {
   );
 }
 
+async function collectArchiveEntriesRecursively({
+  sourceDir,
+  archiveDir,
+}: {
+  sourceDir: string;
+  archiveDir: string;
+}): Promise<ArchiveEntry[]> {
+  if (!(await RNFS.exists(sourceDir))) {
+    return [];
+  }
+
+  const files = await RNFS.readDir(sourceDir);
+  const entries: ArchiveEntry[] = [];
+
+  for (const file of files) {
+    if (!isSafeArchiveFileName(file.name)) {
+      continue;
+    }
+
+    const archivePath = `${archiveDir}/${file.name}`;
+    if (file.isFile()) {
+      entries.push({ sourcePath: file.path, archivePath });
+    } else if (file.isDirectory()) {
+      entries.push(
+        ...(await collectArchiveEntriesRecursively({
+          sourceDir: file.path,
+          archiveDir: archivePath,
+        })),
+      );
+    }
+  }
+
+  return entries;
+}
+
+async function collectKeyringStartupDiagnosticArchiveEntries() {
+  return collectArchiveEntriesRecursively({
+    sourceDir: KEYRING_STARTUP_DIAGNOSTICS_PATH,
+    archiveDir: 'keyring-startup-diagnostics',
+  });
+}
+
 function isNativeZipArchiveAvailable() {
   try {
     return RNFS.isNativeZipArchiveAvailable();
@@ -92,11 +145,14 @@ function getErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error);
 }
 
-function readRawKeyringEntry(key: string): KeyringDumpEntry {
+function readRawMMKVEntry(
+  storage: typeof keyringMMKV,
+  key: string,
+): RawMMKVDumpEntry {
   const errors: string[] = [];
 
   try {
-    const value = keyringMMKV.getString(key);
+    const value = storage.getString(key);
     if (value !== undefined) {
       return { type: 'string', value };
     }
@@ -105,7 +161,7 @@ function readRawKeyringEntry(key: string): KeyringDumpEntry {
   }
 
   try {
-    const value = keyringMMKV.getNumber(key);
+    const value = storage.getNumber(key);
     if (value !== undefined) {
       return { type: 'number', value };
     }
@@ -114,7 +170,7 @@ function readRawKeyringEntry(key: string): KeyringDumpEntry {
   }
 
   try {
-    const value = keyringMMKV.getBoolean(key);
+    const value = storage.getBoolean(key);
     if (value !== undefined) {
       return { type: 'boolean', value };
     }
@@ -123,7 +179,7 @@ function readRawKeyringEntry(key: string): KeyringDumpEntry {
   }
 
   try {
-    const value = keyringMMKV.getBuffer(key);
+    const value = storage.getBuffer(key);
     if (value !== undefined) {
       return { type: 'buffer', value: Array.from(value) };
     }
@@ -134,23 +190,28 @@ function readRawKeyringEntry(key: string): KeyringDumpEntry {
   return { type: 'unreadable', errors };
 }
 
-function createRawKeyringDump() {
+function createRawMMKVDump(
+  storageId: string,
+  storage: typeof keyringMMKV,
+): RawMMKVDump {
   try {
-    const keys = keyringMMKV.getAllKeys().slice().sort();
+    const keys = storage.getAllKeys().slice().sort();
 
     return {
       schemaVersion: 1,
       generatedAt: new Date().toISOString(),
+      storageId,
       encoding: 'native-mmkv-raw-values',
       keyCount: keys.length,
       entries: Object.fromEntries(
-        keys.map(key => [key, readRawKeyringEntry(key)]),
+        keys.map(key => [key, readRawMMKVEntry(storage, key)]),
       ),
     };
   } catch (error) {
     return {
       schemaVersion: 1,
       generatedAt: new Date().toISOString(),
+      storageId,
       encoding: 'native-mmkv-raw-values',
       keyCount: 0,
       entries: {},
@@ -159,35 +220,48 @@ function createRawKeyringDump() {
   }
 }
 
-async function writeRawKeyringDump({
+async function writeRawMMKVDumps({
   archiveDir,
   timestamp,
 }: {
   archiveDir: string;
   timestamp: number;
 }) {
-  const name = `rabby-keyring-mmkv-${timestamp}.json`;
-  const path = `${archiveDir}/${name}`;
-  const dump = createRawKeyringDump();
+  const entries: ArchiveEntry[] = [];
+  const cleanupPaths: string[] = [];
+  let totalKeyCount = 0;
 
-  await RNFS.writeFile(path, JSON.stringify(dump, null, 2), 'utf8');
+  for (const [storageId, storage] of Object.entries(
+    ALL_KNOWN_MMKV_INSTANCES,
+  ).sort(([firstId], [secondId]) => firstId.localeCompare(secondId))) {
+    const name = `rabby-mmkv-${storageId}-${timestamp}.json`;
+    const path = `${archiveDir}/${name}`;
+    const dump = createRawMMKVDump(storageId, storage);
+
+    await RNFS.writeFile(path, JSON.stringify(dump, null, 2), 'utf8');
+
+    entries.push({
+      sourcePath: path,
+      archivePath: `mmkv-json/${storageId}.json`,
+    });
+    cleanupPaths.push(path);
+    totalKeyCount += dump.keyCount;
+  }
 
   return {
-    path,
-    name,
-    keyCount: dump.keyCount,
+    entries,
+    cleanupPaths,
+    storageCount: entries.length,
+    totalKeyCount,
   };
 }
 
 export type LocalStorageArchiveShareResult = {
-  archive: {
-    dismissed: boolean;
-    fileCount: number;
-  };
-  keyringDump: {
-    dismissed: boolean;
-    keyCount: number;
-  };
+  dismissed: boolean;
+  fileCount: number;
+  mmkvDumpCount: number;
+  mmkvDumpKeyCount: number;
+  keyringStartupDiagnosticFileCount: number;
 };
 
 /**
@@ -206,11 +280,17 @@ export async function shareCurrentLocalStorageArchive(): Promise<LocalStorageArc
     throw new Error('Native ZIP export is unavailable in this build.');
   }
 
-  const [mmkvEntries, sqliteEntries] = await Promise.all([
-    collectMMKVArchiveEntries(),
-    collectSQLiteArchiveEntries(),
-  ]);
-  const entries = [...mmkvEntries, ...sqliteEntries];
+  const [mmkvEntries, sqliteEntries, keyringStartupDiagnosticEntries] =
+    await Promise.all([
+      collectMMKVArchiveEntries(),
+      collectSQLiteArchiveEntries(),
+      collectKeyringStartupDiagnosticArchiveEntries(),
+    ]);
+  const entries = [
+    ...mmkvEntries,
+    ...sqliteEntries,
+    ...keyringStartupDiagnosticEntries,
+  ];
 
   if (entries.length === 0) {
     throw new Error('No local MMKV or SQLite files are available to export.');
@@ -220,14 +300,17 @@ export async function shareCurrentLocalStorageArchive(): Promise<LocalStorageArc
   const timestamp = Date.now();
   const fileName = `rabby-local-storage-${timestamp}.zip`;
   const archivePath = `${archiveDir}/${fileName}`;
+  let rawMMKVDumpPaths: string[] = [];
 
   await RNFS.mkdir(archiveDir, {
     NSURLIsExcludedFromBackupKey: true,
   });
 
   try {
-    await RNFS.createZipArchive(archivePath, entries);
-    const keyringDump = await writeRawKeyringDump({ archiveDir, timestamp });
+    const rawMMKVDumps = await writeRawMMKVDumps({ archiveDir, timestamp });
+    rawMMKVDumpPaths = rawMMKVDumps.cleanupPaths;
+    const archiveEntries = [...entries, ...rawMMKVDumps.entries];
+    await RNFS.createZipArchive(archivePath, archiveEntries);
 
     const archiveResult = await shareLocalFile({
       path: archivePath,
@@ -236,37 +319,23 @@ export async function shareCurrentLocalStorageArchive(): Promise<LocalStorageArc
       title: 'Share local storage archive',
       subject: fileName,
       message: 'Rabby local MMKV and SQLite diagnostic archive',
-      cleanupPaths: [archivePath],
-    });
-    const keyringDumpResult = await shareLocalFile({
-      path: keyringDump.path,
-      name: keyringDump.name,
-      mimeType: 'application/json',
-      title: 'Share raw keyring MMKV dump',
-      subject: keyringDump.name,
-      message: 'Rabby raw keyring MMKV diagnostic dump',
-      cleanupPaths: [keyringDump.path],
+      cleanupPaths: [archivePath, ...rawMMKVDumpPaths],
     });
 
     return {
-      archive: {
-        ...archiveResult,
-        fileCount: entries.length,
-      },
-      keyringDump: {
-        ...keyringDumpResult,
-        keyCount: keyringDump.keyCount,
-      },
+      ...archiveResult,
+      fileCount: archiveEntries.length,
+      mmkvDumpCount: rawMMKVDumps.storageCount,
+      mmkvDumpKeyCount: rawMMKVDumps.totalKeyCount,
+      keyringStartupDiagnosticFileCount: keyringStartupDiagnosticEntries.length,
     };
   } catch (error) {
     await Promise.allSettled(
-      [archivePath, `${archiveDir}/rabby-keyring-mmkv-${timestamp}.json`].map(
-        async path => {
-          if (await RNFS.exists(path)) {
-            await RNFS.unlink(path);
-          }
-        },
-      ),
+      [archivePath, ...rawMMKVDumpPaths].map(async path => {
+        if (await RNFS.exists(path)) {
+          await RNFS.unlink(path);
+        }
+      }),
     );
 
     throw error;

--- a/apps/mobile/src/core/storage/mmkv.keyringMigration.test.ts
+++ b/apps/mobile/src/core/storage/mmkv.keyringMigration.test.ts
@@ -69,7 +69,6 @@ class FailingMemoryMMKV extends MemoryMMKV {
 
 function loadFixture() {
   const defaultMMKV = new MemoryMMKV();
-  const legacyKeyringMMKV = new MemoryMMKV();
   const keyringMMKV = new MemoryMMKV();
   const checkpointMMKV = new MemoryMMKV();
   const normalizeKeyringState = () =>
@@ -77,13 +76,11 @@ function loadFixture() {
       key: KEY,
       keyringStorage: keyringMMKV,
       checkpointStorage: checkpointMMKV,
-      legacyKeyringStorage: legacyKeyringMMKV,
       legacyStorage: defaultMMKV,
     });
 
   return {
     defaultMMKV,
-    legacyKeyringMMKV,
     keyringMMKV,
     checkpointMMKV,
     normalizeKeyringState,
@@ -117,7 +114,6 @@ describe('keyring state legacy migration', () => {
       key: KEY,
       keyringStorage: keyringMMKV,
       checkpointStorage: new MemoryMMKV(),
-      legacyKeyringStorage: new MemoryMMKV(),
       legacyStorage: defaultMMKV,
       onKeyringStateWrite: event => events.push(event.phase),
     });
@@ -133,7 +129,7 @@ describe('keyring state legacy migration', () => {
     expect(normalizeKeyringState()).toEqual({
       legacyData: null,
       keyringData: VALID_DESTINATION_STATE,
-      recoverySource: 'keyring-v2',
+      recoverySource: 'keyring-primary',
     });
     expect(keyringMMKV.getString(KEY)).toBe(
       JSON.stringify(VALID_DESTINATION_STATE),
@@ -179,7 +175,7 @@ describe('keyring state legacy migration', () => {
     expect(normalizeKeyringState()).toEqual({
       legacyData: VALID_LEGACY_STATE,
       keyringData: VALID_DESTINATION_STATE,
-      recoverySource: 'keyring-v2',
+      recoverySource: 'keyring-primary',
     });
     expect(keyringMMKV.getString(KEY)).toBe(
       JSON.stringify(VALID_DESTINATION_STATE),
@@ -214,30 +210,7 @@ describe('keyring state legacy migration', () => {
     });
   });
 
-  it('migrates the original encrypted keyring file into v2 without deleting the fallback', () => {
-    const {
-      legacyKeyringMMKV,
-      keyringMMKV,
-      checkpointMMKV,
-      normalizeKeyringState,
-    } = loadFixture();
-    legacyKeyringMMKV.set(KEY, JSON.stringify(VALID_LEGACY_STATE));
-
-    expect(normalizeKeyringState()).toEqual({
-      legacyData: null,
-      keyringData: VALID_LEGACY_STATE,
-      recoverySource: 'legacy-keyring-mmkv',
-    });
-    expect(keyringMMKV.getString(KEY)).toBe(JSON.stringify(VALID_LEGACY_STATE));
-    expect(checkpointMMKV.getString(KEY)).toBe(
-      JSON.stringify(VALID_LEGACY_STATE),
-    );
-    expect(legacyKeyringMMKV.getString(KEY)).toBe(
-      JSON.stringify(VALID_LEGACY_STATE),
-    );
-  });
-
-  it('restores an invalid v2 primary from its encrypted checkpoint', () => {
+  it('restores an invalid primary keyring state from its encrypted checkpoint', () => {
     const { keyringMMKV, checkpointMMKV, normalizeKeyringState } =
       loadFixture();
     keyringMMKV.set(KEY, '{invalid-json');
@@ -253,7 +226,7 @@ describe('keyring state legacy migration', () => {
     );
   });
 
-  it('writes a verified rollback copy before advancing the v2 primary', () => {
+  it('writes a verified rollback copy before advancing the primary keyring state', () => {
     const keyringMMKV = new MemoryMMKV();
     const checkpointMMKV = new MemoryMMKV();
     keyringMMKV.set(KEY, JSON.stringify(VALID_DESTINATION_STATE));
@@ -273,7 +246,7 @@ describe('keyring state legacy migration', () => {
     expect(keyringMMKV.sync).toHaveBeenCalledTimes(1);
   });
 
-  it('does not mutate the v2 primary when the rollback checkpoint cannot be written', () => {
+  it('does not mutate the primary keyring state when the rollback checkpoint cannot be written', () => {
     const keyringMMKV = new MemoryMMKV();
     const checkpointMMKV = new FailingMemoryMMKV();
     keyringMMKV.set(KEY, JSON.stringify(VALID_DESTINATION_STATE));

--- a/apps/mobile/src/core/storage/mmkv.keyringMigration.test.ts
+++ b/apps/mobile/src/core/storage/mmkv.keyringMigration.test.ts
@@ -1,0 +1,294 @@
+import {
+  inspectPersistedKeyringState,
+  normalizePersistedKeyringState,
+  persistKeyringState,
+  type KeyringStateStorage,
+} from './keyringStateMigration';
+
+const KEY = 'keyringState';
+
+const VALID_DESTINATION_STATE = {
+  booted: 'destination-booted',
+  vault: 'destination-vault',
+  hasEncryptedKeyringData: true,
+};
+
+const VALID_LEGACY_STATE = {
+  booted: 'legacy-booted',
+  vault: 'legacy-vault',
+  hasEncryptedKeyringData: true,
+};
+
+const BIG_NUMBER_LIKE_VALUE = {
+  c: [1, 2, 3],
+  e: 2,
+  s: 1,
+};
+
+class MemoryMMKV implements KeyringStateStorage {
+  protected values = new Map<string, string | number>();
+
+  trim = jest.fn();
+  sync = jest.fn();
+  reload = jest.fn();
+
+  contains(key: string) {
+    return this.values.has(key);
+  }
+
+  delete(key: string) {
+    this.values.delete(key);
+  }
+
+  getNumber(key: string) {
+    const value = this.values.get(key);
+    return typeof value === 'number' ? value : null;
+  }
+
+  getString(key: string) {
+    const value = this.values.get(key);
+    return typeof value === 'string' ? value : null;
+  }
+
+  set(key: string, value: string | number) {
+    this.values.set(key, value);
+  }
+}
+
+class FailingMemoryMMKV extends MemoryMMKV {
+  failNextSet = false;
+
+  set(key: string, value: string | number) {
+    if (this.failNextSet) {
+      this.failNextSet = false;
+      throw new Error('expected test write failure');
+    }
+    super.set(key, value);
+  }
+}
+
+function loadFixture() {
+  const defaultMMKV = new MemoryMMKV();
+  const legacyKeyringMMKV = new MemoryMMKV();
+  const keyringMMKV = new MemoryMMKV();
+  const checkpointMMKV = new MemoryMMKV();
+  const normalizeKeyringState = () =>
+    normalizePersistedKeyringState({
+      key: KEY,
+      keyringStorage: keyringMMKV,
+      checkpointStorage: checkpointMMKV,
+      legacyKeyringStorage: legacyKeyringMMKV,
+      legacyStorage: defaultMMKV,
+    });
+
+  return {
+    defaultMMKV,
+    legacyKeyringMMKV,
+    keyringMMKV,
+    checkpointMMKV,
+    normalizeKeyringState,
+  };
+}
+
+describe('keyring state legacy migration', () => {
+  it('migrates a valid legacy keyring state only when the encrypted store is absent', () => {
+    const { defaultMMKV, keyringMMKV, checkpointMMKV, normalizeKeyringState } =
+      loadFixture();
+    defaultMMKV.set(KEY, JSON.stringify(VALID_LEGACY_STATE));
+
+    expect(normalizeKeyringState()).toEqual({
+      legacyData: VALID_LEGACY_STATE,
+      keyringData: VALID_LEGACY_STATE,
+      recoverySource: 'legacy-default-mmkv',
+    });
+    expect(keyringMMKV.getString(KEY)).toBe(JSON.stringify(VALID_LEGACY_STATE));
+    expect(checkpointMMKV.getString(KEY)).toBe(
+      JSON.stringify(VALID_LEGACY_STATE),
+    );
+    expect(defaultMMKV.contains(KEY)).toBe(false);
+  });
+
+  it('reports every legacy-to-keyring write phase through the migration observer', () => {
+    const { defaultMMKV, keyringMMKV } = loadFixture();
+    const events: string[] = [];
+    defaultMMKV.set(KEY, JSON.stringify(VALID_LEGACY_STATE));
+
+    normalizePersistedKeyringState({
+      key: KEY,
+      keyringStorage: keyringMMKV,
+      checkpointStorage: new MemoryMMKV(),
+      legacyKeyringStorage: new MemoryMMKV(),
+      legacyStorage: defaultMMKV,
+      onKeyringStateWrite: event => events.push(event.phase),
+    });
+
+    expect(events).toEqual(['request', 'complete']);
+  });
+
+  it('keeps a valid encrypted keyring state when legacy data is malformed', () => {
+    const { defaultMMKV, keyringMMKV, normalizeKeyringState } = loadFixture();
+    defaultMMKV.set(KEY, JSON.stringify({ accidental: 1 }));
+    keyringMMKV.set(KEY, JSON.stringify(VALID_DESTINATION_STATE));
+
+    expect(normalizeKeyringState()).toEqual({
+      legacyData: null,
+      keyringData: VALID_DESTINATION_STATE,
+      recoverySource: 'keyring-v2',
+    });
+    expect(keyringMMKV.getString(KEY)).toBe(
+      JSON.stringify(VALID_DESTINATION_STATE),
+    );
+    expect(defaultMMKV.getString(KEY)).toBe(JSON.stringify({ accidental: 1 }));
+  });
+
+  it('does not migrate a scalar legacy value into the encrypted keyring store', () => {
+    const { defaultMMKV, keyringMMKV, normalizeKeyringState } = loadFixture();
+    defaultMMKV.set(KEY, JSON.stringify(7));
+
+    expect(normalizeKeyringState()).toEqual({
+      legacyData: null,
+      keyringData: null,
+      recoverySource: null,
+      persistenceBlocked: true,
+    });
+    expect(keyringMMKV.contains(KEY)).toBe(false);
+    expect(defaultMMKV.getString(KEY)).toBe(JSON.stringify(7));
+  });
+
+  it('does not migrate a BigNumber-like legacy object into the encrypted keyring store', () => {
+    const { defaultMMKV, keyringMMKV, normalizeKeyringState } = loadFixture();
+    defaultMMKV.set(KEY, JSON.stringify(BIG_NUMBER_LIKE_VALUE));
+
+    expect(normalizeKeyringState()).toEqual({
+      legacyData: null,
+      keyringData: null,
+      recoverySource: null,
+      persistenceBlocked: true,
+    });
+    expect(keyringMMKV.contains(KEY)).toBe(false);
+    expect(defaultMMKV.getString(KEY)).toBe(
+      JSON.stringify(BIG_NUMBER_LIKE_VALUE),
+    );
+  });
+
+  it('keeps a valid encrypted keyring state authoritative over a valid legacy duplicate', () => {
+    const { defaultMMKV, keyringMMKV, normalizeKeyringState } = loadFixture();
+    defaultMMKV.set(KEY, JSON.stringify(VALID_LEGACY_STATE));
+    keyringMMKV.set(KEY, JSON.stringify(VALID_DESTINATION_STATE));
+
+    expect(normalizeKeyringState()).toEqual({
+      legacyData: VALID_LEGACY_STATE,
+      keyringData: VALID_DESTINATION_STATE,
+      recoverySource: 'keyring-v2',
+    });
+    expect(keyringMMKV.getString(KEY)).toBe(
+      JSON.stringify(VALID_DESTINATION_STATE),
+    );
+    expect(defaultMMKV.contains(KEY)).toBe(false);
+  });
+
+  it('does not treat a native numeric keyring value as a valid keyring state', () => {
+    const { keyringMMKV, normalizeKeyringState } = loadFixture();
+    keyringMMKV.set(KEY, 7);
+
+    expect(normalizeKeyringState()).toEqual({
+      legacyData: null,
+      keyringData: null,
+      recoverySource: null,
+      persistenceBlocked: true,
+    });
+    expect(keyringMMKV.getNumber(KEY)).toBe(7);
+  });
+
+  it('reports a native numeric keyring value without logging the value itself', () => {
+    const { keyringMMKV } = loadFixture();
+    keyringMMKV.set(KEY, 7);
+
+    expect(inspectPersistedKeyringState(keyringMMKV, KEY)).toMatchObject({
+      status: 'invalid',
+      contains: true,
+      string: { status: 'missing' },
+      nativeFallback: {
+        number: { status: 'value' },
+      },
+    });
+  });
+
+  it('migrates the original encrypted keyring file into v2 without deleting the fallback', () => {
+    const {
+      legacyKeyringMMKV,
+      keyringMMKV,
+      checkpointMMKV,
+      normalizeKeyringState,
+    } = loadFixture();
+    legacyKeyringMMKV.set(KEY, JSON.stringify(VALID_LEGACY_STATE));
+
+    expect(normalizeKeyringState()).toEqual({
+      legacyData: null,
+      keyringData: VALID_LEGACY_STATE,
+      recoverySource: 'legacy-keyring-mmkv',
+    });
+    expect(keyringMMKV.getString(KEY)).toBe(JSON.stringify(VALID_LEGACY_STATE));
+    expect(checkpointMMKV.getString(KEY)).toBe(
+      JSON.stringify(VALID_LEGACY_STATE),
+    );
+    expect(legacyKeyringMMKV.getString(KEY)).toBe(
+      JSON.stringify(VALID_LEGACY_STATE),
+    );
+  });
+
+  it('restores an invalid v2 primary from its encrypted checkpoint', () => {
+    const { keyringMMKV, checkpointMMKV, normalizeKeyringState } =
+      loadFixture();
+    keyringMMKV.set(KEY, '{invalid-json');
+    checkpointMMKV.set(KEY, JSON.stringify(VALID_DESTINATION_STATE));
+
+    expect(normalizeKeyringState()).toEqual({
+      legacyData: null,
+      keyringData: VALID_DESTINATION_STATE,
+      recoverySource: 'keyring-checkpoint',
+    });
+    expect(keyringMMKV.getString(KEY)).toBe(
+      JSON.stringify(VALID_DESTINATION_STATE),
+    );
+  });
+
+  it('writes a verified rollback copy before advancing the v2 primary', () => {
+    const keyringMMKV = new MemoryMMKV();
+    const checkpointMMKV = new MemoryMMKV();
+    keyringMMKV.set(KEY, JSON.stringify(VALID_DESTINATION_STATE));
+
+    persistKeyringState({
+      key: KEY,
+      keyringStorage: keyringMMKV,
+      checkpointStorage: checkpointMMKV,
+      value: VALID_LEGACY_STATE,
+    });
+
+    expect(checkpointMMKV.getString(KEY)).toBe(
+      JSON.stringify(VALID_DESTINATION_STATE),
+    );
+    expect(keyringMMKV.getString(KEY)).toBe(JSON.stringify(VALID_LEGACY_STATE));
+    expect(checkpointMMKV.sync).toHaveBeenCalledTimes(1);
+    expect(keyringMMKV.sync).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not mutate the v2 primary when the rollback checkpoint cannot be written', () => {
+    const keyringMMKV = new MemoryMMKV();
+    const checkpointMMKV = new FailingMemoryMMKV();
+    keyringMMKV.set(KEY, JSON.stringify(VALID_DESTINATION_STATE));
+    checkpointMMKV.failNextSet = true;
+
+    expect(() =>
+      persistKeyringState({
+        key: KEY,
+        keyringStorage: keyringMMKV,
+        checkpointStorage: checkpointMMKV,
+        value: VALID_LEGACY_STATE,
+      }),
+    ).toThrow('expected test write failure');
+    expect(keyringMMKV.getString(KEY)).toBe(
+      JSON.stringify(VALID_DESTINATION_STATE),
+    );
+  });
+});

--- a/apps/mobile/src/core/storage/mmkv.ts
+++ b/apps/mobile/src/core/storage/mmkv.ts
@@ -23,12 +23,7 @@ import {
   zMutative,
   zPersist,
 } from '../utils/reexports';
-import {
-  appMMKV,
-  keyringCheckpointMMKV,
-  keyringMMKV,
-  legacyKeyringMMKV,
-} from './mmkvInstances';
+import { appMMKV, keyringCheckpointMMKV, keyringMMKV } from './mmkvInstances';
 import { APP_MMKV_KEYS, MMKV_FILE_NAMES } from './mmkvConstants';
 import { unwrapDuplicatedJsonString } from './mmkvJsonCompat';
 import {
@@ -138,9 +133,8 @@ const {
 
 const { storage: keyringStorage, mmkv: keyringMMKVInstance } =
   makeMMKVStorageByInstance(keyringMMKV, {
-    id: MMKV_FILE_NAMES.KEYRING_V2,
+    id: MMKV_FILE_NAMES.KEYRING,
     encryptionKey: 'keyring',
-    expectedCapacity: 256 * 1024,
   });
 
 export function normalizeKeyringState(options?: {
@@ -150,7 +144,6 @@ export function normalizeKeyringState(options?: {
     key: APP_MMKV_KEYS.LEGACY_KEYRING_STATE,
     keyringStorage: keyringMMKVInstance,
     checkpointStorage: keyringCheckpointMMKV,
-    legacyKeyringStorage: legacyKeyringMMKV,
     legacyStorage: appMMKVInstance,
     onKeyringStateWrite: options?.onKeyringStateWrite,
   });
@@ -168,7 +161,6 @@ export {
   appMMKVInstance,
   keyringMMKVInstance,
   keyringCheckpointMMKV,
-  legacyKeyringMMKV,
   persistKeyringState,
 };
 
@@ -183,10 +175,6 @@ export const IS_BOOTED_USER =
   ) ||
   hasValidPersistedKeyringState(
     keyringCheckpointMMKV,
-    APP_MMKV_KEYS.LEGACY_KEYRING_STATE,
-  ) ||
-  hasValidPersistedKeyringState(
-    legacyKeyringMMKV,
     APP_MMKV_KEYS.LEGACY_KEYRING_STATE,
   );
 
@@ -440,7 +428,6 @@ export function removeLegacyMMKVStorageByKey(key: `@${string}`) {
         default:
         case MMKV_FILE_NAMES.DEFAULT:
         case MMKV_FILE_NAMES.KEYRING:
-        case MMKV_FILE_NAMES.KEYRING_V2:
         case MMKV_FILE_NAMES.KEYRING_CHECKPOINT:
         case MMKV_FILE_NAMES.KEYCHAIN: {
           if (fileExist) {

--- a/apps/mobile/src/core/storage/mmkv.ts
+++ b/apps/mobile/src/core/storage/mmkv.ts
@@ -23,9 +23,20 @@ import {
   zMutative,
   zPersist,
 } from '../utils/reexports';
-import { appMMKV, keyringMMKV } from './mmkvInstances';
+import {
+  appMMKV,
+  keyringCheckpointMMKV,
+  keyringMMKV,
+  legacyKeyringMMKV,
+} from './mmkvInstances';
 import { APP_MMKV_KEYS, MMKV_FILE_NAMES } from './mmkvConstants';
 import { unwrapDuplicatedJsonString } from './mmkvJsonCompat';
+import {
+  hasValidPersistedKeyringState,
+  normalizePersistedKeyringState,
+  persistKeyringState,
+  type KeyringStateMigrationWriteEvent,
+} from './keyringStateMigration';
 // import { lendingCacheStorage } from '@/screens/Lending/hooks';
 
 export function getJsonValueStringCompat(
@@ -127,31 +138,22 @@ const {
 
 const { storage: keyringStorage, mmkv: keyringMMKVInstance } =
   makeMMKVStorageByInstance(keyringMMKV, {
-    id: MMKV_FILE_NAMES.KEYRING,
+    id: MMKV_FILE_NAMES.KEYRING_V2,
     encryptionKey: 'keyring',
+    expectedCapacity: 256 * 1024,
   });
 
-export function normalizeKeyringState() {
-  const legacyData = appStorage.getItem(APP_MMKV_KEYS.LEGACY_KEYRING_STATE);
-  const result = {
-    legacyData,
-    keyringData:
-      keyringStorage.getItem(APP_MMKV_KEYS.LEGACY_KEYRING_STATE) || legacyData,
-  };
-
-  if (legacyData) appMMKVInstance.trim();
-
-  // console.debug('result.legacyData', result.legacyData);
-  // console.debug('result.keyringData', result.keyringData);
-  if (!result.legacyData) return result;
-
-  keyringStorage.setItem(APP_MMKV_KEYS.LEGACY_KEYRING_STATE, result.legacyData);
-  result.keyringData = result.legacyData;
-
-  appStorage.removeItem(APP_MMKV_KEYS.LEGACY_KEYRING_STATE);
-  appMMKVInstance.trim();
-
-  return result;
+export function normalizeKeyringState(options?: {
+  onKeyringStateWrite?(event: KeyringStateMigrationWriteEvent): void;
+}) {
+  return normalizePersistedKeyringState({
+    key: APP_MMKV_KEYS.LEGACY_KEYRING_STATE,
+    keyringStorage: keyringMMKVInstance,
+    checkpointStorage: keyringCheckpointMMKV,
+    legacyKeyringStorage: legacyKeyringMMKV,
+    legacyStorage: appMMKVInstance,
+    onKeyringStateWrite: options?.onKeyringStateWrite,
+  });
 }
 
 export const appMMKVForDebug = __DEV__
@@ -160,11 +162,33 @@ export const appMMKVForDebug = __DEV__
 export const keyringMMKVForDebug = __DEV__
   ? keyringMMKVInstance
   : (null as any as typeof keyringMMKVInstance);
-export { appStorage, keyringStorage, appMMKVInstance, keyringMMKVInstance };
+export {
+  appStorage,
+  keyringStorage,
+  appMMKVInstance,
+  keyringMMKVInstance,
+  keyringCheckpointMMKV,
+  legacyKeyringMMKV,
+  persistKeyringState,
+};
 
 export const IS_BOOTED_USER =
-  !!appStorage.getItem(APP_MMKV_KEYS.LEGACY_KEYRING_STATE) ||
-  !!keyringStorage.getItem(APP_MMKV_KEYS.LEGACY_KEYRING_STATE);
+  hasValidPersistedKeyringState(
+    appMMKVInstance,
+    APP_MMKV_KEYS.LEGACY_KEYRING_STATE,
+  ) ||
+  hasValidPersistedKeyringState(
+    keyringMMKVInstance,
+    APP_MMKV_KEYS.LEGACY_KEYRING_STATE,
+  ) ||
+  hasValidPersistedKeyringState(
+    keyringCheckpointMMKV,
+    APP_MMKV_KEYS.LEGACY_KEYRING_STATE,
+  ) ||
+  hasValidPersistedKeyringState(
+    legacyKeyringMMKV,
+    APP_MMKV_KEYS.LEGACY_KEYRING_STATE,
+  );
 
 export const enum MMKVStorageStrategy {
   'legacy' = -1,
@@ -416,6 +440,8 @@ export function removeLegacyMMKVStorageByKey(key: `@${string}`) {
         default:
         case MMKV_FILE_NAMES.DEFAULT:
         case MMKV_FILE_NAMES.KEYRING:
+        case MMKV_FILE_NAMES.KEYRING_V2:
+        case MMKV_FILE_NAMES.KEYRING_CHECKPOINT:
         case MMKV_FILE_NAMES.KEYCHAIN: {
           if (fileExist) {
             RNHelpers.iosExcludeFileFromBackup(filePath).then(success => {

--- a/apps/mobile/src/core/storage/mmkvConstants.ts
+++ b/apps/mobile/src/core/storage/mmkvConstants.ts
@@ -2,7 +2,6 @@ export enum MMKV_FILE_NAMES {
   DEFAULT = 'mmkv.default',
   KEYCHAIN = 'mmkv.keychain',
   KEYRING = 'mmkv.keyring',
-  KEYRING_V2 = 'mmkv.keyring.v2',
   KEYRING_CHECKPOINT = 'mmkv.keyring.checkpoint',
   CHAINS = 'mmkv.chains',
   DAYCURVE = 'mmkv.24hCurve',

--- a/apps/mobile/src/core/storage/mmkvConstants.ts
+++ b/apps/mobile/src/core/storage/mmkvConstants.ts
@@ -2,6 +2,8 @@ export enum MMKV_FILE_NAMES {
   DEFAULT = 'mmkv.default',
   KEYCHAIN = 'mmkv.keychain',
   KEYRING = 'mmkv.keyring',
+  KEYRING_V2 = 'mmkv.keyring.v2',
+  KEYRING_CHECKPOINT = 'mmkv.keyring.checkpoint',
   CHAINS = 'mmkv.chains',
   DAYCURVE = 'mmkv.24hCurve',
   CEXID = 'mmkv.cexid',

--- a/apps/mobile/src/core/storage/mmkvInstances.ts
+++ b/apps/mobile/src/core/storage/mmkvInstances.ts
@@ -5,9 +5,29 @@ export const appMMKV = new MMKV({
   id: MMKV_FILE_NAMES.DEFAULT,
 });
 
-export const keyringMMKV = new MMKV({
+const KEYRING_EXPECTED_CAPACITY = 256 * 1024;
+
+/** Original encrypted keyring file, retained only as a migration fallback. */
+export const legacyKeyringMMKV = new MMKV({
   id: MMKV_FILE_NAMES.KEYRING,
   encryptionKey: 'keyring',
+});
+
+/**
+ * New primary file. Reserving capacity avoids the 4 KiB -> 64 KiB expansion
+ * branch observed immediately before the Huawei MiniPB corruption.
+ */
+export const keyringMMKV = new MMKV({
+  id: MMKV_FILE_NAMES.KEYRING_V2,
+  encryptionKey: 'keyring',
+  expectedCapacity: KEYRING_EXPECTED_CAPACITY,
+});
+
+/** One-generation encrypted rollback point for the v2 primary. */
+export const keyringCheckpointMMKV = new MMKV({
+  id: MMKV_FILE_NAMES.KEYRING_CHECKPOINT,
+  encryptionKey: 'keyring',
+  expectedCapacity: KEYRING_EXPECTED_CAPACITY,
 });
 
 export const keychainMMKV = new MMKV({
@@ -46,7 +66,9 @@ export const lendingDataCacheMMKV = new MMKV({
 export const ALL_KNOWN_MMKV_INSTANCES = {
   [MMKV_FILE_NAMES.DEFAULT]: appMMKV,
   [MMKV_FILE_NAMES.KEYCHAIN]: keychainMMKV,
-  [MMKV_FILE_NAMES.KEYRING]: keyringMMKV,
+  [MMKV_FILE_NAMES.KEYRING]: legacyKeyringMMKV,
+  [MMKV_FILE_NAMES.KEYRING_V2]: keyringMMKV,
+  [MMKV_FILE_NAMES.KEYRING_CHECKPOINT]: keyringCheckpointMMKV,
   [MMKV_FILE_NAMES.CHAINS]: chainsMMKV,
   [MMKV_FILE_NAMES.DAYCURVE]: dayCurveMMKV,
   [MMKV_FILE_NAMES.CEXID]: cexIdMMKV,

--- a/apps/mobile/src/core/storage/mmkvInstances.ts
+++ b/apps/mobile/src/core/storage/mmkvInstances.ts
@@ -5,29 +5,16 @@ export const appMMKV = new MMKV({
   id: MMKV_FILE_NAMES.DEFAULT,
 });
 
-const KEYRING_EXPECTED_CAPACITY = 256 * 1024;
-
-/** Original encrypted keyring file, retained only as a migration fallback. */
-export const legacyKeyringMMKV = new MMKV({
+/** The established encrypted primary keyring file. */
+export const keyringMMKV = new MMKV({
   id: MMKV_FILE_NAMES.KEYRING,
   encryptionKey: 'keyring',
 });
 
-/**
- * New primary file. Reserving capacity avoids the 4 KiB -> 64 KiB expansion
- * branch observed immediately before the Huawei MiniPB corruption.
- */
-export const keyringMMKV = new MMKV({
-  id: MMKV_FILE_NAMES.KEYRING_V2,
-  encryptionKey: 'keyring',
-  expectedCapacity: KEYRING_EXPECTED_CAPACITY,
-});
-
-/** One-generation encrypted rollback point for the v2 primary. */
+/** One-generation encrypted rollback point for the established primary. */
 export const keyringCheckpointMMKV = new MMKV({
   id: MMKV_FILE_NAMES.KEYRING_CHECKPOINT,
   encryptionKey: 'keyring',
-  expectedCapacity: KEYRING_EXPECTED_CAPACITY,
 });
 
 export const keychainMMKV = new MMKV({
@@ -66,8 +53,7 @@ export const lendingDataCacheMMKV = new MMKV({
 export const ALL_KNOWN_MMKV_INSTANCES = {
   [MMKV_FILE_NAMES.DEFAULT]: appMMKV,
   [MMKV_FILE_NAMES.KEYCHAIN]: keychainMMKV,
-  [MMKV_FILE_NAMES.KEYRING]: legacyKeyringMMKV,
-  [MMKV_FILE_NAMES.KEYRING_V2]: keyringMMKV,
+  [MMKV_FILE_NAMES.KEYRING]: keyringMMKV,
   [MMKV_FILE_NAMES.KEYRING_CHECKPOINT]: keyringCheckpointMMKV,
   [MMKV_FILE_NAMES.CHAINS]: chainsMMKV,
   [MMKV_FILE_NAMES.DAYCURVE]: dayCurveMMKV,

--- a/apps/mobile/src/screens/GetStarted/GetStarted.tsx
+++ b/apps/mobile/src/screens/GetStarted/GetStarted.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { View, Dimensions, TouchableOpacity } from 'react-native';
 import Animated, {
   useSharedValue,
@@ -41,6 +41,7 @@ import ChevronRightSmallCC from '@/assets/icons/common/chevron-right-small-cc.sv
 import { E2E_ID } from '@/constant/e2e';
 import { makeTestIDProps } from '@/utils/makeTestIDProps';
 import { ensureWalletUnlockedForAction } from '@/utils/walletUnlock';
+import { promptLocalStorageArchiveShare } from '@/utils/promptLocalStorageArchive';
 
 import StartScreenAnimation from '@/assets2024/animations/start-screen-animation.min.json';
 import StartScreenAnimationDark from '@/assets2024/animations/start-screen-animation-dark.min.json';
@@ -53,21 +54,54 @@ import logoDark from '@/assets/images/get-started/logo-dark.png';
 
 // Lottie animation dimensions
 const HERO_ASPECT_RATIO = 452 / 393;
+const LOCAL_STORAGE_EXPORT_TAP_COUNT = 20;
+const LOCAL_STORAGE_EXPORT_TAP_INTERVAL_MS = 500;
 
 // Hero illustration component using Lottie animation
 const HeroIllustration = ({ isLight }: { isLight: boolean }) => {
   const { styles } = useTheme2024({ getStyle });
+  const animationCompletedRef = useRef(false);
+  const rapidTapRef = useRef({ count: 0, lastTappedAt: 0 });
 
   const heroHeight = Math.ceil(SCREEN_WIDTH * HERO_ASPECT_RATIO);
 
+  const handleAnimationTap = useCallback(() => {
+    if (!isNonPublicProductionEnv || !animationCompletedRef.current) {
+      return;
+    }
+
+    const now = Date.now();
+    const isRapidTap =
+      now - rapidTapRef.current.lastTappedAt <=
+      LOCAL_STORAGE_EXPORT_TAP_INTERVAL_MS;
+    const count = isRapidTap ? rapidTapRef.current.count + 1 : 1;
+
+    rapidTapRef.current = { count, lastTappedAt: now };
+
+    if (count < LOCAL_STORAGE_EXPORT_TAP_COUNT) {
+      return;
+    }
+
+    rapidTapRef.current = { count: 0, lastTappedAt: 0 };
+    promptLocalStorageArchiveShare();
+  }, []);
+
   return (
     <View style={[styles.heroContainer, { height: heroHeight }]}>
-      <Lottie
-        source={isLight ? StartScreenAnimation : StartScreenAnimationDark}
-        style={[styles.heroBackground, { height: heroHeight }]}
-        loop={false}
-        autoPlay
-      />
+      <TouchableOpacity
+        activeOpacity={1}
+        onPress={handleAnimationTap}
+        disabled={!isNonPublicProductionEnv}>
+        <Lottie
+          source={isLight ? StartScreenAnimation : StartScreenAnimationDark}
+          style={[styles.heroBackground, { height: heroHeight }]}
+          loop={false}
+          autoPlay
+          onAnimationFinish={() => {
+            animationCompletedRef.current = true;
+          }}
+        />
+      </TouchableOpacity>
     </View>
   );
 };

--- a/apps/mobile/src/screens/Settings/Settings.tsx
+++ b/apps/mobile/src/screens/Settings/Settings.tsx
@@ -193,6 +193,7 @@ import {
 } from '@/components2024/GlobalBottomSheetModal';
 import { MODAL_NAMES } from '@/components2024/GlobalBottomSheetModal/types';
 import { apiGlobalModal } from '@/components2024/GlobalBottomSheetModal/apiGlobalModal';
+import { promptLocalStorageArchiveShare } from '@/utils/promptLocalStorageArchive';
 
 const LAYOUTS = {
   fiexedFooterHeight: 50,
@@ -1142,6 +1143,11 @@ function DevSettingsBlocks({
               onPress: () => {
                 setDataPlaygroundModalVisible(true);
               },
+            },
+            {
+              label: 'Export Local Storage Archive',
+              icon: RcCode,
+              onPress: promptLocalStorageArchiveShare,
             },
             {
               label: 'Capability Playground',

--- a/apps/mobile/src/utils/promptLocalStorageArchive.ts
+++ b/apps/mobile/src/utils/promptLocalStorageArchive.ts
@@ -1,0 +1,73 @@
+import { Alert } from 'react-native';
+
+import { isNonPublicProductionEnv } from '@/constant';
+import { shareCurrentLocalStorageArchive } from '@/core/storage/localStorageArchive';
+import { toast } from '@/components2024/Toast';
+
+let isPromptVisible = false;
+let isExportInProgress = false;
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function exportAndShareLocalStorageArchive() {
+  if (isExportInProgress) {
+    return;
+  }
+
+  isExportInProgress = true;
+
+  try {
+    toast.show('Preparing local storage archive...');
+    const result = await shareCurrentLocalStorageArchive();
+    const sharedParts = [
+      !result.archive.dismissed && 'archive',
+      !result.keyringDump.dismissed && 'keyring dump',
+    ].filter(Boolean);
+
+    if (sharedParts.length > 0) {
+      toast.success(`${sharedParts.join(' and ')} ready to share`);
+    }
+  } catch (error) {
+    Alert.alert('Local storage export failed', getErrorMessage(error));
+  } finally {
+    isExportInProgress = false;
+  }
+}
+
+export function promptLocalStorageArchiveShare() {
+  if (!isNonPublicProductionEnv || isPromptVisible || isExportInProgress) {
+    return;
+  }
+
+  isPromptVisible = true;
+
+  Alert.alert(
+    'Export local storage?',
+    'This opens two share dialogs: a ZIP with the current raw MMKV and SQLite files, then a JSON dump of raw keyring MMKV values. They can include wallet and keyring data. Share them only with a trusted recipient.',
+    [
+      {
+        text: 'Cancel',
+        style: 'cancel',
+        onPress: () => {
+          isPromptVisible = false;
+        },
+      },
+      {
+        text: 'Export and Share',
+        style: 'destructive',
+        onPress: () => {
+          isPromptVisible = false;
+          void exportAndShareLocalStorageArchive();
+        },
+      },
+    ],
+    {
+      cancelable: true,
+      onDismiss: () => {
+        isPromptVisible = false;
+      },
+    },
+  );
+}

--- a/apps/mobile/src/utils/promptLocalStorageArchive.ts
+++ b/apps/mobile/src/utils/promptLocalStorageArchive.ts
@@ -21,13 +21,10 @@ async function exportAndShareLocalStorageArchive() {
   try {
     toast.show('Preparing local storage archive...');
     const result = await shareCurrentLocalStorageArchive();
-    const sharedParts = [
-      !result.archive.dismissed && 'archive',
-      !result.keyringDump.dismissed && 'keyring dump',
-    ].filter(Boolean);
-
-    if (sharedParts.length > 0) {
-      toast.success(`${sharedParts.join(' and ')} ready to share`);
+    if (!result.dismissed) {
+      toast.success(
+        `Archive with ${result.mmkvDumpCount} MMKV dumps and ${result.keyringStartupDiagnosticFileCount} startup diagnostic files ready to share`,
+      );
     }
   } catch (error) {
     Alert.alert('Local storage export failed', getErrorMessage(error));
@@ -45,7 +42,7 @@ export function promptLocalStorageArchiveShare() {
 
   Alert.alert(
     'Export local storage?',
-    'This opens two share dialogs: a ZIP with the current raw MMKV and SQLite files, then a JSON dump of raw keyring MMKV values. They can include wallet and keyring data. Share them only with a trusted recipient.',
+    'This creates one ZIP with the current raw MMKV and SQLite files, JSON dumps for every known MMKV storage, and preserved pre-React-Native keyring snapshots. It can include wallet and keyring data. Share it only with a trusted recipient.',
     [
       {
         text: 'Cancel',

--- a/yarn.lock
+++ b/yarn.lock
@@ -39957,11 +39957,11 @@ __metadata:
 
 "react-native-mmkv@patch:react-native-mmkv@patch%3Areact-native-mmkv@npm%253A2.12.2%23./.yarn/patches/react-native-mmkv-npm-2.12.2-9efa7abf70.patch%3A%3Aversion=2.12.2&hash=e0fc6c&locator=%2540rabby-wallet%252Fmobile-monorepo%2540workspace%253A.#~/.yarn/patches/react-native-mmkv-patch-b5ece05891.patch":
   version: 2.12.2
-  resolution: "react-native-mmkv@patch:react-native-mmkv@patch%3Areact-native-mmkv@npm%253A2.12.2%23./.yarn/patches/react-native-mmkv-npm-2.12.2-9efa7abf70.patch%3A%3Aversion=2.12.2&hash=e0fc6c&locator=%2540rabby-wallet%252Fmobile-monorepo%2540workspace%253A.#~/.yarn/patches/react-native-mmkv-patch-b5ece05891.patch::version=2.12.2&hash=5ed6c0"
+  resolution: "react-native-mmkv@patch:react-native-mmkv@patch%3Areact-native-mmkv@npm%253A2.12.2%23./.yarn/patches/react-native-mmkv-npm-2.12.2-9efa7abf70.patch%3A%3Aversion=2.12.2&hash=e0fc6c&locator=%2540rabby-wallet%252Fmobile-monorepo%2540workspace%253A.#~/.yarn/patches/react-native-mmkv-patch-b5ece05891.patch::version=2.12.2&hash=7c9bad"
   peerDependencies:
     react: "*"
     react-native: ">=0.71.0"
-  checksum: 10/8ee9734cb3e72fb820869ba45eb470e34fd7855d9a3eeb9585f3508381f2431e2b478fe31ccd25e5d147dfd32d74ee266b029893b4da17c3314eefb10ec3470f
+  checksum: 10/44c37e137ae191e72693b3ef4be096f0b07ba562b384c95ac5d338d3023b1995cdb187f7c6584d05af6861ad8b1973554737cb58928dd740080a235703cd9411
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -39957,11 +39957,11 @@ __metadata:
 
 "react-native-mmkv@patch:react-native-mmkv@patch%3Areact-native-mmkv@npm%253A2.12.2%23./.yarn/patches/react-native-mmkv-npm-2.12.2-9efa7abf70.patch%3A%3Aversion=2.12.2&hash=e0fc6c&locator=%2540rabby-wallet%252Fmobile-monorepo%2540workspace%253A.#~/.yarn/patches/react-native-mmkv-patch-b5ece05891.patch":
   version: 2.12.2
-  resolution: "react-native-mmkv@patch:react-native-mmkv@patch%3Areact-native-mmkv@npm%253A2.12.2%23./.yarn/patches/react-native-mmkv-npm-2.12.2-9efa7abf70.patch%3A%3Aversion=2.12.2&hash=e0fc6c&locator=%2540rabby-wallet%252Fmobile-monorepo%2540workspace%253A.#~/.yarn/patches/react-native-mmkv-patch-b5ece05891.patch::version=2.12.2&hash=799326"
+  resolution: "react-native-mmkv@patch:react-native-mmkv@patch%3Areact-native-mmkv@npm%253A2.12.2%23./.yarn/patches/react-native-mmkv-npm-2.12.2-9efa7abf70.patch%3A%3Aversion=2.12.2&hash=e0fc6c&locator=%2540rabby-wallet%252Fmobile-monorepo%2540workspace%253A.#~/.yarn/patches/react-native-mmkv-patch-b5ece05891.patch::version=2.12.2&hash=5ed6c0"
   peerDependencies:
     react: "*"
     react-native: ">=0.71.0"
-  checksum: 10/5e7629669b21afc1d76d8627e2caa8b7ba33ed1ad135eb71dd29449b0cbf1ab2ea2efdf60370014b1f9d941c87be04c9860116b264866cff2a5e54a09bb6e08a
+  checksum: 10/8ee9734cb3e72fb820869ba45eb470e34fd7855d9a3eeb9585f3508381f2431e2b478fe31ccd25e5d147dfd32d74ee266b029893b4da17c3314eefb10ec3470f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -38968,7 +38968,7 @@ __metadata:
     react-native-keychain: "patch:react-native-keychain@npm%3A10.0.0#../../.yarn/patches/react-native-keychain-npm-10.0.0-rabby.patch"
     react-native-linear-gradient: "npm:^2.8.3"
     react-native-localize: "npm:3.3.0"
-    react-native-mmkv: "npm:^2.12.2"
+    react-native-mmkv: "patch:react-native-mmkv@patch%3Areact-native-mmkv@npm%253A2.12.2%23./.yarn/patches/react-native-mmkv-npm-2.12.2-9efa7abf70.patch%3A%3Aversion=2.12.2&hash=e0fc6c&locator=%2540rabby-wallet%252Fmobile-monorepo%2540workspace%253A.#~/.yarn/patches/react-native-mmkv-patch-b5ece05891.patch"
     react-native-nitro-modules: "npm:0.35.9"
     react-native-pager-view: "npm:6.7.0"
     react-native-permissions: "npm:5.3.0"
@@ -39945,13 +39945,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-mmkv@patch:react-native-mmkv@npm%3A2.12.2#./.yarn/patches/react-native-mmkv-npm-2.12.2-9efa7abf70.patch::locator=%40rabby-wallet%2Fmobile-monorepo%40workspace%3A.":
+"react-native-mmkv@patch:react-native-mmkv@npm%3A2.12.2#./.yarn/patches/react-native-mmkv-npm-2.12.2-9efa7abf70.patch::version=2.12.2&hash=e0fc6c&locator=%40rabby-wallet%2Fmobile-monorepo%40workspace%3A.":
   version: 2.12.2
   resolution: "react-native-mmkv@patch:react-native-mmkv@npm%3A2.12.2#./.yarn/patches/react-native-mmkv-npm-2.12.2-9efa7abf70.patch::version=2.12.2&hash=e0fc6c&locator=%40rabby-wallet%2Fmobile-monorepo%40workspace%3A."
   peerDependencies:
     react: "*"
     react-native: ">=0.71.0"
   checksum: 10/6255dbb5a07fd6cec2524fc86f2c5c971060883e6e2bd76f2303768aaeba0a10d78505411f5ddb16d9f44595bfc4b6d49e8f28a3ae2df6ce0ee8a69035954938
+  languageName: node
+  linkType: hard
+
+"react-native-mmkv@patch:react-native-mmkv@patch%3Areact-native-mmkv@npm%253A2.12.2%23./.yarn/patches/react-native-mmkv-npm-2.12.2-9efa7abf70.patch%3A%3Aversion=2.12.2&hash=e0fc6c&locator=%2540rabby-wallet%252Fmobile-monorepo%2540workspace%253A.#~/.yarn/patches/react-native-mmkv-patch-b5ece05891.patch":
+  version: 2.12.2
+  resolution: "react-native-mmkv@patch:react-native-mmkv@patch%3Areact-native-mmkv@npm%253A2.12.2%23./.yarn/patches/react-native-mmkv-npm-2.12.2-9efa7abf70.patch%3A%3Aversion=2.12.2&hash=e0fc6c&locator=%2540rabby-wallet%252Fmobile-monorepo%2540workspace%253A.#~/.yarn/patches/react-native-mmkv-patch-b5ece05891.patch::version=2.12.2&hash=799326"
+  peerDependencies:
+    react: "*"
+    react-native: ">=0.71.0"
+  checksum: 10/5e7629669b21afc1d76d8627e2caa8b7ba33ed1ad135eb71dd29449b0cbf1ab2ea2efdf60370014b1f9d941c87be04c9860116b264866cff2a5e54a09bb6e08a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Validation branch is based directly on d19767205e20c905f0bb6a7a16340694d9c8d2ad, the commit used by the reproducible Perps Pro package. It intentionally does not include later target-branch changes.

Keeps mmkv.keyring as the primary encrypted keyring file; adds only an encrypted rollback checkpoint, strict persisted-shape validation, and sync/reload read-back verification. Includes non-production storage diagnostics/export for the repro.

Validated: yarn workspace rabby-mobile typecheck; keyring migration Jest suite (11 tests).