### PR TITLE
fix: clear import error after scanning

### DIFF
--- a/apps/mobile/src/screens/Address/ImportPrivateKeyScreen.tsx
+++ b/apps/mobile/src/screens/Address/ImportPrivateKeyScreen.tsx
@@ -75,6 +75,7 @@ export const ImportPrivateKeyScreen = () => {
 
   React.useEffect(() => {
     if (scanner.text) {
+      setError(undefined);
       setPrivateKey(scanner.text);
       scanner.clear();
     }

--- a/apps/mobile/src/screens/Address/ImportPrivateKeyScreen2024.tsx
+++ b/apps/mobile/src/screens/Address/ImportPrivateKeyScreen2024.tsx
@@ -133,6 +133,7 @@ export const ImportPrivateKeyScreen2024 = () => {
 
   React.useEffect(() => {
     if (scanner.text) {
+      setError(undefined);
       setPrivateKey(scanner.text);
       scanner.clear();
     }

--- a/apps/mobile/src/screens/Address/ImportSecret.tsx
+++ b/apps/mobile/src/screens/Address/ImportSecret.tsx
@@ -395,14 +395,10 @@ export const ImportSecret = ({ route }: ScreenProps) => {
   // Handle scanner result
   React.useEffect(() => {
     if (scanner.text) {
-      if (activeTab === 'seedPhrase') {
-        setMnemonics(scanner.text);
-      } else {
-        setPrivateKey(scanner.text);
-      }
+      handleInputChange(activeTab, scanner.text);
       scanner.clear();
     }
-  }, [scanner, activeTab]);
+  }, [scanner, activeTab, handleInputChange]);
 
   const isConfirmDisabled = React.useMemo(() => {
     if (activeTab === 'seedPhrase') {

--- a/apps/mobile/src/screens/Address/ImportSeedPhraseScreen.tsx
+++ b/apps/mobile/src/screens/Address/ImportSeedPhraseScreen.tsx
@@ -160,6 +160,7 @@ export const ImportSeedPhraseScreen = () => {
 
   React.useEffect(() => {
     if (scanner.text) {
+      setError(undefined);
       setMnemonics(scanner.text);
       scanner.clear();
     }

--- a/apps/mobile/src/screens/Address/ImportSeedPhraseScreen2024.tsx
+++ b/apps/mobile/src/screens/Address/ImportSeedPhraseScreen2024.tsx
@@ -308,6 +308,7 @@ export const ImportSeedPhraseScreen2024 = () => {
 
   React.useEffect(() => {
     if (scanner.text) {
+      setError(undefined);
       setMnemonics(scanner.text);
       scanner.clear();
     }


### PR DESCRIPTION
## Problem

When importing a private key or seed phrase, entering an invalid value first shows a validation error. If the user then scans a valid value, the input is replaced but the previous error state is retained, so the Confirm button stays disabled. This can happen in both the unified import flow and the legacy Android add-address flow.

## Fix

- Route QR scan results in the unified flow through the existing input-change handler.
- Clear the matching validation error synchronously when legacy import screens receive a QR result.
- Cover both private-key and seed-phrase import paths without changing validation, import, or persistence behavior.

## Validation

- `yarn workspace rabby-mobile lint:cycles`
- `yarn workspace rabby-mobile lint:cycles:eslint`
- `yarn workspace rabby-mobile typecheck`
- `yarn workspace rabby-mobile test --runInBand --watchman=false`
- `yarn workspace rabby-mobile test:integration:ci --watchman=false`

The regression check covers the private-key and seed-phrase scan replacement paths.