### PR TITLE
fix(mobile): hydrate custom testnets for home assets

### DIFF
--- a/apps/mobile/src/constant/homeAssetSelection.ts
+++ b/apps/mobile/src/constant/homeAssetSelection.ts
@@ -1,0 +1,14 @@
+export const HOME_ASSET_TOP_N_OPTIONS = [10, 20, 30, 50, 100] as const;
+
+export type HomeAssetTopN = (typeof HOME_ASSET_TOP_N_OPTIONS)[number];
+
+export const DEFAULT_HOME_ASSET_TOP_N: HomeAssetTopN = 10;
+
+export function coerceHomeAssetTopN(value: unknown): HomeAssetTopN {
+  const numericValue = typeof value === 'number' ? value : Number(value);
+  const option = HOME_ASSET_TOP_N_OPTIONS.find(
+    candidate => candidate === numericValue,
+  );
+
+  return option || DEFAULT_HOME_ASSET_TOP_N;
+}

--- a/apps/mobile/src/core/serviceApi/customTestnet.ts
+++ b/apps/mobile/src/core/serviceApi/customTestnet.ts
@@ -5,6 +5,12 @@ import type {
 import { appStorage } from '@/core/storage/mmkv';
 import { APP_STORE_NAMES } from '@/core/storage/storeConstant';
 import { getLoadedCoreService } from '@/core/services/serviceRegistry';
+import {
+  markCustomTestnetStoreHydrating,
+  markCustomTestnetStoreHydrationFailed,
+  syncCustomTestnetStore,
+  useCustomTestnetStore,
+} from '@/store/customTestnet';
 import { createDeferredServiceApi } from './createDeferredServiceApi';
 
 export type CustomTestnetServiceApiContract = CustomTestnetService;
@@ -12,6 +18,26 @@ export const customTestnetServiceApi = createDeferredServiceApi<
   'customTestnetService',
   CustomTestnetServiceApiContract
 >('customTestnetService');
+
+/**
+ * Publishes the persisted custom-network snapshot without activating the full
+ * viem-backed service. Callers that need a final empty-state decision must
+ * cross this boundary instead of treating the store's initial empty values as
+ * data.
+ */
+export function ensureCustomTestnetStoreHydrated() {
+  if (useCustomTestnetStore.getState().hydrationState === 'ready') {
+    return;
+  }
+
+  markCustomTestnetStoreHydrating();
+  try {
+    syncCustomTestnetStore(getCustomTestnetStoreSnapshot());
+  } catch (error) {
+    markCustomTestnetStoreHydrationFailed();
+    throw error;
+  }
+}
 
 export function getCustomTestnetStoreSnapshot(): CutsomTestnetServiceStore {
   const loadedSnapshot = getLoadedCoreService(

--- a/apps/mobile/src/core/serviceApi/serviceContractCatalog.json
+++ b/apps/mobile/src/core/serviceApi/serviceContractCatalog.json
@@ -124,7 +124,7 @@
       "apiExport": "customTestnetServiceApi",
       "access": "deferred-api",
       "defaultReadiness": "loaded",
-      "snapshotApi": false
+      "snapshotApi": true
     },
     "dappService": {
       "apiModule": "dapp",

--- a/apps/mobile/src/core/storage/mmkvConstants.ts
+++ b/apps/mobile/src/core/storage/mmkvConstants.ts
@@ -34,6 +34,7 @@ export const APP_MMKV_WEAK_KEYS = {
   LENDING_MARKET: '@lendingMarket',
   FAILED_UNLOCK: '@failed_unlock',
   HOME_TOP10_ADDRESSES: '@homeTop10Addresses',
+  HOME_NONPROD_ASSET_SELECTION: '@homeNonprodAssetSelectionV1',
   WALLETCONNECT_SETTINGS: '@walletConnectSettings',
   WALLETCONNECT_LAST_APPROVED_ACCOUNTS: '@walletConnectLastApprovedAccounts',
   WALLETCONNECT_APPROVED_ACCOUNTS_BY_TOPIC:

--- a/apps/mobile/src/core/utils/startupTaskManifest.ts
+++ b/apps/mobile/src/core/utils/startupTaskManifest.ts
@@ -343,6 +343,16 @@ export const STARTUP_TASKS = {
     priority: 'normal',
     budgetMs: 220,
   }),
+  customTestnetSnapshotHydration: defineStartupTask({
+    label: 'customTestnet.snapshotHydration',
+    owner: 'home-assets',
+    reason:
+      'restore persisted custom-network sections before Home can present a final empty token state',
+    stage: 'homePostStartupReady',
+    priority: 'high',
+    fallbackMs: 5000,
+    budgetMs: 24,
+  }),
   readableAccountStoresIdleWarmup: defineStartupTask({
     label: 'readableAccountStores.idleWarmup',
     owner: 'home-assets',

--- a/apps/mobile/src/hooks/appSettings.ts
+++ b/apps/mobile/src/hooks/appSettings.ts
@@ -22,6 +22,11 @@ import {
 } from '@/core/apis/keychainVersionShared';
 import { setPreference } from '@/core/serviceApi/preference';
 import { useCallback, useMemo } from 'react';
+import {
+  coerceHomeAssetTopN,
+  DEFAULT_HOME_ASSET_TOP_N,
+  type HomeAssetTopN,
+} from '@/constant/homeAssetSelection';
 
 export {
   CURRENT_KEYCHAIN_VERSION_VALUES,
@@ -128,6 +133,8 @@ type ScreenshotSettings = {
   [DEBUG_CURRENT_KEYCHAIN_VERSION_FIELD]: CurrentKeychainVersion;
   debugKeychainStorageByVersion: DebugKeychainStorageByVersion;
   enablePerpsWatchAddress: boolean;
+  homeAssetTopN: HomeAssetTopN;
+  includeWatchAddressesInHomeAssetSelection: boolean;
   screenE2EEnabled: boolean;
 };
 const experimentalSettingsStore = zustandByMMKV<ScreenshotSettings>(
@@ -153,6 +160,8 @@ const experimentalSettingsStore = zustandByMMKV<ScreenshotSettings>(
     [DEBUG_CURRENT_KEYCHAIN_VERSION_FIELD]: DEFAULT_CURRENT_KEYCHAIN_VERSION,
     debugKeychainStorageByVersion: makeDefaultDebugKeychainStorageByVersion(),
     enablePerpsWatchAddress: false,
+    homeAssetTopN: DEFAULT_HOME_ASSET_TOP_N,
+    includeWatchAddressesInHomeAssetSelection: false,
     screenE2EEnabled: false,
   },
 );
@@ -163,6 +172,9 @@ export const storeApiExpSettingData = {
   getCurrentKeychainVersion,
   getDebugKeychainStorageByVersion,
   getShouldBlockSubmitIfFormChangedOnAuth,
+  getHomeAssetSelectionSettings,
+  setHomeAssetTopN,
+  setIncludeWatchAddressesInHomeAssetSelection,
   getScreenE2EEnabled: () =>
     isNonPublicProductionEnv &&
     experimentalSettingsStore.getState().screenE2EEnabled,
@@ -198,6 +210,123 @@ export function useScreenE2EEnabled() {
   return {
     screenE2EEnabled: isNonPublicProductionEnv && screenE2EEnabled,
     setScreenE2EEnabled,
+  };
+}
+
+export type HomeAssetSelectionSettings = {
+  topN: HomeAssetTopN;
+  includeWatchAddresses: boolean;
+};
+
+/**
+ * This is deliberately a non-production test policy.  Production always uses
+ * the legacy Top 10 owned-address selection, regardless of persisted values.
+ */
+export function getHomeAssetSelectionSettings(): HomeAssetSelectionSettings {
+  if (!isNonPublicProductionEnv) {
+    return {
+      topN: DEFAULT_HOME_ASSET_TOP_N,
+      includeWatchAddresses: false,
+    };
+  }
+
+  const state = experimentalSettingsStore.getState();
+  return {
+    topN: coerceHomeAssetTopN(state.homeAssetTopN),
+    includeWatchAddresses: !!state.includeWatchAddressesInHomeAssetSelection,
+  };
+}
+
+export function isHomeAssetSelectionExperimentEnabled(
+  settings = getHomeAssetSelectionSettings(),
+) {
+  return (
+    isNonPublicProductionEnv &&
+    (settings.topN !== DEFAULT_HOME_ASSET_TOP_N ||
+      settings.includeWatchAddresses)
+  );
+}
+
+export function getHomeAssetSelectionSettingsKey(
+  settings = getHomeAssetSelectionSettings(),
+) {
+  return `${settings.topN}:${settings.includeWatchAddresses ? 1 : 0}`;
+}
+
+export function setHomeAssetTopN(value: unknown) {
+  if (!isNonPublicProductionEnv) {
+    return DEFAULT_HOME_ASSET_TOP_N;
+  }
+
+  const topN = coerceHomeAssetTopN(value);
+  setExpSettingData(prev => ({
+    ...prev,
+    homeAssetTopN: topN,
+  }));
+  return topN;
+}
+
+export function setIncludeWatchAddressesInHomeAssetSelection(enabled: boolean) {
+  if (!isNonPublicProductionEnv) {
+    return false;
+  }
+
+  setExpSettingData(prev => ({
+    ...prev,
+    includeWatchAddressesInHomeAssetSelection: enabled,
+  }));
+  return enabled;
+}
+
+export function subscribeHomeAssetSelectionSettings(
+  listener: (settings: HomeAssetSelectionSettings) => void,
+) {
+  if (!isNonPublicProductionEnv) {
+    return () => undefined;
+  }
+
+  let previous = getHomeAssetSelectionSettings();
+  return experimentalSettingsStore.subscribe(() => {
+    const next = getHomeAssetSelectionSettings();
+    if (
+      next.topN === previous.topN &&
+      next.includeWatchAddresses === previous.includeWatchAddresses
+    ) {
+      return;
+    }
+    previous = next;
+    listener(next);
+  });
+}
+
+export function useHomeAssetSelectionSettings() {
+  const persistedTopN = experimentalSettingsStore(state => state.homeAssetTopN);
+  const persistedIncludeWatchAddresses = experimentalSettingsStore(
+    state => state.includeWatchAddressesInHomeAssetSelection,
+  );
+
+  const setTopN = useCallback((value: HomeAssetTopN) => {
+    return setHomeAssetTopN(value);
+  }, []);
+  const setIncludeWatchAddresses = useCallback((enabled: boolean) => {
+    return setIncludeWatchAddressesInHomeAssetSelection(enabled);
+  }, []);
+
+  const topN = isNonPublicProductionEnv
+    ? coerceHomeAssetTopN(persistedTopN)
+    : DEFAULT_HOME_ASSET_TOP_N;
+  const includeWatchAddresses =
+    isNonPublicProductionEnv && persistedIncludeWatchAddresses;
+
+  return {
+    topN,
+    includeWatchAddresses,
+    isExperimentEnabled: isHomeAssetSelectionExperimentEnabled({
+      topN,
+      includeWatchAddresses,
+    }),
+    setTopN,
+    setIncludeWatchAddresses,
   };
 }
 

--- a/apps/mobile/src/hooks/useScene24hBalance.test.ts
+++ b/apps/mobile/src/hooks/useScene24hBalance.test.ts
@@ -61,6 +61,9 @@ describe('store/balance24h scene', () => {
       getTop10MyAccounts: (...args: unknown[]) =>
         mockGetTop10MyAccounts(...args),
     }));
+    jest.doMock('@/hooks/appSettings', () => ({
+      isHomeAssetSelectionExperimentEnabled: jest.fn(() => false),
+    }));
     jest.doMock('@/core/services', () => ({
       keyringService: {
         on: jest.fn(),

--- a/apps/mobile/src/screens/Address/NotMatterAddressDialog.tsx
+++ b/apps/mobile/src/screens/Address/NotMatterAddressDialog.tsx
@@ -6,7 +6,7 @@ import { AddressItemEntry } from './components/AddressItem';
 import { createGetStyles2024 } from '@/utils/styles';
 import HelpIcon from '@/assets2024/icons/common/help.svg';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useAccountInfo } from './components/MultiAssets/hooks';
+import { useHomeAssetAccountInfo } from './components/MultiAssets/hooks';
 import { useTranslation } from 'react-i18next';
 import AutoLockView from '@/components/AutoLockView';
 import { BottomSheetSectionList } from '@gorhom/bottom-sheet';
@@ -27,7 +27,7 @@ export const NotMatterAddressDialog: React.FC<{
   isShowBackupBadge?: boolean;
 }> = ({ onDone, onBack, showBackArrow = true, variant, isShowBackupBadge }) => {
   const { myNotTop10Accounts, gnosisAccounts, watchAccounts, fetchAccounts } =
-    useAccountInfo();
+    useHomeAssetAccountInfo();
   const { bottom } = useSafeAreaInsets();
   const { t } = useTranslation();
   const { styles, colors2024 } = useTheme2024({ getStyle });

--- a/apps/mobile/src/screens/Address/components/MultiAssets/AddressList.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/AddressList.tsx
@@ -8,7 +8,7 @@ import { Card } from '@/components2024/Card';
 import { useTheme2024 } from '@/hooks/theme';
 import RightArrowSVG from '@/assets2024/icons/common/right-cc.svg';
 import { useTranslation } from 'react-i18next';
-import { useAccountInfo } from './hooks';
+import { useHomeAssetAccountInfo } from './hooks';
 import { createGetStyles2024 } from '@/utils/styles';
 import WalletSVG from '@/assets2024/icons/common/wallet-cc.svg';
 import { WalletIcon } from '@/components2024/WalletIcon/WalletIcon';
@@ -44,7 +44,7 @@ const AddressList = ({
   const { t } = useTranslation();
 
   const { myTop10Accounts, myTop10Records, notMatteredAccounts } =
-    useAccountInfo();
+    useHomeAssetAccountInfo();
   const top10Addresses = useMemo(() => {
     return myTop10Accounts.map(item => item.address.toLowerCase());
   }, [myTop10Accounts]);

--- a/apps/mobile/src/screens/Address/components/MultiAssets/CustomTestnetAssets/useCustomTestnetAssetSections.ts
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/CustomTestnetAssets/useCustomTestnetAssetSections.ts
@@ -2,7 +2,10 @@ import { useCallback, useMemo } from 'react';
 import PQueue from 'p-queue';
 
 import { apiCustomTestnet } from '@/core/apis';
-import { useCustomTestnetAssetSectionsData } from '@/store/customTestnet';
+import {
+  useCustomTestnetAssetSectionsData,
+  useCustomTestnetHydrationState,
+} from '@/store/customTestnet';
 import { customTestnetTokenToTokenItem } from '@/utils/token';
 
 import type {
@@ -33,6 +36,7 @@ const makeFallbackTokenItem = (
 // for multi-address
 export function useCustomTestnetAssetSections(addresses: string[]) {
   const sections = useCustomTestnetAssetSectionsData(addresses);
+  const hydrationState = useCustomTestnetHydrationState();
 
   const loadTokenItems = useCallback(
     async (
@@ -109,6 +113,7 @@ export function useCustomTestnetAssetSections(addresses: string[]) {
 
   return {
     sections,
+    hydrationState,
     loadTokens,
     loadToken,
   };

--- a/apps/mobile/src/screens/Address/components/MultiAssets/NFTList.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/NFTList.tsx
@@ -49,7 +49,7 @@ import {
   useFindAccountByAddress,
   useIsFocusedCurrentTab,
 } from './hooks/share';
-import { isTabsSwiping, useAccountInfo } from './hooks';
+import { isTabsSwiping, useHomeAssetAccountInfo } from './hooks';
 import nftListStore, {
   EMPTY_NFT_ASSETS_INDEX_RESULT,
   getMultiNftsCacheKey,
@@ -184,7 +184,7 @@ const NFTListInner = () => {
   const regressionScenarioReport = regressionScenario.active
     ? regressionScenario.report
     : null;
-  const { myTop10Addresses } = useAccountInfo();
+  const { myTop10Addresses } = useHomeAssetAccountInfo();
 
   const selectedChainItem = useSelectedChainItem();
   const chain = selectedChainItem?.chain;
@@ -464,7 +464,7 @@ const NFTListInner = () => {
   const onRefresh = useCallback(async () => {
     const balanceRefresh = triggerUpdate(true);
     const nftListRefresh = Promise.all([
-      batchGetNFTList(true, {}),
+      batchGetNFTList(true, { realTimeAddresses: myTop10Addresses }),
       nftRefresh(),
     ]);
 
@@ -477,14 +477,14 @@ const NFTListInner = () => {
     } catch (error) {
       console.error('Refresh failed:', error);
     }
-  }, [batchGetNFTList, triggerUpdate, nftRefresh]);
+  }, [batchGetNFTList, triggerUpdate, nftRefresh, myTop10Addresses]);
 
   const handleForeground = useCallback(() => {
     if (isLoading || !isFocusing || !myTop10Addresses) {
       return;
     }
     triggerUpdate(false);
-    batchGetNFTList(false, {});
+    batchGetNFTList(false, { realTimeAddresses: myTop10Addresses });
   }, [isLoading, isFocusing, myTop10Addresses, triggerUpdate, batchGetNFTList]);
 
   useAppForeground({

--- a/apps/mobile/src/screens/Address/components/MultiAssets/ProtocolList.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/ProtocolList.tsx
@@ -31,7 +31,7 @@ import useProtocols, {
   useProtocolListComputedStore,
 } from '@/store/protocols';
 import { useShallow } from 'zustand/react/shallow';
-import { useAccountInfo } from './hooks';
+import { useHomeAssetAccountInfo } from './hooks';
 import addressBalanceStore from '@/store/balance';
 import {
   HOME_TOP_HEADER_SIZES,
@@ -134,7 +134,7 @@ export const ProtocolList = () => {
     ? regressionScenario.report
     : null;
 
-  const { myTop10Addresses } = useAccountInfo();
+  const { myTop10Addresses } = useHomeAssetAccountInfo();
   const selectedChainItem = useSelectedChainItem();
   const chain = selectedChainItem?.chain;
   const [foldDefi, setFoldDefi] = useState(true);

--- a/apps/mobile/src/screens/Address/components/MultiAssets/TokenList.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/TokenList.tsx
@@ -33,7 +33,7 @@ import {
   removeGlobalBottomSheetModal2024,
 } from '@/components2024/GlobalBottomSheetModal';
 import { MODAL_NAMES } from '@/components2024/GlobalBottomSheetModal/types';
-import { isTabsSwiping, useAccountInfo } from './hooks';
+import { isTabsSwiping, useHomeAssetAccountInfo } from './hooks';
 import { KeyringAccountWithAlias } from '@/hooks/account';
 import { EmptyAssets } from '@/screens/Home/components/AssetRenderItems/EmptyAssets';
 import { HomeTabName as TabName } from '@/hooks/navigation';
@@ -255,7 +255,7 @@ export const TokenList = () => {
   const regressionScenarioReport = regressionScenario.active
     ? regressionScenario.report
     : null;
-  const { myTop10Addresses } = useAccountInfo();
+  const { myTop10Addresses } = useHomeAssetAccountInfo();
   const selectedChainItem = useSelectedChainItem();
   const chain = useMemo(() => {
     return selectedChainItem?.chain;
@@ -279,10 +279,15 @@ export const TokenList = () => {
   const getAccountByAddress = useFindAccountByAddress();
   const {
     sections: customTestnetSections,
+    hydrationState: customTestnetHydrationState,
     loadTokens: loadCustomTestnetTokens,
     loadToken: loadCustomTestnetToken,
   } = useCustomTestnetAssetSections(myTop10Addresses);
   const shouldShowCustomTestnetSections = !chain && !isLpTokenEnabled;
+  const isCustomTestnetSnapshotPending =
+    shouldShowCustomTestnetSections &&
+    customTestnetHydrationState !== 'ready' &&
+    customTestnetHydrationState !== 'failed';
   const { triggerUpdate } = addressBalanceStore.useAccountsBalanceTrigger();
 
   const { isFocused, isFocusing } = useIsFocusedCurrentTab(TabName.token);
@@ -409,9 +414,11 @@ export const TokenList = () => {
     isLoading && !hasDefaultTokenData;
   const visibleCustomTestnetSections =
     shouldShowCustomTestnetSections &&
+    customTestnetHydrationState === 'ready' &&
     !shouldHideCustomTestnetSectionsWhileLoading
       ? customTestnetSections
       : EMPTY_CUSTOM_TESTNET_SECTIONS;
+  const isTokenListDisplayLoading = isLoading || isCustomTestnetSnapshotPending;
 
   useEffect(() => {
     batchGetTokenList(myTop10Addresses);
@@ -432,7 +439,7 @@ export const TokenList = () => {
 
   const hasNoAssets =
     tokenRows.length + foldRows.length + scamRows.length === 0 &&
-    !isLoading &&
+    !isTokenListDisplayLoading &&
     !hasFoldTokens &&
     isFocused;
 
@@ -467,7 +474,7 @@ export const TokenList = () => {
       !regressionScenarioReport ||
       !isFocused ||
       !scenarioReadyCheckTick ||
-      isLoading
+      isTokenListDisplayLoading
     ) {
       return;
     }
@@ -509,6 +516,7 @@ export const TokenList = () => {
     hasNoAssets,
     isFocused,
     isLoading,
+    isTokenListDisplayLoading,
     isLpTokenEnabled,
     multiAssetsKey,
     myTop10Addresses.length,
@@ -767,7 +775,7 @@ export const TokenList = () => {
     //tokenRows.length + foldRows.length + scamRows.length > 0;
     const hasFoldSection = hasFoldTokens || isLpTokenEnabled;
 
-    if (isLoading && hasNoTokenItems) {
+    if (isTokenListDisplayLoading && hasNoTokenItems) {
       items.push(
         ...Array.from({ length: 5 }, (_, index) => ({
           type: 'loading-skeleton' as const,
@@ -833,7 +841,7 @@ export const TokenList = () => {
     visibleCustomTestnetSections,
     hasFoldTokens,
     isLpTokenEnabled,
-    isLoading,
+    isTokenListDisplayLoading,
     hasNoAssets,
     foldHideList,
     t,

--- a/apps/mobile/src/screens/Address/components/MultiAssets/hooks/index.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/hooks/index.tsx
@@ -1,6 +1,5 @@
 import {
   accountEvents,
-  filterOutTop10Accounts,
   isDirectlySignableAccount,
   isHardwareAccount,
 } from '@/core/apis/account';
@@ -11,8 +10,14 @@ import {
   storeApiAccounts,
   useAccounts,
 } from '@/hooks/account';
+import { useHomeAssetSelectionSettings } from '@/hooks/appSettings';
+import { DEFAULT_HOME_ASSET_TOP_N } from '@/constant/homeAssetSelection';
 import { useCreationWithShallowCompare } from '@/hooks/common/useMemozied';
-import addressBalanceStore from '@/store/balance';
+import addressBalanceStore, { balanceAccountsStore } from '@/store/balance';
+import {
+  pickHomeAccountSelectionFromAddresses,
+  pickHomeAccountSelectionFromSortedAccounts,
+} from '@/store/homePortfolio/accountSelection';
 import { useSortAddressList } from '@/screens/Address/useSortAddressList';
 import { filterMyAccounts } from '@/utils/account';
 import { eventBus, EventBusListeners, EVENTS } from '@/utils/events';
@@ -25,37 +30,74 @@ export const isTabsSwiping = {
   value: false,
 };
 
-export function useAccountInfo() {
+const EMPTY_SELECTED_ADDRESSES: string[] = [];
+
+type UseAccountInfoOptions = {
+  useHomeAssetSelectionPolicy?: boolean;
+};
+
+export function useAccountInfo(options?: UseAccountInfoOptions) {
   const { accounts, fetchAccounts } = useAccounts({
     disableAutoFetch: true,
   });
+  const {
+    topN: configuredTopN,
+    includeWatchAddresses: configuredIncludeWatchAddresses,
+    isExperimentEnabled: configuredHomeAssetSelectionExperimentEnabled,
+  } = useHomeAssetSelectionSettings();
+  const useHomeAssetSelectionPolicy = !!options?.useHomeAssetSelectionPolicy;
+  const topN = useHomeAssetSelectionPolicy
+    ? configuredTopN
+    : DEFAULT_HOME_ASSET_TOP_N;
+  const includeWatchAddresses =
+    useHomeAssetSelectionPolicy && configuredIncludeWatchAddresses;
+  const isHomeAssetSelectionExperimentEnabled =
+    useHomeAssetSelectionPolicy &&
+    configuredHomeAssetSelectionExperimentEnabled;
+  const selectedAddresses = balanceAccountsStore(state =>
+    isHomeAssetSelectionExperimentEnabled
+      ? state.selectedAddresses
+      : EMPTY_SELECTED_ADDRESSES,
+  );
+  const hasResolvedSelection = balanceAccountsStore(state =>
+    isHomeAssetSelectionExperimentEnabled ? state.hasResolvedSelection : false,
+  );
 
   const myAccounts = useCreationWithShallowCompare(
     () => filterMyAccounts(accounts),
     [accounts],
   );
 
-  const sortedList = useSortAddressList(myAccounts);
+  const sortedList = useSortAddressList(
+    includeWatchAddresses ? accounts : myAccounts,
+  );
   const {
     myTop10Accounts,
     myTop10Addresses,
     myTop10Records,
     myNotTop10Accounts,
   } = useCreationWithShallowCompare(() => {
-    const {
-      top10Accounts: myTop10Accounts,
-      top10Addresses: myTop10Addresses,
-      top10Records: myTop10Records,
-      restAccounts: myNotTop10Accounts,
-    } = filterOutTop10Accounts(sortedList, { gatherSameAddress: false });
+    const selection =
+      isHomeAssetSelectionExperimentEnabled && hasResolvedSelection
+        ? pickHomeAccountSelectionFromAddresses(sortedList, selectedAddresses)
+        : pickHomeAccountSelectionFromSortedAccounts(sortedList, {
+            topN,
+            uniqueAddresses: isHomeAssetSelectionExperimentEnabled,
+          });
 
     return {
-      myTop10Accounts,
-      myTop10Addresses,
-      myTop10Records,
-      myNotTop10Accounts,
+      myTop10Accounts: selection.selectedAccounts,
+      myTop10Addresses: selection.selectedAddresses,
+      myTop10Records: selection.selectedAddressRecords,
+      myNotTop10Accounts: selection.restAccounts,
     };
-  }, [sortedList]);
+  }, [
+    hasResolvedSelection,
+    isHomeAssetSelectionExperimentEnabled,
+    topN,
+    selectedAddresses,
+    sortedList,
+  ]);
 
   const stableTop10Addresses = useCreationWithShallowCompare(
     () => myTop10Addresses,
@@ -85,8 +127,16 @@ export function useAccountInfo() {
     }, [accounts]);
 
   const notMatteredAccounts = useCreationWithShallowCompare(() => {
+    if (includeWatchAddresses) {
+      return myNotTop10Accounts;
+    }
     return [...myNotTop10Accounts, ...gnosisAccounts, ...watchAccounts];
-  }, [myNotTop10Accounts, gnosisAccounts, watchAccounts]);
+  }, [
+    includeWatchAddresses,
+    myNotTop10Accounts,
+    gnosisAccounts,
+    watchAccounts,
+  ]);
 
   return {
     myTop10Accounts,
@@ -101,8 +151,14 @@ export function useAccountInfo() {
     hasSafeAddress,
     fetchAccounts,
     rawAllAccounts: accounts,
-    matteredAccountCount: filterMyAccounts(sortedList).length,
+    matteredAccountCount: includeWatchAddresses
+      ? sortedList.length
+      : filterMyAccounts(sortedList).length,
   };
+}
+
+export function useHomeAssetAccountInfo() {
+  return useAccountInfo({ useHomeAssetSelectionPolicy: true });
 }
 
 function isAccountToShowReceiveTip(account: KeyringAccountWithAlias) {
@@ -127,13 +183,19 @@ export async function getShowReceiveAddressTip(options?: {
     const accountsToCheck = myAccounts.filter(account =>
       isAccountToShowReceiveTip(account),
     );
-    if (accountsToCheck.length !== 1) return null;
+    if (accountsToCheck.length !== 1) {
+      return null;
+    }
 
     targetAccount = accountsToCheck[0];
   }
 
-  if (!targetAccount) return null;
-  if (!isAccountToShowReceiveTip(targetAccount)) return null;
+  if (!targetAccount) {
+    return null;
+  }
+  if (!isAccountToShowReceiveTip(targetAccount)) {
+    return null;
+  }
 
   const evmBalance =
     addressBalanceStore.getAddressValue(targetAccount.address)?.evmBalance ??
@@ -196,7 +258,9 @@ export function useAccountHomeShowReceiveTip(
   }, [detect]);
 
   useEffect(() => {
-    if (isForSingle) return;
+    if (isForSingle) {
+      return;
+    }
 
     const onTxCompleted: EventBusListeners[typeof EVENTS.TX_COMPLETED] = () => {
       detect();
@@ -219,7 +283,9 @@ export function useAccountHomeShowReceiveTip(
   }, [isForSingle, detect]);
 
   useEffect(() => {
-    if (isForSingle) return;
+    if (isForSingle) {
+      return;
+    }
 
     const onAccountsChanged = () => {
       detect();

--- a/apps/mobile/src/screens/Address/components/MultiAssets/hooks/share.ts
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/hooks/share.ts
@@ -4,7 +4,7 @@ import { useFocusedTab } from 'react-native-collapsible-tab-view';
 import { isSameAddress } from '@rabby-wallet/base-utils/dist/isomorphic/address';
 
 import { useLoadAssets } from '@/screens/Search/useAssets';
-import { useAccountInfo } from '../hooks';
+import { useHomeAssetAccountInfo } from '../hooks';
 import type { HomeTabName as TabName } from '@/hooks/navigation';
 import { useMyAccounts } from '@/hooks/account';
 import addressBalanceStore, { balanceAccountsStore } from '@/store/balance';
@@ -53,7 +53,7 @@ export const useCheckIsExpireAndUpdate = ({
   isFocusing: boolean;
 }) => {
   const initRef = useRef(false);
-  const { myTop10Addresses } = useAccountInfo();
+  const { myTop10Addresses } = useHomeAssetAccountInfo();
   const balanceAccounts = useActivityStore(
     balanceAccountsStore,
     state => state.balance,

--- a/apps/mobile/src/screens/Home/TokenList.tsx
+++ b/apps/mobile/src/screens/Home/TokenList.tsx
@@ -450,6 +450,7 @@ export const TokenList = ({
 
   const {
     sections: customTestnetSections,
+    hydrationState: customTestnetHydrationState,
     loadTokens: loadCustomTestnetTokens,
     loadToken: loadCustomTestnetToken,
   } = useSingleAddressCustomTestnetAssetSections(currentAddress);
@@ -458,6 +459,10 @@ export const TokenList = ({
     !isWatchOrSafeAccount(currentAccount) &&
     !selectedChain &&
     !isLpTokenEnabled;
+  const isCustomTestnetSnapshotPending =
+    shouldShowCustomTestnetSections &&
+    customTestnetHydrationState !== 'ready' &&
+    customTestnetHydrationState !== 'failed';
 
   const singleAssetsKey = useMemo(() => {
     if (!lowerAddress) {
@@ -528,6 +533,7 @@ export const TokenList = ({
     !hasDefaultTokenData;
   const visibleCustomTestnetSections =
     shouldShowCustomTestnetSections &&
+    customTestnetHydrationState === 'ready' &&
     hasRequestedTokenList &&
     !shouldHideCustomTestnetSectionsWhileLoading
       ? customTestnetSections
@@ -536,6 +542,7 @@ export const TokenList = ({
     hasDefaultTokenData || visibleCustomTestnetSections.length > 0;
   const isTokenContentReady =
     isTokenProjectionReady &&
+    !isCustomTestnetSnapshotPending &&
     (hasVisibleTokenContent ||
       (hasRequestedTokenList &&
         isTokenListRequestSettled &&
@@ -603,7 +610,8 @@ export const TokenList = ({
       foldScam,
       hasFoldTokens,
       isLpTokenEnabled,
-      isLoading: isLoading || isTokenProjectionLoading,
+      isLoading:
+        isLoading || isTokenProjectionLoading || isCustomTestnetSnapshotPending,
       isAllLoading,
       noAnyAssets,
       emptyAssetsText,
@@ -618,6 +626,7 @@ export const TokenList = ({
     isAllLoading,
     isLoading,
     isLpTokenEnabled,
+    isCustomTestnetSnapshotPending,
     isTokenProjectionLoading,
     noAnyAssets,
     scamTokenIds,

--- a/apps/mobile/src/screens/Home/hooks/store.ts
+++ b/apps/mobile/src/screens/Home/hooks/store.ts
@@ -5,7 +5,7 @@ import {
   DisplayNftItem,
 } from '../types';
 import { useMemo } from 'react';
-import { useAccountInfo } from '@/screens/Address/components/MultiAssets/hooks';
+import { useHomeAssetAccountInfo } from '@/screens/Address/components/MultiAssets/hooks';
 import nftListStore, {
   combinedNfts,
   getAssetsMapDirectly,
@@ -87,7 +87,7 @@ export function useAssetsNFTs({
 }) {
   const globalNftsMap = nftListStore(s => s.nftsMap);
 
-  const { myTop10Addresses } = useAccountInfo();
+  const { myTop10Addresses } = useHomeAssetAccountInfo();
 
   const memoNfts = useMemo(() => {
     if (hideCombined) {

--- a/apps/mobile/src/screens/Testkits/DevSwitches.tsx
+++ b/apps/mobile/src/screens/Testkits/DevSwitches.tsx
@@ -42,6 +42,7 @@ import {
   useDebugSwapHistorySkipLocalLookup,
   useEnablePerpsWatchAddress,
   useExpScreenCapture,
+  useHomeAssetSelectionSettings,
   useIosForceDisableAlertForSensitiveScene,
   useMockBatchRevoke,
   useScreenE2EEnabled,
@@ -52,6 +53,7 @@ import {
   WIDE_SCREEN_DEBUG_PANEL_MIN_ALLOWED_WIDTH,
   WIDE_SCREEN_DEBUG_PANEL_WIDTH,
 } from '@/hooks/appSettings';
+import { HOME_ASSET_TOP_N_OPTIONS } from '@/constant/homeAssetSelection';
 import type { SwitchToggleType } from '@/components';
 import { AppBottomSheetModal } from '@/components';
 import AutoLockView from '@/components/AutoLockView';
@@ -1618,6 +1620,78 @@ function DevSwitchPerpsWatchAddress() {
   );
 }
 
+function DevSwitchHomeAssetSelection() {
+  const { styles } = useTheme2024({ getStyle: getStyles });
+  const {
+    topN,
+    includeWatchAddresses,
+    isExperimentEnabled,
+    setTopN,
+    setIncludeWatchAddresses,
+  } = useHomeAssetSelectionSettings();
+
+  return (
+    <View style={styles.showCaseRowsContainer}>
+      <View style={styles.secondarySectionHeader}>
+        <RcCode
+          width={24}
+          height={24}
+          color={styles.secondarySectionTitle.color}
+        />
+        <Text
+          style={[
+            styles.secondarySectionTitle,
+            { fontSize: 24, marginLeft: 2 },
+          ]}>
+          Home Asset Selection
+        </Text>
+      </View>
+
+      <TouchableOpacity
+        style={styles.switchRowWrapper}
+        onPress={() => {
+          setIncludeWatchAddresses(!includeWatchAddresses);
+        }}>
+        <AppSwitch2024
+          value={includeWatchAddresses}
+          onPress={evt => evt.stopPropagation()}
+          onValueChange={setIncludeWatchAddresses}
+        />
+        <Text style={styles.switchLabel}>
+          {includeWatchAddresses
+            ? 'Include Watch and other non-owned addresses in Home Top-N'
+            : 'Use owned addresses only (default)'}
+        </Text>
+      </TouchableOpacity>
+
+      <View
+        style={[
+          styles.secondarySectionContent,
+          { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 12 },
+        ]}>
+        {HOME_ASSET_TOP_N_OPTIONS.map(option => (
+          <Button
+            key={option}
+            title={'Top ' + option}
+            type={option === topN ? 'primary' : 'ghost'}
+            height={40}
+            containerStyle={{ minWidth: 84 }}
+            onPress={() => setTopN(option)}
+          />
+        ))}
+      </View>
+      <Text style={[styles.metaLabel, { marginTop: 4 }]}>
+        {isExperimentEnabled
+          ? 'Test-only policy active: Top ' +
+            topN +
+            (includeWatchAddresses ? ' with Watch addresses.' : '.')
+          : 'Production-compatible default: Top 10 owned addresses.'}{' '}
+        Production builds always keep the default policy.
+      </Text>
+    </View>
+  );
+}
+
 function DevSwitchRegressionScenarioE2E() {
   const { styles } = useTheme2024({ getStyle: getStyles });
   const { screenE2EEnabled, setScreenE2EEnabled } = useScreenE2EEnabled();
@@ -1862,6 +1936,9 @@ function DevSwitches(): JSX.Element {
 
         <Text style={styles.areaTitle}>Perps</Text>
         <DevSwitchPerpsWatchAddress />
+
+        <Text style={styles.areaTitle}>Asset Scale</Text>
+        <DevSwitchHomeAssetSelection />
 
         <Text style={styles.areaTitle}>Lifecycle E2E</Text>
         <DevSwitchRegressionScenarioE2E />

--- a/apps/mobile/src/startup/launchTaskDefinitions.ts
+++ b/apps/mobile/src/startup/launchTaskDefinitions.ts
@@ -130,6 +130,17 @@ export function createLaunchTaskDefinitions(
       },
     },
     {
+      taskKey: 'customTestnetSnapshotHydration',
+      run: async () => {
+        const { ensureCustomTestnetStoreHydrated } = await loadLaunchModule(
+          'customTestnetSnapshotHydration',
+          'core/serviceApi/customTestnet',
+          loaders.customTestnetSnapshotHydration,
+        );
+        await ensureCustomTestnetStoreHydrated();
+      },
+    },
+    {
       taskKey: 'transactionWatchersStart',
       run: async () => {
         const { ensureServiceApiReady } = await loadLaunchModule(

--- a/apps/mobile/src/startup/moduleLoading/launchTaskContracts.ts
+++ b/apps/mobile/src/startup/moduleLoading/launchTaskContracts.ts
@@ -18,6 +18,9 @@ export type LaunchTaskLoaderCatalog = {
   computationWorkerPrewarm: LaunchTaskModuleLoader<{
     requestComputationThreadStart: (reason?: string) => unknown;
   }>;
+  customTestnetSnapshotHydration: LaunchTaskModuleLoader<{
+    ensureCustomTestnetStoreHydrated: () => unknown | Promise<unknown>;
+  }>;
   globalNetworkPolling: LaunchTaskModuleLoader<{
     startGlobalNetworkPolling: () => unknown;
   }>;

--- a/apps/mobile/src/startup/moduleLoading/launchTaskLoaders.eager.ts
+++ b/apps/mobile/src/startup/moduleLoading/launchTaskLoaders.eager.ts
@@ -5,6 +5,7 @@ import * as lang from '@/hooks/lang';
 import * as globalStatus from '@/hooks/useGlobalStatus';
 import * as computationThread from '@/perfs/thread';
 import * as lock from '@/core/apis/lock';
+import * as customTestnet from '@/core/serviceApi/customTestnet';
 import * as deferredServiceApi from '@/core/serviceApi/createDeferredServiceApi';
 import * as syncChain from '@/core/serviceApi/syncChain';
 import * as homePreSplashLocalState from '@/setup-home-pre-splash-state';
@@ -15,6 +16,7 @@ export const launchTaskLoaders = {
   biometricsSystemAuthAvailability: () => Promise.resolve(biometrics),
   bootstrapI18nReady: () => Promise.resolve(lang),
   computationWorkerPrewarm: () => Promise.resolve(computationThread),
+  customTestnetSnapshotHydration: () => Promise.resolve(customTestnet),
   globalNetworkPolling: () => Promise.resolve(globalStatus),
   homePreSplashLocalStateWarmup: () => Promise.resolve(homePreSplashLocalState),
   lockUnlockEventBridge: () => Promise.resolve(lock),

--- a/apps/mobile/src/startup/moduleLoading/launchTaskLoaders.lazy.ts
+++ b/apps/mobile/src/startup/moduleLoading/launchTaskLoaders.lazy.ts
@@ -6,6 +6,8 @@ export const launchTaskLoaders = {
   biometricsSystemAuthAvailability: () => import('@/hooks/biometrics'),
   bootstrapI18nReady: () => import('@/hooks/lang'),
   computationWorkerPrewarm: () => import('@/perfs/thread'),
+  customTestnetSnapshotHydration: () =>
+    import('@/core/serviceApi/customTestnet'),
   globalNetworkPolling: () => import('@/hooks/useGlobalStatus'),
   homePreSplashLocalStateWarmup: () => import('@/setup-home-pre-splash-state'),
   lockUnlockEventBridge: () => import('@/core/apis/lock'),

--- a/apps/mobile/src/startup/startupLifecycle.integration.test.ts
+++ b/apps/mobile/src/startup/startupLifecycle.integration.test.ts
@@ -61,6 +61,7 @@ const EXPECTED_LAUNCH_TASK_LABELS = [
   'network.globalPolling',
   'home.preSplashLocalStateWarmup',
   'computation.workerPrewarm',
+  'customTestnet.snapshotHydration',
   'transaction.watchersStart',
   'chain.syncMetadataWarmup',
 ];
@@ -142,6 +143,11 @@ function createBoundaryLoaders(events: string[]): LaunchTaskLoaderCatalog {
     computationWorkerPrewarm: async () => ({
       requestComputationThreadStart: reason => {
         events.push(`worker:${reason}`);
+      },
+    }),
+    customTestnetSnapshotHydration: async () => ({
+      ensureCustomTestnetStoreHydrated: async () => {
+        events.push('custom-testnet:snapshot-hydrated');
       },
     }),
     transactionWatchersStart: async () => ({
@@ -332,6 +338,7 @@ describe.each([
       expect(markHomeEntryReadyIfEligible(readiness, name)).toBe(true);
       await flushMicrotasks();
       expect(events).toContain('keyringService:loader-started');
+      expect(events).not.toContain('custom-testnet:snapshot-hydrated');
       expect(lifecycleStore.getState().accountContextReady).toBe(false);
 
       keyring.release();
@@ -345,6 +352,7 @@ describe.each([
 
       expect(getHomeStartupReady()).toBe(true);
       expect(getHomePostStartupReady()).toBe(true);
+      expect(events).toContain('custom-testnet:snapshot-hydrated');
       expect(events).toEqual(
         expect.arrayContaining([
           'transactionWatcherService:requested',

--- a/apps/mobile/src/store/balance.test.ts
+++ b/apps/mobile/src/store/balance.test.ts
@@ -103,6 +103,14 @@ describe('store/balance', () => {
     jest.doMock('@rabby-wallet/keyring-utils', () => ({
       CORE_KEYRING_TYPES: ['SimpleKeyring'],
     }));
+    jest.doMock('@/hooks/appSettings', () => ({
+      getHomeAssetSelectionSettings: () => ({
+        topN: 10,
+        includeWatchAddresses: false,
+      }),
+      getHomeAssetSelectionSettingsKey: () => '10:0',
+      isHomeAssetSelectionExperimentEnabled: () => false,
+    }));
 
     balanceModule = require('./balance');
   });

--- a/apps/mobile/src/store/balance.ts
+++ b/apps/mobile/src/store/balance.ts
@@ -6,6 +6,11 @@ import type { EvmTotalBalanceResponse } from '@/databases/hooks/balance';
 import { HOME_REFRESH_INTERVAL } from '@/constant/home';
 import { appStorage } from '@/core/storage/mmkv';
 import { APP_MMKV_WEAK_KEYS } from '@/core/storage/mmkvConstants';
+import {
+  getHomeAssetSelectionSettings,
+  getHomeAssetSelectionSettingsKey,
+  isHomeAssetSelectionExperimentEnabled,
+} from '@/hooks/appSettings';
 import { isSameAddress } from '@rabby-wallet/base-utils/dist/isomorphic/address';
 import type { KeyringTypeName } from '@rabby-wallet/keyring-utils';
 import { CORE_KEYRING_TYPES } from '@rabby-wallet/keyring-utils';
@@ -1043,8 +1048,12 @@ class AddressBalanceStore extends ResourceBaseStore<AddressBalanceResourceValue>
           return nextBalance;
         }
 
+        const selectionPolicyKey = getHomeAssetSelectionSettingsKey();
         const selectionSnapshot = await getAccountBalanceSelectionSnapshot();
         if (!selectionSnapshot) {
+          return retBalances;
+        }
+        if (selectionPolicyKey !== getHomeAssetSelectionSettingsKey()) {
           return retBalances;
         }
         const { selectedAccounts, selectedAddresses } = selectionSnapshot;
@@ -1059,6 +1068,10 @@ class AddressBalanceStore extends ResourceBaseStore<AddressBalanceResourceValue>
               endpoint: 'openapi.getTotalBalanceV2',
             },
           );
+        }
+
+        if (selectionPolicyKey !== getHomeAssetSelectionSettingsKey()) {
+          return retBalances;
         }
 
         Object.assign(
@@ -1191,7 +1204,7 @@ const { EventEmitter: AccountsBalanceEE } =
 export const balanceAccountsStore = zCreate(
   zMutative<AccountsBalanceState>(() => ({
     balance: {},
-    selectedAddresses: getCachedHomeTop10Addresses(),
+    selectedAddresses: getCachedHomeSelectedAddresses(),
     hasResolvedSelection: false,
     hasResolvedMatteredAccountLength: false,
     matteredAccountLength: 0,
@@ -1249,10 +1262,12 @@ async function getAccountBalanceSelectionSnapshot() {
   return accountBalanceSelectionSnapshotGetter?.() ?? null;
 }
 
-function getCachedHomeTop10Addresses() {
-  const cached = appStorage.getItem(APP_MMKV_WEAK_KEYS.HOME_TOP10_ADDRESSES) as
-    | string[]
-    | null;
+function getCachedHomeAddresses(
+  key:
+    | typeof APP_MMKV_WEAK_KEYS.HOME_TOP10_ADDRESSES
+    | typeof APP_MMKV_WEAK_KEYS.HOME_NONPROD_ASSET_SELECTION,
+) {
+  const cached = appStorage.getItem(key) as string[] | null;
   if (!Array.isArray(cached)) {
     return [];
   }
@@ -1266,12 +1281,64 @@ function getCachedHomeTop10Addresses() {
   );
 }
 
-function persistCachedHomeTop10Addresses(addresses: string[]) {
+function getCachedHomeTop10Addresses() {
+  return getCachedHomeAddresses(APP_MMKV_WEAK_KEYS.HOME_TOP10_ADDRESSES);
+}
+
+type CachedNonprodHomeAssetSelection = {
+  topN?: unknown;
+  includeWatchAddresses?: unknown;
+  addresses?: unknown;
+};
+
+function getCachedHomeNonprodAssetSelectionAddresses() {
+  const cached = appStorage.getItem(
+    APP_MMKV_WEAK_KEYS.HOME_NONPROD_ASSET_SELECTION,
+  ) as CachedNonprodHomeAssetSelection | null;
+  const settings = getHomeAssetSelectionSettings();
+
+  if (
+    !cached ||
+    cached.topN !== settings.topN ||
+    cached.includeWatchAddresses !== settings.includeWatchAddresses ||
+    !Array.isArray(cached.addresses)
+  ) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      cached.addresses
+        .filter(address => typeof address === 'string' && !!address)
+        .map(address => address.toLowerCase()),
+    ),
+  );
+}
+
+function getCachedHomeSelectedAddresses() {
+  return isHomeAssetSelectionExperimentEnabled()
+    ? getCachedHomeNonprodAssetSelectionAddresses()
+    : getCachedHomeTop10Addresses();
+}
+
+function persistCachedHomeSelectedAddresses(addresses: string[]) {
+  const normalizedAddresses = Array.from(
+    new Set(addresses.filter(Boolean).map(address => address.toLowerCase())),
+  );
+
+  if (isHomeAssetSelectionExperimentEnabled()) {
+    const { topN, includeWatchAddresses } = getHomeAssetSelectionSettings();
+    appStorage.setItem(APP_MMKV_WEAK_KEYS.HOME_NONPROD_ASSET_SELECTION, {
+      topN,
+      includeWatchAddresses,
+      addresses: normalizedAddresses,
+    });
+    return;
+  }
+
   appStorage.setItem(
     APP_MMKV_WEAK_KEYS.HOME_TOP10_ADDRESSES,
-    Array.from(
-      new Set(addresses.filter(Boolean).map(address => address.toLowerCase())),
-    ),
+    normalizedAddresses,
   );
 }
 
@@ -1352,7 +1419,7 @@ function setAccountsBalanceState(
   );
 
   if (selectionChanged) {
-    persistCachedHomeTop10Addresses(nextState.selectedAddresses);
+    persistCachedHomeSelectedAddresses(nextState.selectedAddresses);
     accountsBalanceEvents.emit('SELECTION_CHANGED', {
       prevAddresses: prevState.selectedAddresses,
       nextAddresses: nextState.selectedAddresses,
@@ -1578,4 +1645,8 @@ export function startProcessAddressBalanceEvents() {
 
 export const addressBalanceStore = new AddressBalanceStore();
 export default addressBalanceStore;
-export { getCachedHomeTop10Addresses };
+export {
+  getCachedHomeNonprodAssetSelectionAddresses,
+  getCachedHomeSelectedAddresses,
+  getCachedHomeTop10Addresses,
+};

--- a/apps/mobile/src/store/balance24h.test.ts
+++ b/apps/mobile/src/store/balance24h.test.ts
@@ -4,7 +4,9 @@ describe('store/balance24h', () => {
   const mockSetBalance24hCache = jest.fn();
   const mockComputeTotalBalance = jest.fn();
   const mockGetBalanceCacheAccounts = jest.fn();
+  const mockGetSelectedBalanceAddressesSnapshot = jest.fn(() => [] as string[]);
   const mockGetTop10MyAccounts = jest.fn();
+  const mockIsHomeAssetSelectionExperimentEnabled = jest.fn(() => false);
   const mockPerfEmit = jest.fn();
   let mockBalanceValueMap: Record<
     string,
@@ -54,6 +56,10 @@ describe('store/balance24h', () => {
       getTop10MyAccounts: (...args: unknown[]) =>
         mockGetTop10MyAccounts(...args),
     }));
+    jest.doMock('@/hooks/appSettings', () => ({
+      isHomeAssetSelectionExperimentEnabled: (...args: unknown[]) =>
+        mockIsHomeAssetSelectionExperimentEnabled(...args),
+    }));
     jest.doMock('@/core/services', () => ({
       keyringService: {
         on: jest.fn(),
@@ -79,10 +85,21 @@ describe('store/balance24h', () => {
           balance: mockGetBalanceCacheAccounts(),
         })),
       },
+      getSelectedBalanceAddressesSnapshot: (...args: unknown[]) =>
+        mockGetSelectedBalanceAddressesSnapshot(...args),
       accountsBalanceEvents: {
         on: jest.fn(),
       },
     }));
+
+    mockGetSelectedBalanceAddressesSnapshot.mockReset();
+    mockGetSelectedBalanceAddressesSnapshot.mockReturnValue([]);
+    mockGetTop10MyAccounts.mockReset();
+    mockGetTop10MyAccounts.mockResolvedValue({
+      top10Addresses: [],
+    });
+    mockIsHomeAssetSelectionExperimentEnabled.mockReset();
+    mockIsHomeAssetSelectionExperimentEnabled.mockReturnValue(false);
 
     balance24hModule = require('./balance24h');
   });
@@ -137,6 +154,56 @@ describe('store/balance24h', () => {
       sourceOfCurrentValue: 'hydrate',
       hasValue: true,
     });
+  });
+
+  it('uses the active balance selection instead of re-reading the legacy Top-10 list', async () => {
+    mockGetSelectedBalanceAddressesSnapshot.mockReturnValue([
+      '0xselected-a',
+      '0xselected-b',
+    ]);
+    mockGetBalance24hCache.mockReturnValue(null);
+    mockFetch24hBalance.mockResolvedValue({
+      data: { total_usd_value: 1 },
+      updateTime: 1,
+    });
+
+    await balance24hModule.scene24hBalanceStore.refresh24hAssets({
+      reason: 'manual_refresh',
+    });
+
+    expect(mockFetch24hBalance.mock.calls.map(([address]) => address)).toEqual([
+      '0xselected-a',
+      '0xselected-b',
+    ]);
+  });
+
+  it('retains the legacy Top-10 fallback until normal selection resolves', async () => {
+    mockGetTop10MyAccounts.mockResolvedValue({
+      top10Addresses: ['0xlegacy'],
+    });
+    mockGetBalance24hCache.mockReturnValue(null);
+    mockFetch24hBalance.mockResolvedValue({
+      data: { total_usd_value: 1 },
+      updateTime: 1,
+    });
+
+    await balance24hModule.scene24hBalanceStore.refresh24hAssets({
+      reason: 'manual_refresh',
+    });
+
+    expect(mockGetTop10MyAccounts).toHaveBeenCalledTimes(1);
+    expect(mockFetch24hBalance).toHaveBeenCalledWith('0xlegacy');
+  });
+
+  it('does not fall back to Top-10 while an experimental selection is unresolved', async () => {
+    mockIsHomeAssetSelectionExperimentEnabled.mockReturnValue(true);
+
+    await balance24hModule.scene24hBalanceStore.refresh24hAssets({
+      reason: 'manual_refresh',
+    });
+
+    expect(mockGetTop10MyAccounts).not.toHaveBeenCalled();
+    expect(mockFetch24hBalance).not.toHaveBeenCalled();
   });
 
   it('updates in-memory cache before scheduling persistence when fetching fresh data', async () => {

--- a/apps/mobile/src/store/balance24h.ts
+++ b/apps/mobile/src/store/balance24h.ts
@@ -12,6 +12,7 @@ import {
   balanceAccountsStore,
   getSelectedBalanceAddressesSnapshot,
 } from './balance';
+import { isHomeAssetSelectionExperimentEnabled } from '@/hooks/appSettings';
 import { formatSmallUsdValue } from './curveShared';
 import { formatUsdValue } from '@/utils/number';
 import { debounce, isEqual } from 'lodash';
@@ -143,7 +144,7 @@ const build24hTraceDetail = (
 
 async function getSelectedBalanceAddressesOrTop10Fallback() {
   const selectedAddresses = getSelectedBalanceAddressesSnapshot();
-  if (selectedAddresses.length) {
+  if (selectedAddresses.length || isHomeAssetSelectionExperimentEnabled()) {
     return selectedAddresses;
   }
 

--- a/apps/mobile/src/store/balanceAccountSelection.test.ts
+++ b/apps/mobile/src/store/balanceAccountSelection.test.ts
@@ -23,6 +23,27 @@ const flushPromises = () =>
 describe('account balance selection lifecycle', () => {
   const mockHydrateCachedBalancesForAccounts = jest.fn();
   const mockApplyAccountBalanceSelectionSnapshot = jest.fn();
+  const mockFilterMyAccounts = jest.fn((accounts: Array<{ type: string }>) =>
+    accounts.filter(account => account.type !== 'WatchAddressKeyring'),
+  );
+  const mockSubscribeHomeAssetSelectionSettings = jest.fn();
+
+  let homeAssetSelectionSettings = {
+    topN: 10,
+    includeWatchAddresses: false,
+  };
+  let accountState = {
+    accounts: [] as Array<{
+      address: string;
+      type: string;
+      brandName: string;
+    }>,
+    hasFetchedAccounts: false,
+    pinnedAddresses: [] as Array<{
+      address: string;
+      brandName: string;
+    }>,
+  };
 
   let accountSubscriber:
     | ((state: {
@@ -45,9 +66,18 @@ describe('account balance selection lifecycle', () => {
     jest.clearAllMocks();
     accountSubscriber = undefined;
     committedAddresses = [];
+    homeAssetSelectionSettings = {
+      topN: 10,
+      includeWatchAddresses: false,
+    };
+    accountState = {
+      accounts: [],
+      hasFetchedAccounts: false,
+      pinnedAddresses: [],
+    };
 
     jest.doMock('@/core/apis/account', () => ({
-      filterMyAccounts: (accounts: unknown[]) => accounts,
+      filterMyAccounts: mockFilterMyAccounts,
       filterOutTop10Accounts: (
         accounts: Array<{
           address: string;
@@ -55,9 +85,42 @@ describe('account balance selection lifecycle', () => {
       ) => ({
         top10Accounts: accounts.slice(0, 10),
         top10Addresses: accounts.slice(0, 10).map(account => account.address),
+        top10Records: new Set(
+          accounts.slice(0, 10).map(account => account.address.toLowerCase()),
+        ),
+        restAccounts: accounts.slice(10),
       }),
+      filterOutTopAccounts: (
+        accounts: Array<{ address: string }>,
+        options: { topCount: number },
+      ) => {
+        const topRecords = new Set<string>();
+        accounts.forEach(account => {
+          if (topRecords.size < options.topCount) {
+            topRecords.add(account.address.toLowerCase());
+          }
+        });
+        return {
+          topAccounts: accounts.filter(account =>
+            topRecords.has(account.address.toLowerCase()),
+          ),
+          topAddresses: Array.from(topRecords),
+          topRecords,
+          restAccounts: accounts.filter(
+            account => !topRecords.has(account.address.toLowerCase()),
+          ),
+        };
+      },
       getAccountList: jest.fn(),
       sortAccountList: (accounts: unknown[]) => accounts,
+    }));
+    jest.doMock('@/hooks/appSettings', () => ({
+      getHomeAssetSelectionSettings: () => homeAssetSelectionSettings,
+      isHomeAssetSelectionExperimentEnabled: (
+        settings = homeAssetSelectionSettings,
+      ) => settings.topN !== 10 || settings.includeWatchAddresses,
+      subscribeHomeAssetSelectionSettings:
+        mockSubscribeHomeAssetSelectionSettings,
     }));
     jest.doMock('@/core/serviceApi/keyring', () => ({
       bindKeyringEventAfterRegistration: jest.fn(),
@@ -69,11 +132,7 @@ describe('account balance selection lifecycle', () => {
     jest.doMock('./account', () => ({
       __esModule: true,
       default: {
-        getState: () => ({
-          accounts: [],
-          hasFetchedAccounts: false,
-          pinnedAddresses: [],
-        }),
+        getState: () => accountState,
         subscribe: (subscriber: typeof accountSubscriber) => {
           accountSubscriber = subscriber;
           return jest.fn();
@@ -191,5 +250,39 @@ describe('account balance selection lifecycle', () => {
     expect(mockApplyAccountBalanceSelectionSnapshot).toHaveBeenCalledTimes(3);
     expect(committedAddresses).not.toContain(deletedAccount.address);
     expect(committedAddresses).toContain(promotedAccount.address);
+  });
+
+  it('includes Watch addresses and applies the configured Top-N in non-production policy', async () => {
+    homeAssetSelectionSettings = {
+      topN: 20,
+      includeWatchAddresses: true,
+    };
+    accountState = {
+      accounts: [
+        {
+          address: '0xowned',
+          type: 'SimpleKeyring',
+          brandName: 'Rabby',
+        },
+        {
+          address: '0xwatch',
+          type: 'WatchAddressKeyring',
+          brandName: 'Rabby',
+        },
+      ],
+      hasFetchedAccounts: true,
+      pinnedAddresses: [],
+    };
+
+    const { ensureAccountBalanceSelectionLifecycle } =
+      require('./balanceAccountSelection') as typeof import('./balanceAccountSelection');
+
+    await ensureAccountBalanceSelectionLifecycle();
+
+    expect(committedAddresses).toEqual(['0xowned', '0xwatch']);
+    expect(mockFilterMyAccounts).not.toHaveBeenCalled();
+    expect(mockHydrateCachedBalancesForAccounts).toHaveBeenCalledWith(
+      accountState.accounts,
+    );
   });
 });

--- a/apps/mobile/src/store/balanceAccountSelection.ts
+++ b/apps/mobile/src/store/balanceAccountSelection.ts
@@ -2,10 +2,15 @@ import { unionBy } from 'lodash';
 
 import {
   filterMyAccounts,
-  filterOutTop10Accounts,
   getAccountList,
   sortAccountList,
 } from '@/core/apis/account';
+import {
+  getHomeAssetSelectionSettings,
+  isHomeAssetSelectionExperimentEnabled,
+  subscribeHomeAssetSelectionSettings,
+  type HomeAssetSelectionSettings,
+} from '@/hooks/appSettings';
 import {
   bindKeyringEventAfterRegistration,
   isKeyringUnlockedSnapshot,
@@ -19,34 +24,44 @@ import addressBalanceStore, {
   setAccountBalanceSelectionSnapshotGetter,
   startProcessAddressBalanceEvents,
 } from './balance';
+import { pickHomeAccountSelectionFromSortedAccounts } from './homePortfolio/accountSelection';
 
-function pickSelectedAccountsFromSortedAccounts(sortedAccounts: Account[]) {
-  const { top10Accounts, top10Addresses } = filterOutTop10Accounts(
-    sortedAccounts,
-    {
-      gatherSameAddress: false,
-    },
-  );
+export function pickSelectedAccountsFromSortedAccounts(
+  sortedAccounts: Account[],
+  settings: HomeAssetSelectionSettings = getHomeAssetSelectionSettings(),
+) {
+  const { selectedAccounts, selectedAddresses } =
+    pickHomeAccountSelectionFromSortedAccounts(sortedAccounts, {
+      topN: settings.topN,
+      uniqueAddresses: isHomeAssetSelectionExperimentEnabled(settings),
+    });
 
   return {
-    selectedAccounts: unionBy(top10Accounts, account =>
+    selectedAccounts: unionBy(selectedAccounts, account =>
       account.address.toLowerCase(),
     ),
-    selectedAddresses: top10Addresses.map(address => address.toLowerCase()),
+    selectedAddresses,
   };
 }
 
 async function getMatteredAccountsSnapshot(): Promise<AccountBalanceSelectionSnapshot> {
-  const { sortedAccounts } = await getAccountList({ filter: 'onlyMine' });
-  return buildMatteredAccountsSnapshotFromSortedAccounts(sortedAccounts);
+  const settings = getHomeAssetSelectionSettings();
+  const { sortedAccounts } = await getAccountList({
+    filter: settings.includeWatchAddresses ? 'all' : 'onlyMine',
+  });
+  return buildMatteredAccountsSnapshotFromSortedAccounts(
+    sortedAccounts,
+    settings,
+  );
 }
 
 function buildMatteredAccountsSnapshotFromSortedAccounts(
   sortedAccounts: Account[],
+  settings: HomeAssetSelectionSettings = getHomeAssetSelectionSettings(),
 ): AccountBalanceSelectionSnapshot {
   const matteredAccountLength = sortedAccounts.length;
   const { selectedAccounts, selectedAddresses } =
-    pickSelectedAccountsFromSortedAccounts(sortedAccounts);
+    pickSelectedAccountsFromSortedAccounts(sortedAccounts, settings);
 
   return {
     selectedAccounts,
@@ -59,11 +74,18 @@ function buildMatteredAccountsSnapshotFromStoreAccounts(
   accounts: Account[],
   pinnedAddresses: IPinAddress[],
 ) {
-  const sortedAccounts = sortAccountList(filterMyAccounts(accounts), {
-    highlightedAddresses: pinnedAddresses,
-  });
+  const settings = getHomeAssetSelectionSettings();
+  const sortedAccounts = sortAccountList(
+    settings.includeWatchAddresses ? accounts : filterMyAccounts(accounts),
+    {
+      highlightedAddresses: pinnedAddresses,
+    },
+  );
 
-  return buildMatteredAccountsSnapshotFromSortedAccounts(sortedAccounts);
+  return buildMatteredAccountsSnapshotFromSortedAccounts(
+    sortedAccounts,
+    settings,
+  );
 }
 
 setAccountBalanceSelectionSnapshotGetter(getMatteredAccountsSnapshot);
@@ -156,6 +178,12 @@ async function initAccountBalanceSelectionLifecycle() {
         accountBalanceSelectionLifecycleStateRef.prevSelectionSignature =
           nextSignature;
         void syncSelectionFromAccounts({ accountState: state });
+      });
+
+      subscribeHomeAssetSelectionSettings(() => {
+        void syncSelectionFromAccounts({
+          allowFetchFallback: true,
+        });
       });
     }
 

--- a/apps/mobile/src/store/customTestnet.test.ts
+++ b/apps/mobile/src/store/customTestnet.test.ts
@@ -11,6 +11,8 @@ jest.mock('@/core/utils/reexports', () => {
 import {
   buildCustomTestnetAssetSections,
   getCustomTestnetAssetSections,
+  markCustomTestnetStoreHydrating,
+  markCustomTestnetStoreHydrationFailed,
   syncCustomTestnetStore,
   useCustomTestnetStore,
 } from './customTestnet';
@@ -30,8 +32,28 @@ describe('store/customTestnet', () => {
     useCustomTestnetStore.setState({
       customTestnet: {},
       customTokenList: [],
+      hydrationState: 'pending',
       revision: 0,
     });
+  });
+
+  it('keeps the initial empty snapshot distinct from a hydrated empty snapshot', () => {
+    expect(useCustomTestnetStore.getState().hydrationState).toBe('pending');
+
+    markCustomTestnetStoreHydrating();
+    expect(useCustomTestnetStore.getState().hydrationState).toBe('hydrating');
+
+    syncCustomTestnetStore({
+      customTestnet: {},
+      customTokenList: [],
+    });
+    expect(useCustomTestnetStore.getState().hydrationState).toBe('ready');
+
+    markCustomTestnetStoreHydrating();
+    expect(useCustomTestnetStore.getState().hydrationState).toBe('ready');
+
+    markCustomTestnetStoreHydrationFailed();
+    expect(useCustomTestnetStore.getState().hydrationState).toBe('ready');
   });
 
   it('builds native and custom token sections from custom testnet state', () => {

--- a/apps/mobile/src/store/customTestnet.ts
+++ b/apps/mobile/src/store/customTestnet.ts
@@ -16,9 +16,17 @@ type CustomTestnetSnapshot = {
   customTokenList: CustomTestnetTokenBase[];
 };
 
+export type CustomTestnetHydrationState =
+  | 'pending'
+  | 'hydrating'
+  | 'ready'
+  | 'failed';
+
 type CustomTestnetState = CustomTestnetSnapshot & {
+  hydrationState: CustomTestnetHydrationState;
   revision: number;
   setSnapshot(snapshot: CustomTestnetSnapshot): void;
+  setHydrationState(state: CustomTestnetHydrationState): void;
 };
 
 const EMPTY_CUSTOM_TESTNET: Record<string, TestnetChain> = {};
@@ -28,18 +36,39 @@ const EMPTY_OWNER_ADDRESSES: string[] = [];
 export const useCustomTestnetStore = zCreate<CustomTestnetState>(set => ({
   customTestnet: EMPTY_CUSTOM_TESTNET,
   customTokenList: EMPTY_CUSTOM_TOKEN_LIST,
+  hydrationState: 'pending',
   revision: 0,
   setSnapshot(snapshot) {
     set(state => ({
       customTestnet: snapshot.customTestnet,
       customTokenList: snapshot.customTokenList,
+      hydrationState: 'ready',
       revision: state.revision + 1,
     }));
+  },
+  setHydrationState(hydrationState) {
+    set({ hydrationState });
   },
 }));
 
 export const syncCustomTestnetStore = (snapshot: CustomTestnetSnapshot) => {
   useCustomTestnetStore.getState().setSnapshot(snapshot);
+};
+
+export const markCustomTestnetStoreHydrating = () => {
+  const { hydrationState, setHydrationState } =
+    useCustomTestnetStore.getState();
+  if (hydrationState !== 'ready') {
+    setHydrationState('hydrating');
+  }
+};
+
+export const markCustomTestnetStoreHydrationFailed = () => {
+  const { hydrationState, setHydrationState } =
+    useCustomTestnetStore.getState();
+  if (hydrationState !== 'ready') {
+    setHydrationState('failed');
+  }
 };
 
 export const buildCustomTestnetAssetSections = ({
@@ -116,3 +145,11 @@ export const useCustomTestnetAssetSectionsData = (
     [customTestnet, customTokenList, ownerAddresses],
   );
 };
+
+export const useCustomTestnetHydrationState = () =>
+  useActivityStore(
+    useCustomTestnetStore,
+    state => state.hydrationState,
+    Object.is,
+    { storeLabel: 'custom-testnet-assets' },
+  );

--- a/apps/mobile/src/store/homePortfolio/accountSelection.test.ts
+++ b/apps/mobile/src/store/homePortfolio/accountSelection.test.ts
@@ -1,0 +1,115 @@
+import {
+  DEFAULT_HOME_ASSET_TOP_N,
+  coerceHomeAssetTopN,
+} from '@/constant/homeAssetSelection';
+
+const mockFilterOutTop10Accounts = jest.fn(
+  (accounts: Array<{ address: string }>) => {
+    const top10Accounts = accounts.slice(0, 10);
+    const top10Records = new Set(
+      top10Accounts.map(account => account.address.toLowerCase()),
+    );
+    return {
+      top10Accounts,
+      top10Addresses: Array.from(top10Records),
+      top10Records,
+      restAccounts: accounts.slice(10),
+    };
+  },
+);
+
+const mockFilterOutTopAccounts = jest.fn(
+  (accounts: Array<{ address: string }>, options: { topCount: number }) => {
+    const topRecords = new Set<string>();
+    accounts.forEach(account => {
+      if (topRecords.size < options.topCount) {
+        topRecords.add(account.address.toLowerCase());
+      }
+    });
+    return {
+      topAccounts: accounts.filter(account =>
+        topRecords.has(account.address.toLowerCase()),
+      ),
+      topAddresses: Array.from(topRecords),
+      topRecords,
+      restAccounts: accounts.filter(
+        account => !topRecords.has(account.address.toLowerCase()),
+      ),
+    };
+  },
+);
+
+jest.mock('@/core/apis/account', () => ({
+  filterOutTop10Accounts: (...args: unknown[]) =>
+    mockFilterOutTop10Accounts(...args),
+  filterOutTopAccounts: (...args: unknown[]) =>
+    mockFilterOutTopAccounts(...args),
+}));
+
+import { pickHomeAccountSelectionFromSortedAccounts } from './accountSelection';
+
+describe('home account selection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps the legacy Top-10 behavior for the production-compatible default', () => {
+    const accounts = Array.from({ length: 12 }, (_, index) => ({
+      address: `0x${index}`,
+    }));
+
+    const selection = pickHomeAccountSelectionFromSortedAccounts(accounts);
+
+    expect(selection.selectedAddresses).toEqual(
+      accounts.slice(0, 10).map(account => account.address),
+    );
+    expect(mockFilterOutTop10Accounts).toHaveBeenCalledWith(accounts, {
+      gatherSameAddress: false,
+    });
+    expect(mockFilterOutTopAccounts).not.toHaveBeenCalled();
+  });
+
+  it('preserves distinct legacy account records that share an address', () => {
+    const accounts = [
+      { address: '0xaaa', brandName: 'Rabby' },
+      { address: '0xAAA', brandName: 'Ledger' },
+      ...Array.from({ length: 9 }, (_, index) => ({
+        address: `0x${index}`,
+        brandName: 'Rabby',
+      })),
+    ];
+
+    const selection = pickHomeAccountSelectionFromSortedAccounts(accounts);
+
+    expect(selection.selectedAccounts).toEqual(accounts.slice(0, 10));
+    expect(selection.restAccounts).toEqual(accounts.slice(10));
+  });
+
+  it('counts unique addresses for an explicit non-production Top-N policy', () => {
+    const accounts = [
+      { address: '0xaaa' },
+      { address: '0xAAA' },
+      { address: '0xbbb' },
+      { address: '0xccc' },
+      { address: '0xddd' },
+    ];
+
+    const selection = pickHomeAccountSelectionFromSortedAccounts(accounts, {
+      topN: 3,
+      uniqueAddresses: true,
+    });
+
+    expect(selection.selectedAddresses).toEqual(['0xaaa', '0xbbb', '0xccc']);
+    expect(selection.selectedAccounts.map(account => account.address)).toEqual([
+      '0xaaa',
+      '0xbbb',
+      '0xccc',
+    ]);
+  });
+
+  it('accepts only the reviewed Top-N tiers', () => {
+    expect(coerceHomeAssetTopN(50)).toBe(50);
+    expect(coerceHomeAssetTopN('100')).toBe(100);
+    expect(coerceHomeAssetTopN(75)).toBe(DEFAULT_HOME_ASSET_TOP_N);
+  });
+});

--- a/apps/mobile/src/store/homePortfolio/accountSelection.ts
+++ b/apps/mobile/src/store/homePortfolio/accountSelection.ts
@@ -1,0 +1,97 @@
+import { unionBy } from 'lodash';
+
+import {
+  filterOutTop10Accounts,
+  filterOutTopAccounts,
+} from '@/core/apis/account';
+import { DEFAULT_HOME_ASSET_TOP_N } from '@/constant/homeAssetSelection';
+
+type AddressAccount = {
+  address: string;
+  balance?: number;
+};
+
+export type HomeAccountSelection<T extends AddressAccount> = {
+  selectedAccounts: T[];
+  selectedAddresses: string[];
+  selectedAddressRecords: Set<string>;
+  restAccounts: T[];
+};
+
+export function pickHomeAccountSelectionFromSortedAccounts<
+  T extends AddressAccount,
+>(
+  sortedAccounts: T[],
+  options?: { topN?: number; uniqueAddresses?: boolean },
+): HomeAccountSelection<T> {
+  const topN = Math.max(
+    1,
+    Math.floor(options?.topN ?? DEFAULT_HOME_ASSET_TOP_N),
+  );
+
+  if (topN === DEFAULT_HOME_ASSET_TOP_N && !options?.uniqueAddresses) {
+    const { top10Accounts, top10Addresses, top10Records, restAccounts } =
+      filterOutTop10Accounts(sortedAccounts, {
+        gatherSameAddress: false,
+      });
+
+    return {
+      selectedAccounts: top10Accounts,
+      selectedAddresses: top10Addresses.map(address => address.toLowerCase()),
+      selectedAddressRecords: top10Records,
+      restAccounts,
+    };
+  }
+
+  const { topAccounts, topAddresses, topRecords, restAccounts } =
+    filterOutTopAccounts(sortedAccounts, {
+      topCount: topN,
+      gatherSameAddress: true,
+    });
+
+  return {
+    selectedAccounts: unionBy(topAccounts, account =>
+      account.address.toLowerCase(),
+    ),
+    selectedAddresses: topAddresses.map(address => address.toLowerCase()),
+    selectedAddressRecords: topRecords,
+    restAccounts,
+  };
+}
+
+export function pickHomeAccountSelectionFromAddresses<T extends AddressAccount>(
+  sortedAccounts: T[],
+  addresses: string[],
+): HomeAccountSelection<T> {
+  const accountByAddress = new Map<string, T>();
+  sortedAccounts.forEach(account => {
+    const address = account.address.toLowerCase();
+    if (!accountByAddress.has(address)) {
+      accountByAddress.set(address, account);
+    }
+  });
+
+  const selectedAddressRecords = new Set<string>();
+  const selectedAddresses: string[] = [];
+  const selectedAccounts: T[] = [];
+  addresses.forEach(address => {
+    const normalizedAddress = address.toLowerCase();
+    const account = accountByAddress.get(normalizedAddress);
+    if (!account || selectedAddressRecords.has(normalizedAddress)) {
+      return;
+    }
+
+    selectedAddressRecords.add(normalizedAddress);
+    selectedAddresses.push(normalizedAddress);
+    selectedAccounts.push(account);
+  });
+
+  return {
+    selectedAccounts,
+    selectedAddresses,
+    selectedAddressRecords,
+    restAccounts: sortedAccounts.filter(
+      account => !selectedAddressRecords.has(account.address.toLowerCase()),
+    ),
+  };
+}

--- a/apps/mobile/src/store/homePortfolio/runtime.ts
+++ b/apps/mobile/src/store/homePortfolio/runtime.ts
@@ -1,4 +1,5 @@
 import { filterMyAccounts } from '@/core/apis/account';
+import { getHomeAssetSelectionSettings } from '@/hooks/appSettings';
 import { zCreate } from '@/core/utils/reexports';
 import { useActivityStore } from '@/hooks/storeActivity/useActivityStore';
 import accountStore from '@/store/account';
@@ -132,7 +133,9 @@ function syncHomeAccountProjection() {
       selectedAddresses: balanceState.selectedAddresses,
       hasResolvedSelection: balanceState.hasResolvedSelection,
       matteredAccountLength: canUseFetchedAccountLength
-        ? filterMyAccounts(accountsState.accounts).length
+        ? getHomeAssetSelectionSettings().includeWatchAddresses
+          ? accountsState.accounts.length
+          : filterMyAccounts(accountsState.accounts).length
         : balanceState.matteredAccountLength,
       hasResolvedMatteredAccountLength:
         balanceState.hasResolvedMatteredAccountLength ||


### PR DESCRIPTION
## Summary

- hydrate the persisted custom-testnet snapshot during the post-startup Home lifecycle without activating the full custom-testnet service
- keep Home custom-token loading pending until snapshot hydration settles, while failing open on a genuine hydration failure
- add non-production-only Home asset selection controls for Watch addresses and configurable Top-N coverage
- preserve the production owned-account Top-10 path exactly

## Acceptance context

This fixes acceptance finding #933: after cold start, assets on a previously added custom network no longer require opening the Custom Testnet page first.

The real-device fixture requires adding the network through chainlist.org Connect Wallet / RPC because that network is not present in the app's built-in chain list. Watch-address inclusion alone is not a complete fixture.

## Verification

- targeted Jest: 5 suites, 21 tests passed
- startup lifecycle integration: 2 tests passed
- TypeScript typecheck passed
- module-loading and service API boundary checks passed
- Regression APK built successfully; Android 16 KB page-size check passed
- verified on Huawei FIN-AL60 with the complete custom-network + Watch-address fixture

Runtime impact: runtime fix, review required