### PR TITLE
Sec/fix webview

### DIFF
--- a/apps/mobile/src/components/WebView/DappWebViewControl.tsx
+++ b/apps/mobile/src/components/WebView/DappWebViewControl.tsx
@@ -349,7 +349,7 @@ const DappWebViewControl = ({
         webviewRef={webviewRef}
         webviewIdRef={webviewIdRef}
         siteInfoRefs={{ urlRef, titleRef, iconRef }}>
-        {({ onLoadStart, onMessage: onBridgeMessage }) => {
+        {({ bridgeHardenScript, onLoadStart, onMessage: onBridgeMessage }) => {
           if (!entryScriptWeb3Loaded) {
             return null;
           }
@@ -383,6 +383,9 @@ const DappWebViewControl = ({
               injectedJavaScriptBeforeContentLoadedBuiltinScriptIds={
                 beforeContentLoadedBuiltinScriptIds
               }
+              injectedJavaScriptBeforeContentLoaded={`${bridgeHardenScript}\n${
+                webviewProps?.injectedJavaScriptBeforeContentLoaded ?? ''
+              }`}
               injectedJavaScriptBeforeContentLoadedForMainFrameOnly={true}
               injectedJavaScriptBuiltinScriptIds={documentEndBuiltinScriptIds}
               onNavigationStateChange={webviewActions.onNavigationStateChange}

--- a/apps/mobile/src/components/WebView/DappWebViewControl2/DappWebViewControl2.tsx
+++ b/apps/mobile/src/components/WebView/DappWebViewControl2/DappWebViewControl2.tsx
@@ -325,7 +325,7 @@ const DappWebViewControl2 = ({
         webviewRef={webviewRef}
         webviewIdRef={webviewIdRef}
         siteInfoRefs={{ urlRef, titleRef, iconRef }}>
-        {({ onLoadStart, onMessage: onBridgeMessage }) => {
+        {({ bridgeHardenScript, onLoadStart, onMessage: onBridgeMessage }) => {
           if (!entryScriptWeb3Loaded) {
             return null;
           }
@@ -359,6 +359,9 @@ const DappWebViewControl2 = ({
               injectedJavaScriptBeforeContentLoadedBuiltinScriptIds={
                 beforeContentLoadedBuiltinScriptIds
               }
+              injectedJavaScriptBeforeContentLoaded={`${bridgeHardenScript}\n${
+                webviewProps?.injectedJavaScriptBeforeContentLoaded ?? ''
+              }`}
               injectedJavaScriptBeforeContentLoadedForMainFrameOnly={true}
               injectedJavaScriptBuiltinScriptIds={documentEndBuiltinScriptIds}
               onNavigationStateChange={webviewActions.onNavigationStateChange}

--- a/apps/mobile/src/components/WebView/DappWebViewCore.tsx
+++ b/apps/mobile/src/components/WebView/DappWebViewCore.tsx
@@ -385,8 +385,12 @@ function DappWebViewCore({
         NonNullable<WebViewProps['onShouldStartLoadWithRequest']>
       >[0],
     ) => {
-      const shouldStart =
-        checkShouldStartLoadingWithRequestForDappWebView(event);
+      const shouldStart = checkShouldStartLoadingWithRequestForDappWebView(
+        event,
+        {
+          isFromMobileInnerDapp: true,
+        },
+      );
       const extraResult = onShouldStartLoadWithRequest?.(event);
       const propsResult = webviewOnShouldStartLoadWithRequest?.(event);
       const shouldStartWithExtra =

--- a/apps/mobile/src/components/WebView/DappWebViewCore.tsx
+++ b/apps/mobile/src/components/WebView/DappWebViewCore.tsx
@@ -385,12 +385,8 @@ function DappWebViewCore({
         NonNullable<WebViewProps['onShouldStartLoadWithRequest']>
       >[0],
     ) => {
-      const shouldStart = checkShouldStartLoadingWithRequestForDappWebView(
-        event,
-        {
-          isFromMobileInnerDapp: true,
-        },
-      );
+      const shouldStart =
+        checkShouldStartLoadingWithRequestForDappWebView(event);
       const extraResult = onShouldStartLoadWithRequest?.(event);
       const propsResult = webviewOnShouldStartLoadWithRequest?.(event);
       const shouldStartWithExtra =

--- a/apps/mobile/src/components/WebView/DappWebViewCore.tsx
+++ b/apps/mobile/src/components/WebView/DappWebViewCore.tsx
@@ -169,19 +169,22 @@ function DappWebViewCore({
     documentEndBuiltinScriptIds,
   } = useJavaScriptBeforeContentLoaded();
 
-  const { onLoadStart: onBridgeLoadStart, onMessage: onBridgeMessage } =
-    useSetupWebviewWithServices({
-      dappOrigin,
-      webviewRef,
-      webviewIdRef,
-      siteInfoRefs: {
-        urlRef,
-        titleRef,
-        iconRef,
-      },
-      isFromMobileInnerDapp: true,
-      coreServices,
-    });
+  const {
+    bridgeHardenScript,
+    onLoadStart: onBridgeLoadStart,
+    onMessage: onBridgeMessage,
+  } = useSetupWebviewWithServices({
+    dappOrigin,
+    webviewRef,
+    webviewIdRef,
+    siteInfoRefs: {
+      urlRef,
+      titleRef,
+      iconRef,
+    },
+    isFromMobileInnerDapp: true,
+    coreServices,
+  });
 
   const resolvedUrl = useMemo(() => {
     if (embedHtml) return undefined;
@@ -209,6 +212,8 @@ function DappWebViewCore({
     onLoadProgress: webviewOnLoadProgress,
     onShouldStartLoadWithRequest: webviewOnShouldStartLoadWithRequest,
     onMessage: webviewOnMessage,
+    injectedJavaScriptBeforeContentLoaded:
+      webviewInjectedJavaScriptBeforeContentLoaded,
     onError: webviewOnError,
     onOpenWindow: webviewOnOpenWindow,
     onNavigationStateChange: webviewOnNavigationStateChange,
@@ -531,6 +536,9 @@ function DappWebViewCore({
         injectedJavaScriptBeforeContentLoadedBuiltinScriptIds={
           beforeContentLoadedBuiltinScriptIds
         }
+        injectedJavaScriptBeforeContentLoaded={`${bridgeHardenScript}\n${
+          webviewInjectedJavaScriptBeforeContentLoaded ?? ''
+        }`}
         injectedJavaScriptBeforeContentLoadedForMainFrameOnly={true}
         injectedJavaScriptBuiltinScriptIds={documentEndBuiltinScriptIds}
         injectedJavaScript={autoRunnerInjected}

--- a/apps/mobile/src/components/WebView/utils.ts
+++ b/apps/mobile/src/components/WebView/utils.ts
@@ -19,7 +19,10 @@ import { pairWalletConnectUri } from '@/core/walletconnect';
  *  Return `true` to continue loading the request and `false` to stop loading.
  */
 export function checkShouldStartLoadingWithRequestForDappWebView(
-  evt: Pick<ShouldStartLoadRequestEvent, 'url'>,
+  evt: Pick<ShouldStartLoadRequestEvent, 'url' | 'isTopFrame'>,
+  options: {
+    isFromMobileInnerDapp?: boolean;
+  } = {},
 ): boolean /* should allow */ {
   const url = evt.url;
   const { protocol = '' } = urlUtils.safeParseURL(url) || {};
@@ -35,6 +38,9 @@ export function checkShouldStartLoadingWithRequestForDappWebView(
   }
 
   if (isRabbyWalletConnectDeeplink(url)) {
+    if (!options.isFromMobileInnerDapp || !evt.isTopFrame) {
+      return false;
+    }
     const uri = parseWalletConnectUriFromLink(url);
     if (!uri) {
       return false;

--- a/apps/mobile/src/components/WebView/utils.ts
+++ b/apps/mobile/src/components/WebView/utils.ts
@@ -19,10 +19,7 @@ import { pairWalletConnectUri } from '@/core/walletconnect';
  *  Return `true` to continue loading the request and `false` to stop loading.
  */
 export function checkShouldStartLoadingWithRequestForDappWebView(
-  evt: Pick<ShouldStartLoadRequestEvent, 'url' | 'isTopFrame'>,
-  options: {
-    isFromMobileInnerDapp?: boolean;
-  } = {},
+  evt: Pick<ShouldStartLoadRequestEvent, 'url'>,
 ): boolean /* should allow */ {
   const url = evt.url;
   const { protocol = '' } = urlUtils.safeParseURL(url) || {};
@@ -38,9 +35,6 @@ export function checkShouldStartLoadingWithRequestForDappWebView(
   }
 
   if (isRabbyWalletConnectDeeplink(url)) {
-    if (!options.isFromMobileInnerDapp || !evt.isTopFrame) {
-      return false;
-    }
     const uri = parseWalletConnectUriFromLink(url);
     if (!uri) {
       return false;

--- a/apps/mobile/src/core/bridges/useBackgroundBridge.ts
+++ b/apps/mobile/src/core/bridges/useBackgroundBridge.ts
@@ -7,7 +7,11 @@ import type { WebViewNavigation } from 'react-native-webview';
 import { type BackgroundBridgeServices } from './backgroundBridgeServices';
 import { createDappBySession } from '@/core/utils/createDappBySession';
 import { useRefState } from '@/hooks/common/useRefState';
-import { RABBY_DECLARED_PREFIX } from '@rabby-wallet/rn-webview-bridge';
+import {
+  BRIDGE_FRAME_CAPABILITY_KEY,
+  JSBridgeHarden,
+  RABBY_DECLARED_PREFIX,
+} from '@rabby-wallet/rn-webview-bridge';
 
 export const BLANK_PAGE = 'about:blank';
 export const BLANK_RABBY_PAGE = 'about:rabby';
@@ -29,6 +33,7 @@ type WebViewDataPayload<P = any> = {
   type: string;
   name?: string;
   payload?: P;
+  [BRIDGE_FRAME_CAPABILITY_KEY]?: string;
 };
 
 export type SetupWebviewParams = {
@@ -55,6 +60,25 @@ export function useSetupWebviewWithServices({
 }) {
   const { setRefState: putBackgroundBridge, stateRef: currentBridgeRef } =
     useRefState<BackgroundBridge | null>(null);
+  const bridgeFrameCapabilityRef = useRef<{
+    value: string;
+    injectedJavaScript: string;
+  } | null>(null);
+
+  if (!bridgeFrameCapabilityRef.current) {
+    const randomBytes = new Uint8Array(32);
+    crypto.getRandomValues(randomBytes);
+    const value = Array.from(randomBytes, byte =>
+      byte.toString(16).padStart(2, '0'),
+    ).join('');
+
+    bridgeFrameCapabilityRef.current = {
+      value,
+      injectedJavaScript: JSBridgeHarden(value),
+    };
+  }
+
+  const bridgeFrameCapability = bridgeFrameCapabilityRef.current;
 
   const destroyCurrentBridge = useCallback(() => {
     if (currentBridgeRef.current) {
@@ -134,6 +158,13 @@ export function useSetupWebviewWithServices({
 
         const data = fromData as WebViewDataPayload;
         if (data.name) {
+          if (
+            data[BRIDGE_FRAME_CAPABILITY_KEY] !== bridgeFrameCapability.value
+          ) {
+            return;
+          }
+          delete data[BRIDGE_FRAME_CAPABILITY_KEY];
+
           const msgOrigin =
             typeof (data as any).origin === 'string'
               ? (data as any).origin
@@ -168,7 +199,12 @@ export function useSetupWebviewWithServices({
         console.error(e, `Browser::onMessage on ${urlRef.current}`);
       }
     },
-    [currentBridgeRef, onRabbyDeclaredMessage, urlRef],
+    [
+      bridgeFrameCapability.value,
+      currentBridgeRef,
+      onRabbyDeclaredMessage,
+      urlRef,
+    ],
   );
 
   const changeUrl = useCallback(
@@ -247,6 +283,7 @@ export function useSetupWebviewWithServices({
   }, [destroyCurrentBridge]);
 
   return {
+    bridgeHardenScript: bridgeFrameCapability.injectedJavaScript,
     onLoadStart,
     onMessage,
   };

--- a/apps/mobile/src/core/bridges/useBackgroundBridge.ts
+++ b/apps/mobile/src/core/bridges/useBackgroundBridge.ts
@@ -9,6 +9,7 @@ import { createDappBySession } from '@/core/utils/createDappBySession';
 import { useRefState } from '@/hooks/common/useRefState';
 import {
   BRIDGE_FRAME_CAPABILITY_KEY,
+  BRIDGE_FRAME_PAYLOAD_KEY,
   JSBridgeHarden,
   RABBY_DECLARED_PREFIX,
 } from '@rabby-wallet/rn-webview-bridge';
@@ -33,7 +34,11 @@ type WebViewDataPayload<P = any> = {
   type: string;
   name?: string;
   payload?: P;
-  [BRIDGE_FRAME_CAPABILITY_KEY]?: string;
+};
+
+type WebViewCapabilityEnvelope = {
+  [BRIDGE_FRAME_CAPABILITY_KEY]?: unknown;
+  [BRIDGE_FRAME_PAYLOAD_KEY]?: unknown;
 };
 
 export type SetupWebviewParams = {
@@ -152,18 +157,41 @@ export function useSetupWebviewWithServices({
       try {
         fromData =
           typeof fromData === 'string' ? JSON.parse(fromData) : fromData;
-        if (!fromData || (!fromData.type && !fromData.name)) {
+        const hasCapabilityEnvelope =
+          fromData != null &&
+          typeof fromData === 'object' &&
+          Object.prototype.hasOwnProperty.call(
+            fromData,
+            BRIDGE_FRAME_CAPABILITY_KEY,
+          ) &&
+          Object.prototype.hasOwnProperty.call(
+            fromData,
+            BRIDGE_FRAME_PAYLOAD_KEY,
+          );
+        const capabilityEnvelope = hasCapabilityEnvelope
+          ? (fromData as WebViewCapabilityEnvelope)
+          : null;
+        const messageData = capabilityEnvelope
+          ? capabilityEnvelope[BRIDGE_FRAME_PAYLOAD_KEY]
+          : fromData;
+
+        if (
+          !messageData ||
+          typeof messageData !== 'object' ||
+          (!(messageData as WebViewDataPayload).type &&
+            !(messageData as WebViewDataPayload).name)
+        ) {
           return;
         }
 
-        const data = fromData as WebViewDataPayload;
+        const data = messageData as WebViewDataPayload;
         if (data.name) {
           if (
-            data[BRIDGE_FRAME_CAPABILITY_KEY] !== bridgeFrameCapability.value
+            capabilityEnvelope?.[BRIDGE_FRAME_CAPABILITY_KEY] !==
+            bridgeFrameCapability.value
           ) {
             return;
           }
-          delete data[BRIDGE_FRAME_CAPABILITY_KEY];
 
           const msgOrigin =
             typeof (data as any).origin === 'string'

--- a/apps/mobile/src/hooks/useBootstrap.ts
+++ b/apps/mobile/src/hooks/useBootstrap.ts
@@ -51,7 +51,6 @@ const syncCustomTestChainList = () => {
 };
 
 const WEBVIEW_BEFORE_CONTENT_LOADED_BUILTIN_SCRIPT_IDS = [
-  'rabby-jsbridge-harden',
   'rabby-inpage-web3',
   'rabby-browser-script-base',
   ...(__DEV__ ? ['rabby-dev-window-info-after-load'] : []),

--- a/apps/mobile/src/screens/Browser/BrowserScreen/components/BrowserTab/index.tsx
+++ b/apps/mobile/src/screens/Browser/BrowserScreen/components/BrowserTab/index.tsx
@@ -601,7 +601,11 @@ export const BrowserTab = ({
                 webviewRef={webviewRef}
                 webviewIdRef={webviewIdRef}
                 siteInfoRefs={{ urlRef, titleRef, iconRef }}>
-                {({ onLoadStart, onMessage: onWebViewMessage }) =>
+                {({
+                  bridgeHardenScript,
+                  onLoadStart,
+                  onMessage: onWebViewMessage,
+                }) =>
                   !url ||
                   !/^https?:\/\//.test(url) ||
                   !entryScriptWeb3Loaded ? null : (
@@ -643,6 +647,10 @@ export const BrowserTab = ({
                         injectedJavaScriptBeforeContentLoadedBuiltinScriptIds={
                           beforeContentLoadedBuiltinScriptIds
                         }
+                        injectedJavaScriptBeforeContentLoaded={`${bridgeHardenScript}\n${
+                          webviewProps?.injectedJavaScriptBeforeContentLoaded ??
+                          ''
+                        }`}
                         injectedJavaScriptBeforeContentLoadedForMainFrameOnly={
                           true
                         }

--- a/packages/rn-webview-bridge/src/browserScripts.ts
+++ b/packages/rn-webview-bridge/src/browserScripts.ts
@@ -206,50 +206,72 @@ export const JS_IFRAME_POST_MESSAGE_TO_PROVIDER = (
 })()`;
  */
 
-export const JSBridgeHarden = /* js */`(function () {
-    function safeStartsWith(str, search) {
-        if (typeof str !== 'string' || typeof search !== 'string') {
-            return false;
-        }
+export const BRIDGE_FRAME_CAPABILITY_KEY = '__rabbyFrameCapability';
 
-        for (let i = 0; i < search.length; i++) {
-          if (str[i] !== search[i]) {
-            return false;
-          }
-        }
-
-        return true;
+export const JSBridgeHarden = (capability: string) => /* js */`
+;(function () {
+  function safeStartsWith(str, search) {
+    if (typeof str !== 'string' || typeof search !== 'string') {
+      return false;
     }
 
-    if (window.ReactNativeWebView == null) {
+    for (var i = 0; i < search.length; i++) {
+      if (str[i] !== search[i]) return false;
+    }
+
+    return true;
+  }
+
+  var bridge = window.ReactNativeWebView;
+  if (bridge == null) return;
+
+  var parse = JSON.parse;
+  var stringify = JSON.stringify;
+  var apply = Reflect.apply;
+  var originalPostMessage = bridge.postMessage;
+  var capability = ${JSON.stringify(capability)};
+  var capabilityKey = ${JSON.stringify(BRIDGE_FRAME_CAPABILITY_KEY)};
+
+  function send(message) {
+    return apply(originalPostMessage, bridge, [message]);
+  }
+
+  function postMessageWithHarden(message) {
+    try {
+      var data = parse(message);
+      if (
+        data &&
+        data.name != null &&
+        !(
+          location.origin === data.origin ||
+          location.origin === data.origin + '/' ||
+          safeStartsWith(data.origin, location.origin + '/')
+        )
+      ) {
+        console.warn(
+          'Origin mismatch in postMessage: expected ' +
+            location.origin +
+            ', got ' +
+            data.origin
+        );
         return;
-    }
-    const parse = JSON.parse;
-    const realPost = window.ReactNativeWebView.postMessage.bind(window.ReactNativeWebView);
-    function myPostMessage(msg) {
-        try {
-            const json = parse(msg);
-            if (json &&
-                json.name != null &&
-                !(location.origin === json.origin ||
-                    location.origin === json.origin + '/' || safeStartsWith(json.origin, location.origin + '/'))) {
-                console.warn('Origin mismatch in postMessage: expected ' +
-                    location.origin +
-                    ', got ' +
-                    json.origin);
-                return;
-            }
-        }
-        catch (_a) { }
-        return realPost(msg);
-    }
-    window.ReactNativeWebView = new Proxy(window.ReactNativeWebView || {}, {
-        get: function (target, prop) {
-            if (prop === 'postMessage') {
-                return myPostMessage;
-            }
-            const f = Reflect.get(target, prop);
-            return typeof f === 'function' ? f.bind(target) : f;
-        },
-    });
-})();`;
+      }
+
+      if (data && data.name) {
+        data[capabilityKey] = capability;
+        return send(stringify(data));
+      }
+    } catch (_error) {}
+    return send(message);
+  }
+
+  var facade = Object.create(null);
+  Object.defineProperty(facade, 'postMessage', {
+    value: postMessageWithHarden,
+    enumerable: true,
+    writable: false,
+    configurable: false,
+  });
+  Object.freeze(facade);
+  window.ReactNativeWebView = facade;
+})();true;`;

--- a/packages/rn-webview-bridge/src/browserScripts.ts
+++ b/packages/rn-webview-bridge/src/browserScripts.ts
@@ -207,8 +207,14 @@ export const JS_IFRAME_POST_MESSAGE_TO_PROVIDER = (
  */
 
 export const BRIDGE_FRAME_CAPABILITY_KEY = '__rabbyFrameCapability';
+export const BRIDGE_FRAME_PAYLOAD_KEY = '__rabbyFramePayload';
 
-export const JSBridgeHarden = (capability: string) => /* js */`
+export const JSBridgeHarden = (capability: string) => {
+  const envelopePrefix = `${JSON.stringify({
+    [BRIDGE_FRAME_CAPABILITY_KEY]: capability,
+  }).slice(0, -1)},${JSON.stringify(BRIDGE_FRAME_PAYLOAD_KEY)}:`;
+
+  return /* js */`
 ;(function () {
   function safeStartsWith(str, search) {
     if (typeof str !== 'string' || typeof search !== 'string') {
@@ -228,38 +234,54 @@ export const JSBridgeHarden = (capability: string) => /* js */`
   var parse = JSON.parse;
   var stringify = JSON.stringify;
   var apply = Reflect.apply;
-  var originalPostMessage = bridge.postMessage;
-  var capability = ${JSON.stringify(capability)};
-  var capabilityKey = ${JSON.stringify(BRIDGE_FRAME_CAPABILITY_KEY)};
+  var nativeReceiver;
+  var nativePostMessage;
+  var iosHandler =
+    window.webkit &&
+    window.webkit.messageHandlers &&
+    window.webkit.messageHandlers.ReactNativeWebView;
+
+  if (iosHandler && typeof iosHandler.postMessage === 'function') {
+    nativeReceiver = iosHandler;
+    nativePostMessage = iosHandler.postMessage;
+  } else if (typeof bridge.postMessage === 'function') {
+    nativeReceiver = bridge;
+    nativePostMessage = bridge.postMessage;
+  } else {
+    return;
+  }
+
+  var envelopePrefix = ${JSON.stringify(envelopePrefix)};
 
   function send(message) {
-    return apply(originalPostMessage, bridge, [message]);
+    return apply(nativePostMessage, nativeReceiver, [message]);
   }
 
   function postMessageWithHarden(message) {
     try {
       var data = parse(message);
-      if (
-        data &&
-        data.name != null &&
-        !(
-          location.origin === data.origin ||
-          location.origin === data.origin + '/' ||
-          safeStartsWith(data.origin, location.origin + '/')
-        )
-      ) {
-        console.warn(
-          'Origin mismatch in postMessage: expected ' +
-            location.origin +
-            ', got ' +
-            data.origin
-        );
-        return;
-      }
-
       if (data && data.name) {
-        data[capabilityKey] = capability;
-        return send(stringify(data));
+        var payload = stringify(data);
+        data = parse(payload);
+
+        if (!data || !data.name) return;
+        if (
+          !(
+            location.origin === data.origin ||
+            location.origin === data.origin + '/' ||
+            safeStartsWith(data.origin, location.origin + '/')
+          )
+        ) {
+          console.warn(
+            'Origin mismatch in postMessage: expected ' +
+              location.origin +
+              ', got ' +
+              data.origin
+          );
+          return;
+        }
+
+        return send(envelopePrefix + payload + '}');
       }
     } catch (_error) {}
     return send(message);
@@ -275,3 +297,4 @@ export const JSBridgeHarden = (capability: string) => /* js */`
   Object.freeze(facade);
   window.ReactNativeWebView = facade;
 })();true;`;
+};


### PR DESCRIPTION
修复 dapp webview 的若干外部提交漏洞：
- dapp wc 连接问题。wc 协议有没办法彻底解决的来源校验安全问题，所以禁止在内置 dapp 浏览器发起 wc 配对
- ios 上，非同源 iframe 也能直接请求 webkit.messageHandlers.ReactNativeWebView.postMessage 以 main frame 身份发起 jsb 调用
    - 为 jsb 调用添加 token 鉴权，token 通过闭包变量方式注入 main frame window.ReactNativeWebView.postMessage 方法，iframe 获取不到 token 不能通过鉴权
- jsb 网页跳转的条件竞争问题
    - 添加 token 鉴权后，webkit.messageHandlers.ReactNativeWebView.postMessage 因为不含 token 无法调用，只能通过安全的 window.ReactNativeWebView.postMessage 发起消息，不再存在条件竞争问题