### PR TITLE
chore: use Android Billing Client 8

### DIFF
--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -66,14 +66,94 @@ on:
         required: false
         type: string
         default: ''
+      IOS_SIGNING_EXPORT_PREFLIGHT_ONLY:
+        required: false
+        type: boolean
+        default: false
 
 defaults:
   run:
     shell: bash -ieol pipefail {0}
 
 jobs:
+  ios-signing-export-preflight:
+    name: iOS signing export preflight
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.IOS_SIGNING_EXPORT_PREFLIGHT_ONLY == true }}
+    runs-on:
+      - self-hosted
+      - macOS
+      - ${{ inputs.macos_machine_location }}
+    env:
+      BUILD_TARGET_PLATFORM: ios
+      XCODE_VER: '26.3'
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          clean: false
+
+      - name: Clean git Manually
+        run: |
+          yarn_exclude_args=()
+          if [ "${RABBY_MOBILE_NM_USE_CACHE:-true}" = "true" ]; then
+            echo "Keep yarn install outputs";
+            yarn_exclude_args+=(
+              -e node_modules
+              -e 'apps/*/node_modules'
+              -e 'packages/*/node_modules'
+              -e .yarn/install-state.gz
+              -e .yarn/unplugged
+            )
+          fi
+
+          git clean -ffdx "${yarn_exclude_args[@]}";
+          git reset --hard HEAD;
+
+      - name: Env Test
+        id: env-test
+        run: |
+          echo "whoami $(whoami)"
+          echo "shell is $(echo $0)"
+          echo "HOME is $HOME"
+          echo "which node $(which node)"
+
+      - name: '[macOS] Setup Xcode'
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+        id: setup-xcode
+        with:
+          # use specific version rather than 'latest-stable' if multiple Xcodes installed
+          xcode-version: ${{ env.XCODE_VER }}
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Preflight iOS signing export
+        run: |
+          unset MATCH_GIT_BASIC_AUTHORIZATION
+
+          if [ "$INPUT_MOBILE_LOC" != "mobile-local" ]; then
+            RABBY_MOBILE_UNLOCK_KEYCHAIN_PASS="$KEYCHAIN_PASS"
+          fi
+          if [ -n "${RABBY_MOBILE_UNLOCK_KEYCHAIN_PASS:-}" ]; then
+            security unlock-keychain -p "$RABBY_MOBILE_UNLOCK_KEYCHAIN_PASS" login.keychain
+          else
+            echo "RABBY_MOBILE_UNLOCK_KEYCHAIN_PASS is not set; assuming keychain is already unlocked."
+          fi
+
+          cd apps/mobile
+          ./scripts/ci/ios-signing-export-preflight.sh
+        env:
+          KEYCHAIN_PASS: ${{ secrets.KEYCHAIN_PASS }}
+          MATCH_PASSWORD: ${{ secrets.RABBY_MOBILE_MATCH_PASSWORD }}
+          RABBY_MOBILE_MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.RABBY_MOBILE_MATCH_GIT_BASIC_AUTHORIZATION }}
+          RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_S3_URI: ${{ secrets.RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_S3_URI }}
+          RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_SHA256: ${{ secrets.RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_SHA256 }}
+          INPUT_MOBILE_LOC: ${{ inputs.macos_machine_location }}
+          DISABLE_AWS_CLI_HTTPS_VALIDATION: ${{ inputs.__DANGEROUS_NO_VERIFY_SSL }}
+
   setup:
     name: Build
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.IOS_SIGNING_EXPORT_PREFLIGHT_ONLY != true }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -31,6 +31,10 @@ on:
         required: true
         type: boolean
         default: false
+      IOS_SIGNING_EXPORT_PREFLIGHT_ONLY:
+        required: true
+        type: boolean
+        default: false
   workflow_call:
     secrets:
       KEYCHAIN_PASS:
@@ -122,6 +126,7 @@ jobs:
         run: corepack enable
 
       - name: Preflight App Store Connect API key
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.IOS_SIGNING_EXPORT_PREFLIGHT_ONLY != true || inputs.ASC_PREFLIGHT_ONLY == true }}
         run: |
           node <<'NODE'
           const crypto = require('crypto');
@@ -269,11 +274,35 @@ jobs:
           RABBY_MOBILE_ASC_API_BUNDLE_ID: com.debank.rabby-mobile
 
       - name: Stop after ASC preflight
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.ASC_PREFLIGHT_ONLY == true }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.ASC_PREFLIGHT_ONLY == true && inputs.IOS_SIGNING_EXPORT_PREFLIGHT_ONLY != true }}
         run: echo "ASC preflight-only mode enabled; skipping dependency install and app build."
 
+      - name: Preflight iOS signing export
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.IOS_SIGNING_EXPORT_PREFLIGHT_ONLY == true }}
+        run: |
+          unset MATCH_GIT_BASIC_AUTHORIZATION
+
+          if [ "$INPUT_MOBILE_LOC" != "mobile-local" ]; then
+            RABBY_MOBILE_UNLOCK_KEYCHAIN_PASS="$KEYCHAIN_PASS"
+          fi
+          if [ -n "${RABBY_MOBILE_UNLOCK_KEYCHAIN_PASS:-}" ]; then
+            security unlock-keychain -p "$RABBY_MOBILE_UNLOCK_KEYCHAIN_PASS" login.keychain
+          else
+            echo "RABBY_MOBILE_UNLOCK_KEYCHAIN_PASS is not set; assuming keychain is already unlocked."
+          fi
+
+          cd apps/mobile
+          ./scripts/ci/ios-signing-export-preflight.sh
+        env:
+          KEYCHAIN_PASS: ${{ secrets.KEYCHAIN_PASS }}
+          MATCH_PASSWORD: ${{ secrets.RABBY_MOBILE_MATCH_PASSWORD }}
+          RABBY_MOBILE_MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.RABBY_MOBILE_MATCH_GIT_BASIC_AUTHORIZATION }}
+          RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_S3_URI: ${{ secrets.RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_S3_URI }}
+          RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_SHA256: ${{ secrets.RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_SHA256 }}
+          INPUT_MOBILE_LOC: ${{ inputs.macos_machine_location }}
+
       - name: Install dependencies && Build app
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.ASC_PREFLIGHT_ONLY != true }}
+        if: ${{ github.event_name != 'workflow_dispatch' || (inputs.ASC_PREFLIGHT_ONLY != true && inputs.IOS_SIGNING_EXPORT_PREFLIGHT_ONLY != true) }}
         run: |
           unset MATCH_GIT_BASIC_AUTHORIZATION
           cd apps/mobile;

--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -27,6 +27,10 @@ on:
         required: false
         type: string
         default: ''
+      ASC_PREFLIGHT_ONLY:
+        required: true
+        type: boolean
+        default: false
   workflow_call:
     secrets:
       KEYCHAIN_PASS:
@@ -264,7 +268,12 @@ jobs:
           RABBY_MOBILE_ASC_API_PRIVATE_KEY_BASE64: ${{ secrets.RABBY_MOBILE_ASC_API_PRIVATE_KEY_BASE64 }}
           RABBY_MOBILE_ASC_API_BUNDLE_ID: com.debank.rabby-mobile
 
+      - name: Stop after ASC preflight
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.ASC_PREFLIGHT_ONLY == true }}
+        run: echo "ASC preflight-only mode enabled; skipping dependency install and app build."
+
       - name: Install dependencies && Build app
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.ASC_PREFLIGHT_ONLY != true }}
         run: |
           unset MATCH_GIT_BASIC_AUTHORIZATION
           cd apps/mobile;

--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -117,6 +117,153 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      - name: Preflight App Store Connect API key
+        run: |
+          node <<'NODE'
+          const crypto = require('crypto');
+          const https = require('https');
+
+          const requiredEnvNames = [
+            'RABBY_MOBILE_ASC_API_KEY_ID',
+            'RABBY_MOBILE_ASC_API_ISSUER_ID',
+            'RABBY_MOBILE_ASC_API_PRIVATE_KEY_BASE64',
+          ];
+
+          const missingEnvNames = requiredEnvNames.filter(name => !process.env[name]);
+          if (missingEnvNames.length > 0) {
+            console.error(`[asc-preflight] missing env: ${missingEnvNames.join(', ')}`);
+            process.exit(1);
+          }
+
+          const keyId = process.env.RABBY_MOBILE_ASC_API_KEY_ID;
+          const issuerId = process.env.RABBY_MOBILE_ASC_API_ISSUER_ID;
+          const privateKeyBase64 = process.env.RABBY_MOBILE_ASC_API_PRIVATE_KEY_BASE64;
+          const bundleId = process.env.RABBY_MOBILE_ASC_API_BUNDLE_ID || 'com.debank.rabby-mobile';
+
+          console.log(`[asc-preflight] key_id_length=${keyId.length}`);
+          console.log(`[asc-preflight] issuer_id_uuid_format=${/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(issuerId)}`);
+          console.log(`[asc-preflight] private_key_base64_length=${privateKeyBase64.length}`);
+          console.log(`[asc-preflight] private_key_base64_has_whitespace=${/\s/.test(privateKeyBase64)}`);
+
+          if (!/^[A-Za-z0-9+/=\s]+$/.test(privateKeyBase64)) {
+            console.error('[asc-preflight] private key base64 contains non-base64 characters');
+            process.exit(1);
+          }
+
+          let privateKeyPem;
+          try {
+            privateKeyPem = Buffer.from(privateKeyBase64, 'base64').toString('utf8');
+          } catch (error) {
+            console.error(`[asc-preflight] private key base64 decode failed: ${error.message}`);
+            process.exit(1);
+          }
+
+          console.log(`[asc-preflight] private_key_pem_has_header=${privateKeyPem.includes('BEGIN PRIVATE KEY')}`);
+          console.log(`[asc-preflight] private_key_pem_has_footer=${privateKeyPem.includes('END PRIVATE KEY')}`);
+
+          let privateKeyObject;
+          try {
+            privateKeyObject = crypto.createPrivateKey(privateKeyPem);
+          } catch (error) {
+            console.error(`[asc-preflight] private key parse failed: ${error.message}`);
+            process.exit(1);
+          }
+
+          const publicKeyDer = crypto.createPublicKey(privateKeyObject).export({
+            type: 'spki',
+            format: 'der',
+          });
+          const publicKeyFingerprint = crypto.createHash('sha256')
+            .update(publicKeyDer)
+            .digest('hex')
+            .slice(0, 16);
+          console.log(`[asc-preflight] public_key_sha256_prefix=${publicKeyFingerprint}`);
+
+          const base64UrlEncode = value => Buffer.from(value)
+            .toString('base64')
+            .replace(/=/g, '')
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_');
+
+          const now = Math.floor(Date.now() / 1000);
+          const header = { alg: 'ES256', kid: keyId, typ: 'JWT' };
+          const payload = {
+            aud: 'appstoreconnect-v1',
+            iat: now - 60,
+            exp: now + 500,
+            iss: issuerId,
+          };
+
+          const unsignedToken = [
+            base64UrlEncode(JSON.stringify(header)),
+            base64UrlEncode(JSON.stringify(payload)),
+          ].join('.');
+          const signature = crypto.sign('sha256', Buffer.from(unsignedToken), {
+            key: privateKeyObject,
+            dsaEncoding: 'ieee-p1363',
+          });
+          const token = `${unsignedToken}.${base64UrlEncode(signature)}`;
+
+          const requestUrl = new URL('https://api.appstoreconnect.apple.com/v1/apps');
+          requestUrl.searchParams.set('filter[bundleId]', bundleId);
+          requestUrl.searchParams.set('limit', '1');
+          requestUrl.searchParams.set('fields[apps]', 'name,bundleId,sku,primaryLocale');
+
+          const request = https.request(requestUrl, {
+            method: 'GET',
+            headers: {
+              Accept: 'application/json',
+              Authorization: `Bearer ${token}`,
+            },
+          }, response => {
+            let body = '';
+            response.setEncoding('utf8');
+            response.on('data', chunk => {
+              body += chunk;
+            });
+            response.on('end', () => {
+              console.log(`[asc-preflight] asc_http_status=${response.statusCode}`);
+
+              let parsed;
+              try {
+                parsed = body ? JSON.parse(body) : {};
+              } catch {
+                console.error('[asc-preflight] ASC response JSON parse failed');
+                process.exit(1);
+              }
+
+              if (response.statusCode >= 200 && response.statusCode < 300) {
+                const apps = Array.isArray(parsed.data) ? parsed.data : [];
+                console.log(`[asc-preflight] asc_app_count=${apps.length}`);
+                if (apps[0]) {
+                  console.log(`[asc-preflight] asc_app_id=${apps[0].id || ''}`);
+                  console.log(`[asc-preflight] asc_app_name=${apps[0].attributes?.name || ''}`);
+                  console.log(`[asc-preflight] asc_app_bundle_id=${apps[0].attributes?.bundleId || ''}`);
+                }
+                process.exit(0);
+              }
+
+              const errors = Array.isArray(parsed.errors) ? parsed.errors : [];
+              for (const error of errors) {
+                console.error(`[asc-preflight] asc_error status=${error.status || ''} code=${error.code || ''} title=${error.title || ''}`);
+              }
+              process.exit(1);
+            });
+          });
+
+          request.on('error', error => {
+            console.error(`[asc-preflight] ASC request failed: ${error.message}`);
+            process.exit(1);
+          });
+
+          request.end();
+          NODE
+        env:
+          RABBY_MOBILE_ASC_API_KEY_ID: ${{ secrets.RABBY_MOBILE_ASC_API_KEY_ID }}
+          RABBY_MOBILE_ASC_API_ISSUER_ID: ${{ secrets.RABBY_MOBILE_ASC_API_ISSUER_ID }}
+          RABBY_MOBILE_ASC_API_PRIVATE_KEY_BASE64: ${{ secrets.RABBY_MOBILE_ASC_API_PRIVATE_KEY_BASE64 }}
+          RABBY_MOBILE_ASC_API_BUNDLE_ID: com.debank.rabby-mobile
+
       - name: Install dependencies && Build app
         run: |
           unset MATCH_GIT_BASIC_AUTHORIZATION

--- a/.yarn/patches/react-native-iap-npm-12.16.4-49632744b4.patch
+++ b/.yarn/patches/react-native-iap-npm-12.16.4-49632744b4.patch
@@ -1,13 +1,65 @@
+diff --git a/android/gradle.properties b/android/gradle.properties
+index 05492267ec7850694bc273caf3b112afccfb62f0..671bee216f0a97b73b0408ddb77d997d112e1066 100644
+--- a/android/gradle.properties
++++ b/android/gradle.properties
+@@ -9 +9 @@ RNIap_amazonSdkVersion=3.0.7
+-RNIap_playBillingSdkVersion=7.0.0
++RNIap_playBillingSdkVersion=8.0.0
 diff --git a/android/src/play/java/com/dooboolab/rniap/RNIapModule.kt b/android/src/play/java/com/dooboolab/rniap/RNIapModule.kt
-index 54ca6969c543f5826d77b4ff8cdfcf960cbb5ffa..9adc51f592dd20bbc48516d380b1c07f0a7fbafc 100644
+index 54ca6969c543f5826d77b4ff8cdfcf960cbb5ffa..8b0a14f84e21bdf1c06928ad6414d9f59e70f754 100644
 --- a/android/src/play/java/com/dooboolab/rniap/RNIapModule.kt
 +++ b/android/src/play/java/com/dooboolab/rniap/RNIapModule.kt
-@@ -461,7 +461,7 @@ class RNIapModule(
-         isOfferPersonalized: Boolean, // New parameter in V5
-         promise: Promise,
-     ) {
+@@ -15,0 +16 @@ import com.android.billingclient.api.GetBillingConfigParams.Builder
++import com.android.billingclient.api.PendingPurchasesParams
+@@ -18 +18,0 @@ import com.android.billingclient.api.Purchase
+-import com.android.billingclient.api.PurchaseHistoryRecord
+@@ -21 +20,0 @@ import com.android.billingclient.api.QueryProductDetailsParams
+-import com.android.billingclient.api.QueryPurchaseHistoryParams
+@@ -45 +44,4 @@ class RNIapModule(
+-    private val builder: BillingClient.Builder = BillingClient.newBuilder(reactContext).enablePendingPurchases(),
++    private val builder: BillingClient.Builder =
++        BillingClient.newBuilder(reactContext).enablePendingPurchases(
++            PendingPurchasesParams.newBuilder().enableOneTimeProducts().build(),
++        ),
+@@ -278 +280 @@ class RNIapModule(
+-            billingClient.queryProductDetailsAsync(params) { billingResult, skuDetailsList ->
++            billingClient.queryProductDetailsAsync(params) { billingResult, queryProductDetailsResult ->
+@@ -282 +284 @@ class RNIapModule(
+-                for (skuDetails in skuDetailsList) {
++                for (skuDetails in queryProductDetailsResult.productDetailsList) {
+@@ -421,28 +423,4 @@ class RNIapModule(
+-            billingClient.queryPurchaseHistoryAsync(
+-                QueryPurchaseHistoryParams
+-                    .newBuilder()
+-                    .setProductType(
+-                        if (type == "subs") BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP,
+-                    ).build(),
+-            ) { billingResult: BillingResult, purchaseHistoryRecordList: MutableList<PurchaseHistoryRecord>? ->
+-
+-                if (!isValidResult(billingResult, promise)) return@queryPurchaseHistoryAsync
+-
+-                Log.d(TAG, purchaseHistoryRecordList.toString())
+-                val items = Arguments.createArray()
+-                purchaseHistoryRecordList?.forEach { purchase ->
+-                    val item = Arguments.createMap()
+-                    item.putString("productId", purchase.products[0])
+-                    val products = Arguments.createArray()
+-                    purchase.products.forEach { products.pushString(it) }
+-                    item.putArray("productIds", products)
+-                    item.putDouble("transactionDate", purchase.purchaseTime.toDouble())
+-                    item.putString("transactionReceipt", purchase.originalJson)
+-                    item.putString("purchaseToken", purchase.purchaseToken)
+-                    item.putString("dataAndroid", purchase.originalJson)
+-                    item.putString("signatureAndroid", purchase.signature)
+-                    item.putString("developerPayload", purchase.developerPayload.orEmpty())
+-                    items.pushMap(item)
+-                }
+-                promise.safeResolve(items)
+-            }
++            promise.safeReject(
++                "E_NOT_SUPPORTED",
++                "getPurchaseHistoryByType is unavailable with Google Play Billing Library 8.",
++            )
+@@ -464 +442 @@ class RNIapModule(
 -        val activity = currentActivity
 +        val activity = getReactApplicationContext().getCurrentActivity()
-         if (activity == null) {
-             promise.safeReject(PromiseUtils.E_UNKNOWN, "getCurrentActivity returned null")
-             return

--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -286,5 +286,5 @@ dependencies {
     // implementation project(':isudaji_react-native-install-apk')
 
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.29'
-    implementation 'com.android.billingclient:billing:7.0.0'
+    implementation 'com.android.billingclient:billing-ktx:8.0.0'
 }

--- a/apps/mobile/fastlane/Fastfile
+++ b/apps/mobile/fastlane/Fastfile
@@ -143,6 +143,11 @@ platform :ios do
     #   clone_branch_directly: true)
   end
 
+  desc "Preflight iOS appstore signing assets"
+  lane :appstore_signing_preflight do
+    prepare_apple_sign(type: 'appstore')
+  end
+
   desc "Release for the iOS adhoc"
   lane :adhoc do
     prepare_apple_sign(type: 'adhoc')

--- a/apps/mobile/fastlane/README.md
+++ b/apps/mobile/fastlane/README.md
@@ -1,5 +1,4 @@
-fastlane documentation
-----
+## fastlane documentation
 
 # Installation
 
@@ -14,6 +13,14 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 # Available Actions
 
 ## iOS
+
+### ios appstore_signing_preflight
+
+```sh
+[bundle exec] fastlane ios appstore_signing_preflight
+```
+
+Preflight iOS appstore signing assets
 
 ### ios adhoc
 
@@ -39,8 +46,7 @@ Valid ios adhoc
 
 Release for the iOS production
 
-----
-
+---
 
 ## Android
 
@@ -68,7 +74,7 @@ Release for the Android selfhost
 
 Release for the Android playstore
 
-----
+---
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
 

--- a/apps/mobile/scripts/ci/ios-signing-export-preflight.sh
+++ b/apps/mobile/scripts/ci/ios-signing-export-preflight.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+log() {
+  printf '[ios-signing-preflight] %s\n' "$*"
+}
+
+fail() {
+  printf '[ios-signing-preflight] %s\n' "$*" >&2
+  exit 1
+}
+
+require_env() {
+  local name="$1"
+  local value="${!name:-}"
+  if [ -z "$value" ]; then
+    fail "missing required env: $name"
+  fi
+}
+
+plist_read() {
+  local plist_path="$1"
+  local key_path="$2"
+  /usr/libexec/PlistBuddy -c "Print $key_path" "$plist_path" 2>/dev/null || true
+}
+
+assert_equal() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" != "$expected" ]; then
+    fail "$label mismatch: expected '$expected', got '$actual'"
+  fi
+}
+
+normalize_sha256() {
+  printf '%s' "$1" | awk '{print tolower($1)}'
+}
+
+script_dir="$(cd "$(dirname "$0")" && pwd -P)"
+project_dir="$(cd "$script_dir/../.." && pwd -P)"
+mobile_scripts_dir="$project_dir/scripts"
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  fail "iOS signing export preflight must run on macOS"
+fi
+
+require_env "MATCH_PASSWORD"
+require_env "RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_S3_URI"
+require_env "RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_SHA256"
+
+fixture_s3_uri="$RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_S3_URI"
+case "$fixture_s3_uri" in
+  s3://*) ;;
+  *) fail "RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_S3_URI must be an s3:// URI" ;;
+esac
+
+expected_sha256="$(normalize_sha256 "$RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_SHA256")"
+if [[ ! "$expected_sha256" =~ ^[0-9a-f]{64}$ ]]; then
+  fail "RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_SHA256 must contain a 64-character sha256"
+fi
+
+signing_type="${RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_TYPE:-appstore}"
+case "$signing_type" in
+  appstore) ;;
+  *) fail "unsupported RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_TYPE: $signing_type" ;;
+esac
+
+expected_bundle_id="${RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_BUNDLE_ID:-com.debank.rabby-mobile}"
+expected_team_id="${RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_TEAM_ID:-ZPNP2SF27Q}"
+expected_profile_name="${RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_PROFILE_NAME:-RabbyMobileAppStoreOpcode}"
+export_method="${RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_EXPORT_METHOD:-app-store-connect}"
+work_dir="${RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_WORK_DIR:-$project_dir/ios/Package/signing-preflight}"
+archive_zip="$work_dir/RabbyMobileSigningPreflight.xcarchive.zip"
+unpack_dir="$work_dir/unpacked"
+export_dir="$work_dir/export"
+export_options="$work_dir/ExportOptions.plist"
+inspect_dir="$work_dir/ipa-inspect"
+
+case "$export_method" in
+  app-store|app-store-connect) ;;
+  *) fail "unsupported RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_EXPORT_METHOD: $export_method" ;;
+esac
+
+rm -rf "$work_dir"
+mkdir -p "$work_dir"
+
+log "download fixture archive from configured S3 URI"
+aws_args=()
+if [ "${DISABLE_AWS_CLI_HTTPS_VALIDATION:-false}" = "true" ]; then
+  aws_args+=(--no-verify-ssl)
+fi
+aws "${aws_args[@]}" s3 cp "$fixture_s3_uri" "$archive_zip" --only-show-errors
+
+actual_sha256="$(shasum -a 256 "$archive_zip" | awk '{print tolower($1)}')"
+assert_equal "fixture sha256" "$expected_sha256" "$actual_sha256"
+log "fixture sha256 verified: $actual_sha256"
+
+mkdir -p "$unpack_dir"
+ditto -x -k "$archive_zip" "$unpack_dir"
+
+archive_count="$(find "$unpack_dir" -maxdepth 1 -type d -name '*.xcarchive' | wc -l | tr -d ' ')"
+if [ "$archive_count" != "1" ]; then
+  find "$unpack_dir" -maxdepth 2 -print
+  fail "expected exactly one .xcarchive in fixture zip, got $archive_count"
+fi
+
+archive_path="$(find "$unpack_dir" -maxdepth 1 -type d -name '*.xcarchive' | head -n 1)"
+app_path="$archive_path/Products/Applications/RabbyMobile.app"
+if [ ! -d "$app_path" ]; then
+  fail "fixture archive does not contain RabbyMobile.app"
+fi
+
+archive_bundle_id="$(plist_read "$archive_path/Info.plist" ":ApplicationProperties:CFBundleIdentifier")"
+archive_team_id="$(plist_read "$archive_path/Info.plist" ":ApplicationProperties:Team")"
+app_bundle_id="$(plist_read "$app_path/Info.plist" ":CFBundleIdentifier")"
+
+assert_equal "archive bundle id" "$expected_bundle_id" "$archive_bundle_id"
+assert_equal "app bundle id" "$expected_bundle_id" "$app_bundle_id"
+assert_equal "archive team id" "$expected_team_id" "$archive_team_id"
+log "fixture archive metadata verified: bundle=$archive_bundle_id team=$archive_team_id"
+
+log "prepare fastlane match signing assets"
+cd "$project_dir"
+unset MATCH_GIT_BASIC_AUTHORIZATION
+# shellcheck source=/dev/null
+. "$mobile_scripts_dir/fns.sh" --source-only
+# shellcheck source=/dev/null
+. "$mobile_scripts_dir/turbo-build/_fns.sh" --source-only
+turbo_prepare_ruby_bundle
+export CONFIGURATION=release
+export TYPE="$signing_type"
+unset TARGET
+turbo_bundle_exec exec fastlane ios appstore_signing_preflight
+
+log "write export options"
+/usr/libexec/PlistBuddy -c "Clear dict" "$export_options"
+/usr/libexec/PlistBuddy -c "Add :method string $export_method" "$export_options"
+/usr/libexec/PlistBuddy -c "Add :signingStyle string manual" "$export_options"
+/usr/libexec/PlistBuddy -c "Add :teamID string $expected_team_id" "$export_options"
+/usr/libexec/PlistBuddy -c "Add :provisioningProfiles dict" "$export_options"
+/usr/libexec/PlistBuddy -c "Add :provisioningProfiles:$expected_bundle_id string $expected_profile_name" "$export_options"
+/usr/libexec/PlistBuddy -c "Add :stripSwiftSymbols bool true" "$export_options"
+
+log "export archive"
+mkdir -p "$export_dir"
+xcodebuild \
+  -exportArchive \
+  -archivePath "$archive_path" \
+  -exportPath "$export_dir" \
+  -exportOptionsPlist "$export_options"
+
+ipa_path="$(find "$export_dir" -maxdepth 1 -type f -name '*.ipa' | head -n 1)"
+if [ -z "$ipa_path" ] || [ ! -f "$ipa_path" ]; then
+  fail "export succeeded but no IPA was produced"
+fi
+
+rm -rf "$inspect_dir"
+mkdir -p "$inspect_dir"
+unzip -q "$ipa_path" -d "$inspect_dir"
+exported_app_path="$inspect_dir/Payload/RabbyMobile.app"
+if [ ! -d "$exported_app_path" ]; then
+  fail "exported IPA does not contain RabbyMobile.app"
+fi
+
+exported_bundle_id="$(plist_read "$exported_app_path/Info.plist" ":CFBundleIdentifier")"
+assert_equal "exported app bundle id" "$expected_bundle_id" "$exported_bundle_id"
+
+exported_profile_plist="$work_dir/exported-profile.plist"
+security cms -D -i "$exported_app_path/embedded.mobileprovision" > "$exported_profile_plist"
+exported_profile_name="$(plist_read "$exported_profile_plist" ":Name")"
+exported_application_id="$(plist_read "$exported_profile_plist" ":Entitlements:application-identifier")"
+exported_has_devices="false"
+if /usr/libexec/PlistBuddy -c "Print :ProvisionedDevices:0" "$exported_profile_plist" >/dev/null 2>&1; then
+  exported_has_devices="true"
+fi
+
+assert_equal "exported profile name" "$expected_profile_name" "$exported_profile_name"
+assert_equal "exported application identifier" "$expected_team_id.$expected_bundle_id" "$exported_application_id"
+assert_equal "exported profile provisioned devices" "false" "$exported_has_devices"
+
+ipa_sha256="$(shasum -a 256 "$ipa_path" | awk '{print tolower($1)}')"
+log "export succeeded: ipa=$(basename "$ipa_path") sha256=$ipa_sha256"

--- a/apps/mobile/scripts/ci/ios-signing-export-preflight.sh
+++ b/apps/mobile/scripts/ci/ios-signing-export-preflight.sh
@@ -38,6 +38,59 @@ normalize_sha256() {
   printf '%s' "$1" | awk '{print tolower($1)}'
 }
 
+resolve_preflight_work_dir() {
+  local requested="$1"
+  local root="$2"
+  local root_real
+  local requested_parent
+  local requested_parent_real
+  local requested_base
+  local resolved
+
+  mkdir -p "$root"
+  root_real="$(cd "$root" && pwd -P)"
+
+  if [ -z "$requested" ]; then
+    requested="$root_real/work"
+  fi
+
+  case "$requested" in
+    /*) ;;
+    *) fail "RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_WORK_DIR must be an absolute path" ;;
+  esac
+
+  case "$requested" in
+    *"/../"*|*/..|*/.|*"/./"*)
+      fail "RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_WORK_DIR must not contain . or .. path segments"
+      ;;
+  esac
+
+  requested_parent="$(dirname "$requested")"
+  requested_base="$(basename "$requested")"
+  if [ "$requested_base" = "." ] || [ "$requested_base" = ".." ] || [ -z "$requested_base" ]; then
+    fail "RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_WORK_DIR must name a child directory"
+  fi
+
+  if [ ! -d "$requested_parent" ]; then
+    fail "RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_WORK_DIR parent must already exist: $requested_parent"
+  fi
+
+  requested_parent_real="$(cd "$requested_parent" && pwd -P)"
+  if [ "$requested_parent_real" != "$root_real" ]; then
+    fail "RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_WORK_DIR must be a direct child of $root_real"
+  fi
+
+  resolved="$root_real/$requested_base"
+  if [ -L "$resolved" ]; then
+    fail "RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_WORK_DIR must not be a symlink: $resolved"
+  fi
+  if [ -e "$resolved" ] && [ ! -d "$resolved" ]; then
+    fail "RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_WORK_DIR must be a directory: $resolved"
+  fi
+
+  printf '%s\n' "$resolved"
+}
+
 script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 project_dir="$(cd "$script_dir/../.." && pwd -P)"
 mobile_scripts_dir="$project_dir/scripts"
@@ -71,7 +124,8 @@ expected_bundle_id="${RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_BUNDLE_ID:-com.debank.r
 expected_team_id="${RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_TEAM_ID:-ZPNP2SF27Q}"
 expected_profile_name="${RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_PROFILE_NAME:-RabbyMobileAppStoreOpcode}"
 export_method="${RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_EXPORT_METHOD:-app-store-connect}"
-work_dir="${RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_WORK_DIR:-$project_dir/ios/Package/signing-preflight}"
+work_root="$project_dir/ios/Package/signing-preflight"
+work_dir="$(resolve_preflight_work_dir "${RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_WORK_DIR:-}" "$work_root")"
 archive_zip="$work_dir/RabbyMobileSigningPreflight.xcarchive.zip"
 unpack_dir="$work_dir/unpacked"
 export_dir="$work_dir/export"

--- a/apps/mobile/scripts/ci/ios-signing-export-preflight.sh
+++ b/apps/mobile/scripts/ci/ios-signing-export-preflight.sh
@@ -87,11 +87,11 @@ rm -rf "$work_dir"
 mkdir -p "$work_dir"
 
 log "download fixture archive from configured S3 URI"
-aws_args=()
 if [ "${DISABLE_AWS_CLI_HTTPS_VALIDATION:-false}" = "true" ]; then
-  aws_args+=(--no-verify-ssl)
+  aws --no-verify-ssl s3 cp "$fixture_s3_uri" "$archive_zip" --only-show-errors
+else
+  aws s3 cp "$fixture_s3_uri" "$archive_zip" --only-show-errors
 fi
-aws "${aws_args[@]}" s3 cp "$fixture_s3_uri" "$archive_zip" --only-show-errors
 
 actual_sha256="$(shasum -a 256 "$archive_zip" | awk '{print tolower($1)}')"
 assert_equal "fixture sha256" "$expected_sha256" "$actual_sha256"

--- a/yarn.lock
+++ b/yarn.lock
@@ -39787,7 +39787,7 @@ __metadata:
 
 "react-native-iap@patch:react-native-iap@npm%3A12.16.4#../../.yarn/patches/react-native-iap-npm-12.16.4-49632744b4.patch::locator=rabby-mobile%40workspace%3Aapps%2Fmobile":
   version: 12.16.4
-  resolution: "react-native-iap@patch:react-native-iap@npm%3A12.16.4#../../.yarn/patches/react-native-iap-npm-12.16.4-49632744b4.patch::version=12.16.4&hash=67e825&locator=rabby-mobile%40workspace%3Aapps%2Fmobile"
+  resolution: "react-native-iap@patch:react-native-iap@npm%3A12.16.4#../../.yarn/patches/react-native-iap-npm-12.16.4-49632744b4.patch::version=12.16.4&hash=0dbf6e&locator=rabby-mobile%40workspace%3Aapps%2Fmobile"
   peerDependencies:
     expo: ">=47.0.0"
     react: ">=16.13.1"
@@ -39795,7 +39795,7 @@ __metadata:
   peerDependenciesMeta:
     expo:
       optional: true
-  checksum: 10/5c14eac159c04692873fb67e120f8f182ff8e120c1d59a702a6f8beaa0f79a2e72c86a5b11569f97c8590621c3115c93d1b286a14519e9aa00ddda819bd7ffde
+  checksum: 10/cb46bde36642199661d02037f18c5709e4d5b033bab7fa66530b5dd39a3ef9fe1a2969498cc7a2a4d6dd1464e3d8743f0c83ec4c871d726f4a821db088a5034d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- keep react-native-iap at 12.16.4 and patch its Android Play Billing integration for Billing Client 8
- keep react-native-nitro-modules at 0.35.9; avoid the wider react-native-iap 16 upgrade
- bring over iOS ASC/signing preflight workflow improvements from chore/upgrade-iap-billing

## Validation
- yarn install --immutable
- git diff --check
- bash -n apps/mobile/scripts/ci/ios-signing-export-preflight.sh
- ruby -c apps/mobile/fastlane/Fastfile
- ./gradlew :react-native-iap:compilePlayReleaseKotlin --no-daemon
- ./gradlew :app:dependencyInsight --configuration releaseRuntimeClasspath --dependency com.android.billingclient --no-daemon

## Notes
- Android releaseRuntimeClasspath resolves com.android.billingclient:billing-ktx:8.0.0 and billing:8.0.0.
- Billing Library 8 removed the old purchase history API; getPurchaseHistoryByType now rejects on Android with E_NOT_SUPPORTED. Current Rabby Mobile code does not call that path.