### PR TITLE
fix(home): restore asset toggle spacing and Android DeFi expansion

### DIFF
--- a/apps/mobile/src/screens/Address/components/MultiAssets/ProtocolList.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/ProtocolList.tsx
@@ -472,7 +472,9 @@ export const ProtocolList = () => {
         maxToRenderPerBatch={8}
         updateCellsBatchingPeriod={32}
         removeClippedSubviews={IS_ANDROID}
-        maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
+        {...(!IS_ANDROID && {
+          maintainVisibleContentPosition: { minIndexForVisible: 0 },
+        })}
         ItemSeparatorComponent={ListRenderSeparator}
         ListHeaderComponent={
           <>

--- a/apps/mobile/src/screens/Home/TokenList.tsx
+++ b/apps/mobile/src/screens/Home/TokenList.tsx
@@ -695,15 +695,19 @@ export const TokenList = ({ onForeground, onRefresh }: Props) => {
 
   const renderAdditionalHeaderItem = useCallback(
     () => (
-      <TokenRowSectionLpTokenHeader
-        isEnabled={isLpTokenEnabled}
-        onValueChange={handleLpTokenEnabledChange}
-        fold={!showAllTokens}
-        str={additionalTokenUsdValue}
-        onPressFold={handleToggleAdditionalTokens}
-        style={styles.sectionHeader}
-        buttonStyle={additionalHeaderButtonStyle}
-      />
+      <View>
+        <View style={styles.additionalToggleSpacer} />
+        <TokenRowSectionLpTokenHeader
+          isEnabled={isLpTokenEnabled}
+          onValueChange={handleLpTokenEnabledChange}
+          fold={!showAllTokens}
+          str={additionalTokenUsdValue}
+          onPressFold={handleToggleAdditionalTokens}
+          style={styles.sectionHeader}
+          buttonStyle={additionalHeaderButtonStyle}
+        />
+        {!showAllTokens ? <View style={styles.additionalToggleSpacer} /> : null}
+      </View>
     ),
     [
       additionalTokenUsdValue,
@@ -712,6 +716,7 @@ export const TokenList = ({ onForeground, onRefresh }: Props) => {
       handleToggleAdditionalTokens,
       isLpTokenEnabled,
       showAllTokens,
+      styles.additionalToggleSpacer,
       styles.sectionHeader,
     ],
   );
@@ -934,6 +939,9 @@ const getStyles = createGetStyles2024(ctx => ({
     backgroundColor: ctx.colors2024['neutral-bg-gray'],
     // paddingRight: 8,
     height: ASSETS_SECTION_HEADER,
+  },
+  additionalToggleSpacer: {
+    height: SPACING_HEIGHT,
   },
   buttonHeader: {
     backgroundColor: ctx.colors2024['neutral-bg-1'],


### PR DESCRIPTION
## Summary\n- restore 8dp spacing around the Home asset toggle\n- avoid Android scroll-position maintenance when the first DeFi item expands\n\n## Validation\n- Android regression package manually verified for issues 937 and 938