### PR TITLE
fix(mobile): clean partial local storage exports

### DIFF
--- a/apps/mobile/src/core/storage/localStorageArchive.test.ts
+++ b/apps/mobile/src/core/storage/localStorageArchive.test.ts
@@ -1,0 +1,125 @@
+type LocalStorageArchiveModule = typeof import('./localStorageArchive');
+
+function createStorage() {
+  return {
+    getAllKeys: jest.fn(() => []),
+    getString: jest.fn(),
+    getNumber: jest.fn(),
+    getBoolean: jest.fn(),
+    getBuffer: jest.fn(),
+  };
+}
+
+function loadLocalStorageArchive({
+  isNonPublicProductionEnv,
+  writeFile = jest.fn(async () => undefined),
+}: {
+  isNonPublicProductionEnv: boolean;
+  writeFile?: jest.Mock;
+}) {
+  jest.resetModules();
+
+  const exists = jest.fn(
+    async (path: string) => path !== '/documents/rabby.db',
+  );
+  const unlink = jest.fn(async () => undefined);
+  const createZipArchive = jest.fn(async () => undefined);
+  const shareLocalFile = jest.fn(async () => ({ dismissed: false }));
+
+  jest.doMock('@/constant', () => ({ isNonPublicProductionEnv }));
+  jest.doMock('@/databases/constant', () => ({
+    getRabbyAppDbName: () => 'rabby.db',
+    getRabbyAppDbPath: () => '/documents/rabby.db',
+  }));
+  jest.doMock('@/core/utils/appFS', () => ({
+    APP_DOCUMENT_LIKE_PATH: '/documents',
+    MMKV_ROOT_PATH: '/mmkv',
+  }));
+  jest.doMock('@/utils/shareLocalFile', () => ({ shareLocalFile }));
+  jest.doMock('./mmkvInstances', () => ({
+    keyringMMKV: createStorage(),
+    ALL_KNOWN_MMKV_INSTANCES: {
+      first: createStorage(),
+      second: createStorage(),
+    },
+  }));
+  jest.doMock('@rabby-wallet/react-native-fs', () => ({
+    TemporaryDirectoryPath: '/tmp',
+    CachesDirectoryPath: '/cache',
+    exists,
+    readDir: jest.fn(async (path: string) =>
+      path === '/mmkv'
+        ? [
+            {
+              name: 'first.mmkv',
+              path: '/mmkv/first.mmkv',
+              isFile: () => true,
+              isDirectory: () => false,
+            },
+          ]
+        : [],
+    ),
+    isNativeZipArchiveAvailable: jest.fn(() => true),
+    mkdir: jest.fn(async () => undefined),
+    writeFile,
+    createZipArchive,
+    unlink,
+  }));
+
+  let module: LocalStorageArchiveModule | undefined;
+  jest.isolateModules(() => {
+    module = require('./localStorageArchive') as LocalStorageArchiveModule;
+  });
+
+  return {
+    module: module as LocalStorageArchiveModule,
+    mocks: { createZipArchive, exists, shareLocalFile, unlink, writeFile },
+  };
+}
+
+describe('local storage archive', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('rejects production exports before touching local storage', async () => {
+    const { module, mocks } = loadLocalStorageArchive({
+      isNonPublicProductionEnv: false,
+    });
+
+    await expect(module.shareCurrentLocalStorageArchive()).rejects.toThrow(
+      'Local storage export is unavailable in production builds.',
+    );
+    expect(mocks.exists).not.toHaveBeenCalled();
+    expect(mocks.writeFile).not.toHaveBeenCalled();
+    expect(mocks.shareLocalFile).not.toHaveBeenCalled();
+  });
+
+  it('removes every attempted raw MMKV dump when a write fails', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(123);
+    const writeFailure = new Error('disk write failed');
+    const writeFile = jest
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(writeFailure);
+    const { module, mocks } = loadLocalStorageArchive({
+      isNonPublicProductionEnv: true,
+      writeFile,
+    });
+
+    await expect(module.shareCurrentLocalStorageArchive()).rejects.toBe(
+      writeFailure,
+    );
+
+    const archiveDir = '/tmp/rabby-local-storage-export';
+    expect(mocks.unlink).toHaveBeenCalledWith(
+      `${archiveDir}/rabby-mmkv-first-123.json`,
+    );
+    expect(mocks.unlink).toHaveBeenCalledWith(
+      `${archiveDir}/rabby-mmkv-second-123.json`,
+    );
+    expect(mocks.createZipArchive).not.toHaveBeenCalled();
+    expect(mocks.shareLocalFile).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/core/storage/localStorageArchive.ts
+++ b/apps/mobile/src/core/storage/localStorageArchive.ts
@@ -145,6 +145,16 @@ function getErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error);
 }
 
+async function cleanupExistingPaths(paths: string[]) {
+  await Promise.allSettled(
+    paths.map(async path => {
+      if (await RNFS.exists(path)) {
+        await RNFS.unlink(path);
+      }
+    }),
+  );
+}
+
 function readRawMMKVEntry(
   storage: typeof keyringMMKV,
   key: string,
@@ -231,21 +241,27 @@ async function writeRawMMKVDumps({
   const cleanupPaths: string[] = [];
   let totalKeyCount = 0;
 
-  for (const [storageId, storage] of Object.entries(
-    ALL_KNOWN_MMKV_INSTANCES,
-  ).sort(([firstId], [secondId]) => firstId.localeCompare(secondId))) {
-    const name = `rabby-mmkv-${storageId}-${timestamp}.json`;
-    const path = `${archiveDir}/${name}`;
-    const dump = createRawMMKVDump(storageId, storage);
+  try {
+    for (const [storageId, storage] of Object.entries(
+      ALL_KNOWN_MMKV_INSTANCES,
+    ).sort(([firstId], [secondId]) => firstId.localeCompare(secondId))) {
+      const name = `rabby-mmkv-${storageId}-${timestamp}.json`;
+      const path = `${archiveDir}/${name}`;
+      const dump = createRawMMKVDump(storageId, storage);
 
-    await RNFS.writeFile(path, JSON.stringify(dump, null, 2), 'utf8');
+      // A rejected write may still leave a partial file on disk.
+      cleanupPaths.push(path);
+      await RNFS.writeFile(path, JSON.stringify(dump, null, 2), 'utf8');
 
-    entries.push({
-      sourcePath: path,
-      archivePath: `mmkv-json/${storageId}.json`,
-    });
-    cleanupPaths.push(path);
-    totalKeyCount += dump.keyCount;
+      entries.push({
+        sourcePath: path,
+        archivePath: `mmkv-json/${storageId}.json`,
+      });
+      totalKeyCount += dump.keyCount;
+    }
+  } catch (error) {
+    await cleanupExistingPaths(cleanupPaths);
+    throw error;
   }
 
   return {
@@ -330,13 +346,7 @@ export async function shareCurrentLocalStorageArchive(): Promise<LocalStorageArc
       keyringStartupDiagnosticFileCount: keyringStartupDiagnosticEntries.length,
     };
   } catch (error) {
-    await Promise.allSettled(
-      [archivePath, ...rawMMKVDumpPaths].map(async path => {
-        if (await RNFS.exists(path)) {
-          await RNFS.unlink(path);
-        }
-      }),
-    );
+    await cleanupExistingPaths([archivePath, ...rawMMKVDumpPaths]);
 
     throw error;
   }

--- a/apps/mobile/src/utils/promptLocalStorageArchive.test.ts
+++ b/apps/mobile/src/utils/promptLocalStorageArchive.test.ts
@@ -1,0 +1,63 @@
+type PromptLocalStorageArchiveModule =
+  typeof import('./promptLocalStorageArchive');
+
+function loadPromptLocalStorageArchive(isNonPublicProductionEnv: boolean) {
+  jest.resetModules();
+
+  const alert = jest.fn();
+  const shareCurrentLocalStorageArchive = jest.fn();
+
+  jest.doMock('react-native', () => ({ Alert: { alert } }));
+  jest.doMock('@/constant', () => ({ isNonPublicProductionEnv }));
+  jest.doMock('@/core/storage/localStorageArchive', () => ({
+    shareCurrentLocalStorageArchive,
+  }));
+  jest.doMock('@/components2024/Toast', () => ({
+    toast: {
+      show: jest.fn(),
+      success: jest.fn(),
+    },
+  }));
+
+  let module: PromptLocalStorageArchiveModule | undefined;
+  jest.isolateModules(() => {
+    module =
+      require('./promptLocalStorageArchive') as PromptLocalStorageArchiveModule;
+  });
+
+  return {
+    module: module as PromptLocalStorageArchiveModule,
+    mocks: { alert, shareCurrentLocalStorageArchive },
+  };
+}
+
+describe('promptLocalStorageArchiveShare', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('never opens the hidden share prompt in production builds', () => {
+    const { module, mocks } = loadPromptLocalStorageArchive(false);
+
+    for (let tap = 0; tap < 20; tap += 1) {
+      module.promptLocalStorageArchiveShare();
+    }
+
+    expect(mocks.alert).not.toHaveBeenCalled();
+    expect(mocks.shareCurrentLocalStorageArchive).not.toHaveBeenCalled();
+  });
+
+  it('opens the confirmation prompt in non-production builds', () => {
+    const { module, mocks } = loadPromptLocalStorageArchive(true);
+
+    module.promptLocalStorageArchiveShare();
+
+    expect(mocks.alert).toHaveBeenCalledWith(
+      'Export local storage?',
+      expect.any(String),
+      expect.any(Array),
+      expect.any(Object),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- remove partially written raw MMKV JSON dumps when local storage export fails
- retain an independent production-build guard at the prompt and export boundaries
- cover production hidden-trigger behavior and partial-write cleanup with tests

## Validation
- `corepack yarn workspace rabby-mobile test src/core/storage/localStorageArchive.test.ts src/utils/promptLocalStorageArchive.test.ts --runInBand`
- `corepack yarn typecheck`
- `corepack yarn lint:cycles`
- `DISABLE_APP_TYPE_CHECK=true corepack yarn lint-staged`