### PR TITLE
fix add shell option for Windows compatibility in dev scripts

### DIFF
--- a/apps/mobile/scripts/prepare-dev.cjs
+++ b/apps/mobile/scripts/prepare-dev.cjs
@@ -100,7 +100,9 @@ function run(command, args, options = {}) {
     env: process.env,
     stdio: 'inherit',
     // Windows requires shell to execute .cmd files (Node CVE-2024-27980 fix)
-    shell: process.platform === 'win32',
+    shell:
+      process.platform === 'win32' &&
+      path.extname(command).toLowerCase() === '.cmd',
   });
 
   if (result.error) {

--- a/apps/mobile/scripts/prepare-dev.cjs
+++ b/apps/mobile/scripts/prepare-dev.cjs
@@ -99,6 +99,8 @@ function run(command, args, options = {}) {
     cwd: options.cwd || MOBILE_DIR,
     env: process.env,
     stdio: 'inherit',
+    // Windows requires shell to execute .cmd files (Node CVE-2024-27980 fix)
+    shell: process.platform === 'win32',
   });
 
   if (result.error) {

--- a/apps/mobile/scripts/start-dev.cjs
+++ b/apps/mobile/scripts/start-dev.cjs
@@ -45,6 +45,8 @@ const metro = spawn(
     cwd: MOBILE_DIR,
     env: environment,
     stdio: 'inherit',
+    // Windows requires shell to execute .cmd files (Node CVE-2024-27980 fix)
+    shell: process.platform === 'win32',
   },
 );
 


### PR DESCRIPTION
This pull request updates the mobile development scripts to improve compatibility with Windows and address a Node.js security advisory. The main change is ensuring that child processes are spawned with the `shell` option enabled on Windows, which is necessary for executing `.cmd` files and mitigates issues related to Node CVE-2024-27980.

**Windows compatibility and security fixes:**

* Updated the `run` function in `apps/mobile/scripts/prepare-dev.cjs` to set `shell: process.platform === 'win32'`, ensuring proper execution of `.cmd` files and addressing Node CVE-2024-27980.
* Updated the `spawn` call for Metro in `apps/mobile/scripts/start-dev.cjs` to set `shell: process.platform === 'win32'` for the same reasons.