### PR TITLE
Enhance Sentry reporting for API timeouts and WebSocket errors

### DIFF
--- a/apps/mobile/src/core/apis/perps.test.ts
+++ b/apps/mobile/src/core/apis/perps.test.ts
@@ -28,9 +28,17 @@ function loadPerpsModule({ isUnlocked = true }: { isUnlocked?: boolean } = {}) {
   const mockSetSelectedKlineInterval = jest.fn();
   const mockSetSendApproveAfterDeposit = jest.fn();
   const mockUpdateAgentWalletPreference = jest.fn();
+  const mockInstallPerpsSdkTimeoutReport = jest.fn();
+  const mockAttachPerpsWsReconnectReport = jest.fn();
 
   jest.doMock('@rabby-wallet/hyperliquid-sdk', () => ({
     HyperliquidSDK: mockHyperliquidSDK,
+  }));
+  // Covered by perpsSdkNetworkReport.test.ts; the fake SDK above has no
+  // HttpClient / ws event API for the real module to hook into.
+  jest.doMock('./perpsSdkNetworkReport', () => ({
+    installPerpsSdkTimeoutReport: mockInstallPerpsSdkTimeoutReport,
+    attachPerpsWsReconnectReport: mockAttachPerpsWsReconnectReport,
   }));
   jest.doMock('@/core/apis/lock', () => ({
     isUnlocked: (...args: unknown[]) => mockIsUnlocked(...args),
@@ -66,10 +74,12 @@ function loadPerpsModule({ isUnlocked = true }: { isUnlocked?: boolean } = {}) {
   return {
     apisPerps,
     mocks: {
+      mockAttachPerpsWsReconnectReport,
       mockCreateAgentWallet,
       mockDisconnect,
       mockGetAgentWallet,
       mockHyperliquidSDK,
+      mockInstallPerpsSdkTimeoutReport,
       mockIsUnlocked,
     },
   };
@@ -92,6 +102,10 @@ describe('core/apis/perps', () => {
       isTestnet: false,
       timeout: 10000,
     });
+    expect(mocks.mockInstallPerpsSdkTimeoutReport).toHaveBeenCalledTimes(1);
+    expect(mocks.mockAttachPerpsWsReconnectReport).toHaveBeenCalledWith(
+      firstSDK.ws,
+    );
 
     apisPerps.destroyPerpsSDK();
     expect(mocks.mockDisconnect).toHaveBeenCalledTimes(1);
@@ -99,6 +113,12 @@ describe('core/apis/perps', () => {
     const recreatedSDK = apisPerps.getPerpsSDK();
     expect(recreatedSDK).not.toBe(firstSDK);
     expect(mocks.mockHyperliquidSDK).toHaveBeenCalledTimes(2);
+    // A rebuilt SDK owns a fresh WebSocketClient, so the outage listener must
+    // be attached again.
+    expect(mocks.mockAttachPerpsWsReconnectReport).toHaveBeenCalledTimes(2);
+    expect(mocks.mockAttachPerpsWsReconnectReport).toHaveBeenLastCalledWith(
+      recreatedSDK.ws,
+    );
   });
 
   it('requires an unlocked wallet before creating an agent wallet', async () => {

--- a/apps/mobile/src/core/apis/perps.ts
+++ b/apps/mobile/src/core/apis/perps.ts
@@ -6,16 +6,22 @@ import { apisKeyring } from './keyring';
 import { PERPS_AGENT_NAME } from '@/constant/perps';
 import type { Account } from '../startupServices/preference';
 import type { ApproveSignatures } from '@/core/services/perpsService';
+import {
+  installPerpsSdkTimeoutReport,
+  attachPerpsWsReconnectReport,
+} from './perpsSdkNetworkReport';
 
 let sdkInstance: HyperliquidSDK | null = null;
 
 class ApisPerps {
   getPerpsSDK() {
     if (!sdkInstance) {
+      installPerpsSdkTimeoutReport();
       sdkInstance = new HyperliquidSDK({
         isTestnet: false,
         timeout: 10000,
       });
+      attachPerpsWsReconnectReport(sdkInstance.ws);
       return sdkInstance;
     }
 

--- a/apps/mobile/src/core/apis/perpsSdkNetworkReport.test.ts
+++ b/apps/mobile/src/core/apis/perpsSdkNetworkReport.test.ts
@@ -1,0 +1,181 @@
+const mockCaptureException = jest.fn();
+const mockRequest = jest.fn();
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
+jest.mock('@rabby-wallet/hyperliquid-sdk', () => {
+  class HttpClient {
+    async info(data: any) {
+      return mockRequest('info', data);
+    }
+    async exchange(data: any) {
+      return mockRequest('exchange', data);
+    }
+  }
+  return { HttpClient };
+});
+
+import { HttpClient } from '@rabby-wallet/hyperliquid-sdk';
+import type { WebSocketClient } from '@rabby-wallet/hyperliquid-sdk';
+import {
+  installPerpsSdkTimeoutReport,
+  attachPerpsWsReconnectReport,
+} from './perpsSdkNetworkReport';
+
+const client = new HttpClient();
+
+const timeoutOnce = () =>
+  mockRequest.mockRejectedValueOnce(new Error('Request timeout'));
+
+const callInfo = () =>
+  client.info({ type: 'clearinghouseState' }).catch(() => {});
+const callExchange = () =>
+  client.exchange({ action: { type: 'order' } }).catch(() => {});
+
+const timeoutInfoTimes = async (n: number) => {
+  for (let i = 0; i < n; i++) {
+    timeoutOnce();
+    await callInfo();
+  }
+};
+
+describe('installPerpsSdkTimeoutReport', () => {
+  beforeAll(() => {
+    installPerpsSdkTimeoutReport();
+  });
+
+  beforeEach(async () => {
+    mockRequest.mockReset();
+    // A success resets the consecutive-timeout streak left by the previous test.
+    mockRequest.mockResolvedValueOnce('ok');
+    await callInfo();
+    mockCaptureException.mockClear();
+  });
+
+  it('reports once after 5 consecutive timeouts, with request context', async () => {
+    await timeoutInfoTimes(4);
+    expect(mockCaptureException).not.toHaveBeenCalled();
+
+    await timeoutInfoTimes(1);
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    const [error, hint] = mockCaptureException.mock.calls[0];
+    expect(error.message).toBe('Hyperliquid API consecutive request timeout');
+    expect(hint.extra).toEqual({
+      endpoint: 'info',
+      requestType: 'clearinghouseState',
+      consecutiveTimeouts: 5,
+    });
+  });
+
+  it('does not report again while the same streak continues', async () => {
+    await timeoutInfoTimes(8);
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('a success resets the streak', async () => {
+    await timeoutInfoTimes(4);
+
+    mockRequest.mockResolvedValueOnce('ok');
+    await callInfo();
+
+    await timeoutInfoTimes(4);
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('a non-timeout error resets the streak', async () => {
+    await timeoutInfoTimes(4);
+
+    mockRequest.mockRejectedValueOnce(new Error('HTTP 500: Internal Error'));
+    await callInfo();
+
+    await timeoutInfoTimes(4);
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('the streak spans info and exchange endpoints', async () => {
+    await timeoutInfoTimes(4);
+
+    timeoutOnce();
+    await callExchange();
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException.mock.calls[0][1].extra).toEqual({
+      endpoint: 'exchange',
+      requestType: 'order',
+      consecutiveTimeouts: 5,
+    });
+  });
+
+  it('installing twice does not double-count timeouts', async () => {
+    installPerpsSdkTimeoutReport();
+    // Double-wrapped methods would count each failure twice and report here.
+    await timeoutInfoTimes(4);
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+});
+
+describe('attachPerpsWsReconnectReport', () => {
+  type Listener = (payload: any) => void;
+
+  const makeFakeWs = () => {
+    const listeners: Record<string, Listener[]> = {};
+    const ws = {
+      on: (event: string, listener: Listener) => {
+        (listeners[event] ??= []).push(listener);
+      },
+      getActiveSubscriptions: () => ['allMids', 'webData2'],
+    };
+    const emit = (event: string, payload: any) =>
+      listeners[event]?.forEach(listener => listener(payload));
+    return { ws: ws as unknown as WebSocketClient, emit };
+  };
+
+  beforeEach(() => {
+    mockCaptureException.mockClear();
+  });
+
+  it('reports once per outage when reconnect attempts reach the threshold', () => {
+    const { ws, emit } = makeFakeWs();
+    attachPerpsWsReconnectReport(ws);
+
+    for (let attempt = 1; attempt <= 4; attempt++) {
+      emit('reconnecting', { attempt, delayMs: 1000 });
+    }
+    expect(mockCaptureException).not.toHaveBeenCalled();
+
+    emit('reconnecting', { attempt: 5, delayMs: 8000 });
+    emit('reconnecting', { attempt: 6, delayMs: 16000 });
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    const [error, hint] = mockCaptureException.mock.calls[0];
+    expect(error.message).toBe('Hyperliquid WebSocket keeps reconnecting');
+    expect(hint.extra).toEqual({
+      attempt: 5,
+      delayMs: 8000,
+      activeSubscriptions: ['allMids', 'webData2'],
+    });
+  });
+
+  it('a successful open starts a new outage that can report again', () => {
+    const { ws, emit } = makeFakeWs();
+    attachPerpsWsReconnectReport(ws);
+
+    emit('reconnecting', { attempt: 5, delayMs: 8000 });
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+
+    emit('open', { resubscribed: 2 });
+    emit('reconnecting', { attempt: 5, delayMs: 8000 });
+    expect(mockCaptureException).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports when the SDK gives up reconnecting entirely', () => {
+    const { ws, emit } = makeFakeWs();
+    attachPerpsWsReconnectReport(ws);
+
+    emit('reconnectFailed', { attempts: 10 });
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException.mock.calls[0][0].message).toBe(
+      'Hyperliquid WebSocket reconnect gave up',
+    );
+  });
+});

--- a/apps/mobile/src/core/apis/perpsSdkNetworkReport.test.ts
+++ b/apps/mobile/src/core/apis/perpsSdkNetworkReport.test.ts
@@ -117,6 +117,7 @@ describe('installPerpsSdkTimeoutReport', () => {
 
 describe('attachPerpsWsReconnectReport', () => {
   type Listener = (payload: any) => void;
+  const WALLET_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
 
   const makeFakeWs = () => {
     const listeners: Record<string, Listener[]> = {};
@@ -124,7 +125,14 @@ describe('attachPerpsWsReconnectReport', () => {
       on: (event: string, listener: Listener) => {
         (listeners[event] ??= []).push(listener);
       },
-      getActiveSubscriptions: () => ['allMids', 'webData2'],
+      // Mirrors the SDK: keys are JSON.stringify(subscription), so user-scoped
+      // channels carry the wallet address.
+      getActiveSubscriptions: () => [
+        JSON.stringify({ type: 'allMids' }),
+        JSON.stringify({ type: 'clearinghouseState', user: WALLET_ADDRESS }),
+        JSON.stringify({ type: 'clearinghouseState', user: WALLET_ADDRESS }),
+        'not-json',
+      ],
     };
     const emit = (event: string, payload: any) =>
       listeners[event]?.forEach(listener => listener(payload));
@@ -152,8 +160,10 @@ describe('attachPerpsWsReconnectReport', () => {
     expect(hint.extra).toEqual({
       attempt: 5,
       delayMs: 8000,
-      activeSubscriptions: ['allMids', 'webData2'],
+      subscriptionTypes: { allMids: 1, clearinghouseState: 2, unknown: 1 },
     });
+    // Privacy: raw subscription keys embed the wallet address — never upload.
+    expect(JSON.stringify(hint)).not.toContain(WALLET_ADDRESS);
   });
 
   it('a successful open starts a new outage that can report again', () => {

--- a/apps/mobile/src/core/apis/perpsSdkNetworkReport.ts
+++ b/apps/mobile/src/core/apis/perpsSdkNetworkReport.ts
@@ -1,0 +1,117 @@
+import { HttpClient, WebSocketClient } from '@rabby-wallet/hyperliquid-sdk';
+import * as Sentry from '@sentry/react-native';
+
+// The SDK's HttpClient converts its own abort-timer firing into exactly
+// `new Error('Request timeout')` — the only timeout signature it produces.
+const TIMEOUT_MESSAGE = 'Request timeout';
+
+// A single timeout is routine on mobile networks. Only a streak of consecutive
+// timeouts means the Hyperliquid official API is effectively unreachable.
+const CONSECUTIVE_TIMEOUT_THRESHOLD = 5;
+
+// With the SDK's 3s-base / 30s-cap jittered backoff, 5 straight failed
+// reconnects means the WS endpoint has been unreachable for roughly a minute.
+const WS_RECONNECT_ATTEMPT_THRESHOLD = 5;
+
+let consecutiveTimeouts = 0;
+let installed = false;
+
+function trackRequestError(
+  endpoint: 'info' | 'exchange',
+  requestType: unknown,
+  error: unknown,
+) {
+  if ((error as Error | null)?.message !== TIMEOUT_MESSAGE) {
+    // A non-timeout failure (HTTP status / business error) means the network
+    // path to the API works — break the streak.
+    consecutiveTimeouts = 0;
+    return;
+  }
+  consecutiveTimeouts += 1;
+  // Report exactly once per streak, not on every request past the threshold.
+  if (consecutiveTimeouts !== CONSECUTIVE_TIMEOUT_THRESHOLD) {
+    return;
+  }
+  Sentry.captureException(
+    new Error('Hyperliquid API consecutive request timeout'),
+    {
+      extra: {
+        endpoint,
+        requestType,
+        consecutiveTimeouts,
+      },
+    },
+  );
+}
+
+/**
+ * Patch the SDK's HttpClient prototype so every Hyperliquid HTTP request goes
+ * through one choke point: InfoClient and ExchangeClient each construct their
+ * own HttpClient internally, so instance-level wrapping cannot cover both.
+ * Reports to Sentry when the official API keeps timing out; a success or a
+ * non-timeout error resets the streak. Install once, before the SDK is created.
+ */
+export function installPerpsSdkTimeoutReport() {
+  if (installed) {
+    return;
+  }
+  installed = true;
+  (['info', 'exchange'] as const).forEach(endpoint => {
+    const original = HttpClient.prototype[endpoint];
+    HttpClient.prototype[endpoint] = async function (
+      this: HttpClient,
+      data: any,
+    ) {
+      try {
+        const result = await original.call(this, data);
+        consecutiveTimeouts = 0;
+        return result;
+      } catch (error) {
+        // info bodies carry `type`; exchange bodies nest it in `action.type`.
+        trackRequestError(endpoint, data?.type ?? data?.action?.type, error);
+        throw error;
+      }
+    } as typeof original;
+  });
+}
+
+/**
+ * Report a Hyperliquid WebSocket outage to Sentry. The SDK resets its attempt
+ * counter on every successful open, so `reconnecting.attempt` counts failed
+ * reconnects within the current outage; report once per outage when it crosses
+ * the threshold. Attach once per WebSocketClient instance, right after the SDK
+ * is created (destroyPerpsSDK drops the instance, so a rebuilt SDK re-attaches
+ * to its fresh client).
+ */
+export function attachPerpsWsReconnectReport(ws: WebSocketClient) {
+  let reported = false;
+  ws.on('reconnecting', ({ attempt, delayMs }) => {
+    if (attempt < WS_RECONNECT_ATTEMPT_THRESHOLD || reported) {
+      return;
+    }
+    reported = true;
+    Sentry.captureException(
+      new Error('Hyperliquid WebSocket keeps reconnecting'),
+      {
+        extra: {
+          attempt,
+          delayMs,
+          activeSubscriptions: ws.getActiveSubscriptions(),
+        },
+      },
+    );
+  });
+  ws.on('open', () => {
+    reported = false;
+  });
+  // Never fires with the default Infinity maxReconnectAttempts, but covers any
+  // future config that makes the SDK give up for good.
+  ws.on('reconnectFailed', ({ attempts }) => {
+    Sentry.captureException(
+      new Error('Hyperliquid WebSocket reconnect gave up'),
+      {
+        extra: { attempts },
+      },
+    );
+  });
+}

--- a/apps/mobile/src/core/apis/perpsSdkNetworkReport.ts
+++ b/apps/mobile/src/core/apis/perpsSdkNetworkReport.ts
@@ -16,6 +16,28 @@ const WS_RECONNECT_ATTEMPT_THRESHOLD = 5;
 let consecutiveTimeouts = 0;
 let installed = false;
 
+/**
+ * The SDK keys active subscriptions by `JSON.stringify(subscription)`, so
+ * user-scoped channels embed the wallet address (and other params). Reduce to
+ * `{ type: count }` so the outage report carries no account identity.
+ */
+function summarizeSubscriptionTypes(keys: string[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  keys.forEach(key => {
+    let type = 'unknown';
+    try {
+      const parsed = JSON.parse(key);
+      if (typeof parsed?.type === 'string') {
+        type = parsed.type;
+      }
+    } catch {
+      // Not JSON — keep 'unknown' rather than leaking the raw key.
+    }
+    counts[type] = (counts[type] ?? 0) + 1;
+  });
+  return counts;
+}
+
 function trackRequestError(
   endpoint: 'info' | 'exchange',
   requestType: unknown,
@@ -96,7 +118,9 @@ export function attachPerpsWsReconnectReport(ws: WebSocketClient) {
         extra: {
           attempt,
           delayMs,
-          activeSubscriptions: ws.getActiveSubscriptions(),
+          subscriptionTypes: summarizeSubscriptionTypes(
+            ws.getActiveSubscriptions(),
+          ),
         },
       },
     );

--- a/apps/mobile/src/hooks/perps/perpsActionError.ts
+++ b/apps/mobile/src/hooks/perps/perpsActionError.ts
@@ -61,6 +61,23 @@ export function isUserCancelledSignature(error: unknown): boolean {
   return error === 'Canceled' || isWalletUnlockCancelled(error);
 }
 
+// Normalize a thrown value into an Error without losing information.
+// `String(obj)` yields "[object Object]" and `JSON.stringify(err)` yields "{}"
+// (Error props are non-enumerable) — both produced message-less Sentry issues.
+function toError(value: unknown): Error {
+  if (value instanceof Error) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    return new Error(value);
+  }
+  try {
+    return new Error(JSON.stringify(value) ?? String(value));
+  } catch {
+    return new Error(String(value));
+  }
+}
+
 type RunPerpsActionConfig<T> = {
   /** Value returned when an error is caught (after the side effects below). */
   fallback: T;
@@ -111,16 +128,20 @@ export async function runPerpsAction<T>(
         (error?.message || `${config.label} error`),
       'error',
     );
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      {
-        extra: {
-          title,
-          context: config.context,
-          rawError: error?.message ?? error,
-        },
+    Sentry.captureException(toError(error), {
+      // Searchable in the issue stream (`perps_action:*`) — the captured
+      // error's own message rarely contains "PERPS".
+      tags: { perps_action: config.label },
+      // Appended to the default grouping so that un-symbolicated builds
+      // (minified single-line stacks) can't lump perps errors into the same
+      // catch-all issue as unrelated errors sharing that stack shape.
+      fingerprint: ['{{ default }}', 'perps-action', config.label],
+      extra: {
+        title,
+        context: config.context,
+        rawError: error?.message ?? error,
       },
-    );
+    });
     return config.fallback;
   }
 }


### PR DESCRIPTION
This pull request introduces robust error reporting and monitoring for the Hyperliquid Perps SDK integration in the mobile app. The main focus is on tracking consecutive HTTP request timeouts and WebSocket reconnection issues, reporting them to Sentry for improved observability. Additionally, error normalization is improved to ensure meaningful error messages are captured in Sentry. Comprehensive tests are added to verify the new reporting logic.

**Error monitoring and reporting enhancements:**

* Added `installPerpsSdkTimeoutReport` and `attachPerpsWsReconnectReport` functions in `perpsSdkNetworkReport.ts` to monitor and report consecutive HTTP timeouts and problematic WebSocket reconnections to Sentry, including contextual details for easier debugging.
* Integrated these monitoring functions into the Perps SDK initialization in `perps.ts`, ensuring they are installed before SDK usage.

**Error normalization improvements:**

* Introduced a `toError` utility in `perpsActionError.ts` to consistently convert thrown values into `Error` objects, preserving error details for Sentry reporting.
* Updated Sentry reporting in `runPerpsAction` to use `toError`, and added custom tags and fingerprints for better issue grouping in Sentry.

**Testing:**

* Added comprehensive tests in `perpsSdkNetworkReport.test.ts` to verify correct Sentry reporting behavior for both HTTP timeout streaks and WebSocket reconnection issues.