### PR TITLE
fix(home): restore asset toggle spacing and Android DeFi expansion

### DIFF
--- a/apps/mobile/src/screens/Address/components/MultiAssets/ProtocolList.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/ProtocolList.tsx
@@ -727,7 +727,9 @@ export const ProtocolList = () => {
         maxToRenderPerBatch={8}
         updateCellsBatchingPeriod={32}
         removeClippedSubviews={IS_ANDROID}
-        maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
+        {...(!IS_ANDROID && {
+          maintainVisibleContentPosition: { minIndexForVisible: 0 },
+        })}
         onLayout={onHighCardinalityListLayout}
         onContentSizeChange={onHighCardinalityListContentSizeChange}
         onViewableItemsChanged={onHighCardinalityViewableItemsChanged}

--- a/apps/mobile/src/screens/Home/TokenList.tsx
+++ b/apps/mobile/src/screens/Home/TokenList.tsx
@@ -695,15 +695,19 @@ export const TokenList = ({ onForeground, onRefresh }: Props) => {
 
   const renderAdditionalHeaderItem = useCallback(
     () => (
-      <TokenRowSectionLpTokenHeader
-        isEnabled={isLpTokenEnabled}
-        onValueChange={handleLpTokenEnabledChange}
-        fold={!showAllTokens}
-        str={additionalTokenUsdValue}
-        onPressFold={handleToggleAdditionalTokens}
-        style={styles.sectionHeader}
-        buttonStyle={additionalHeaderButtonStyle}
-      />
+      <View>
+        <View style={styles.additionalToggleSpacer} />
+        <TokenRowSectionLpTokenHeader
+          isEnabled={isLpTokenEnabled}
+          onValueChange={handleLpTokenEnabledChange}
+          fold={!showAllTokens}
+          str={additionalTokenUsdValue}
+          onPressFold={handleToggleAdditionalTokens}
+          style={styles.sectionHeader}
+          buttonStyle={additionalHeaderButtonStyle}
+        />
+        {!showAllTokens ? <View style={styles.additionalToggleSpacer} /> : null}
+      </View>
     ),
     [
       additionalTokenUsdValue,
@@ -712,6 +716,7 @@ export const TokenList = ({ onForeground, onRefresh }: Props) => {
       handleToggleAdditionalTokens,
       isLpTokenEnabled,
       showAllTokens,
+      styles.additionalToggleSpacer,
       styles.sectionHeader,
     ],
   );
@@ -934,6 +939,9 @@ const getStyles = createGetStyles2024(ctx => ({
     backgroundColor: ctx.colors2024['neutral-bg-gray'],
     // paddingRight: 8,
     height: ASSETS_SECTION_HEADER,
+  },
+  additionalToggleSpacer: {
+    height: SPACING_HEIGHT,
   },
   buttonHeader: {
     backgroundColor: ctx.colors2024['neutral-bg-1'],


### PR DESCRIPTION
## Summary\n- Cherry-pick the fix from #2093 onto develop.\n- Restore spacing around the single-address asset toggle for acceptance issue 937.\n- Keep the Android DeFi expansion behavior from the original 937/938 fix while preserving current develop diagnostics.\n\n## Test\n- lint-staged ran during commit\n- git diff --check HEAD~1 HEAD