### PR TITLE
fix(browser): stop spurious chainChanged from reloading dapps

### DIFF
--- a/apps/mobile/src/core/bridges/BackgroundBridge.ts
+++ b/apps/mobile/src/core/bridges/BackgroundBridge.ts
@@ -26,6 +26,12 @@ import { BroadcastEvent } from '@/constant/event';
 import type { ProviderNetworkState } from '@/core/utils/providerNetworkState';
 import { getProviderNetworkState } from '@/core/utils/providerNetworkState';
 
+/**
+ * Delay before the readiness beacon is sent, giving the document the
+ * navigation is loading time to come up and install its inpage bridge.
+ */
+const READINESS_BEACON_DELAY = 50;
+
 type BackgroundBridgeOptions = {
   webview: RefLikeObject<WebView | null>;
   webviewIdRef: RefLikeObject<string>;
@@ -58,6 +64,8 @@ export class BackgroundBridge extends EventEmitter {
   /** Last `chainChanged` payload actually delivered to this bridge's page. */
   #lastChainIdSent: string | null = null;
   #lastNetworkVersionSent: string | null = null;
+
+  #readinessBeaconTimer: ReturnType<typeof setTimeout> | null = null;
 
   get origin() {
     return this.#webviewOrigin;
@@ -109,19 +117,41 @@ export class BackgroundBridge extends EventEmitter {
     // connect features
     this._setupProviderConnection(portMux.createStream('rabby-provider'));
 
-    // Liveliness ping: tells the inpage provider the background pipeline is up
-    // so messages sent before it was ready can be retried.
+    // Readiness beacon, NOT a chain state update (see #935).
     //
-    // It must be sent synchronously and from `getProviderNetworkState` — the
-    // same function backing `rabby_getProviderState`. A delayed ping, or one
-    // computed from a second independent chain lookup, can carry a chainId that
-    // differs from the state the page bootstrapped with; the inpage provider
-    // then emits a `chainChanged` that never happened, and dapps wired as
-    // `chainChanged -> location.reload()` reload on every page load.
+    // The inpage bridge treats the first `rabby_chainChanged` it receives as
+    // "the background pipeline is up" and replies with
+    // `RABBY_EXTENSION_CONNECT_CAN_RETRY`, which makes the stream middleware
+    // replay requests that were dropped before the pipeline was wired — on
+    // Android an early `rabby_getProviderState` would otherwise hang forever.
+    // See `backgroundBridgeStreamMessageListener` in
+    // `@rabby-wallet/rn-webview-bridge` (scripts/inpage-bridge/inpage/index.js).
+    //
+    // Two properties this send has to keep:
+    //
+    // 1. It must land in the *new* document. The bridge is constructed from
+    //    `onLoadStart`, before the navigation commits, so the page that needs
+    //    the beacon does not exist yet — hence the delay. Sending it
+    //    synchronously injects it into the outgoing document and the retry
+    //    never happens. (Deleting this delay needs the bridge to be created
+    //    after navigation commit instead.)
+    // 2. It must carry exactly the state `rabby_getProviderState` reports,
+    //    which is why both read `getProviderNetworkState`. The value is
+    //    resolved here rather than inside the timer so the two cannot drift
+    //    apart. If they disagree, the inpage provider emits a `chainChanged`
+    //    that never happened and dapps wired as
+    //    `chainChanged -> location.reload()` reload on every page load.
+    //
+    // A beacon carrying the value the page already has is harmless: the retry
+    // fires on receipt, before and independently of the provider's own
+    // de-duplication, so nothing is lost by it being de-duped.
     const networkState = getProviderNetworkState(this.#webviewOrigin);
     this.#lastChainIdSent = networkState.chainId;
     this.#lastNetworkVersionSent = networkState.networkVersion;
-    this.#postChainChanged(networkState);
+    this.#readinessBeaconTimer = setTimeout(() => {
+      this.#readinessBeaconTimer = null;
+      this.#postChainChanged(networkState);
+    }, READINESS_BEACON_DELAY);
   }
 
   #postChainChanged(params: ProviderNetworkState) {
@@ -202,6 +232,14 @@ export class BackgroundBridge extends EventEmitter {
 
   onDisconnect = () => {
     this.#disconnected = true;
+
+    // A bridge is torn down at the start of the next navigation, so a beacon
+    // still in flight would land in the document the *next* bridge serves,
+    // carrying this bridge's (now stale) origin and chain.
+    if (this.#readinessBeaconTimer) {
+      clearTimeout(this.#readinessBeaconTimer);
+      this.#readinessBeaconTimer = null;
+    }
 
     this.port.emit('disconnect', { name: this.port.name, data: null });
   };

--- a/apps/mobile/src/core/bridges/BackgroundBridge.ts
+++ b/apps/mobile/src/core/bridges/BackgroundBridge.ts
@@ -17,15 +17,14 @@ import { stringUtils, urlUtils } from '@rabby-wallet/base-utils';
 
 import { createOriginMiddleware } from './middlewares';
 import { createSanitizationMiddleware } from './middlewares/SanitizationMiddleware';
-import { getDappSnapshot } from '@/core/serviceApi/dapp';
 import { isKeyringUnlockedSnapshot } from '@/core/serviceApi/keyring';
 import getRpcMethodMiddleware, {
   RefLikeObject,
 } from './middlewares/RPCMethodMiddleware';
 import WebView from 'react-native-webview';
 import { BroadcastEvent } from '@/constant/event';
-import { findChain } from '@/utils/chain';
-import { CHAINS_ENUM } from '@debank/common';
+import type { ProviderNetworkState } from '@/core/utils/providerNetworkState';
+import { getProviderNetworkState } from '@/core/utils/providerNetworkState';
 
 type BackgroundBridgeOptions = {
   webview: RefLikeObject<WebView | null>;
@@ -55,6 +54,10 @@ export class BackgroundBridge extends EventEmitter {
   #engine: JsonRpcEngine | null = null;
 
   #isFromMobileInnerDapp = false;
+
+  /** Last `chainChanged` payload actually delivered to this bridge's page. */
+  #lastChainIdSent: string | null = null;
+  #lastNetworkVersionSent: string | null = null;
 
   get origin() {
     return this.#webviewOrigin;
@@ -106,31 +109,68 @@ export class BackgroundBridge extends EventEmitter {
     // connect features
     this._setupProviderConnection(portMux.createStream('rabby-provider'));
 
-    setTimeout(() => {
-      const chain =
-        findChain({
-          enum: getDappSnapshot(this.#webviewOrigin)?.chainId,
-        }) ||
-        findChain({
-          enum: CHAINS_ENUM.ETH,
-        });
-      if (chain) {
-        this.port.postMessage(
-          {
-            name: 'rabby-provider',
-            data: {
-              method: BroadcastEvent.chainChanged,
-              params: {
-                chainId: chain.hex,
-                networkVersion: chain.network,
-              },
-            },
-          },
-          this.#webviewOrigin,
-        );
-      }
-    }, 50);
+    // Liveliness ping: tells the inpage provider the background pipeline is up
+    // so messages sent before it was ready can be retried.
+    //
+    // It must be sent synchronously and from `getProviderNetworkState` — the
+    // same function backing `rabby_getProviderState`. A delayed ping, or one
+    // computed from a second independent chain lookup, can carry a chainId that
+    // differs from the state the page bootstrapped with; the inpage provider
+    // then emits a `chainChanged` that never happened, and dapps wired as
+    // `chainChanged -> location.reload()` reload on every page load.
+    const networkState = getProviderNetworkState(this.#webviewOrigin);
+    this.#lastChainIdSent = networkState.chainId;
+    this.#lastNetworkVersionSent = networkState.networkVersion;
+    this.#postChainChanged(networkState);
   }
+
+  #postChainChanged(params: ProviderNetworkState) {
+    this.port.postMessage(
+      {
+        name: 'rabby-provider',
+        data: {
+          method: BroadcastEvent.chainChanged,
+          params,
+        },
+      },
+      this.#webviewOrigin,
+    );
+  }
+
+  /**
+   * Consulted by {@link Session.pushMessage} before a broadcast reaches this
+   * bridge's page. Returning `false` drops the push.
+   *
+   * Tracks what was last delivered so a `chainChanged` carrying the values the
+   * page already holds is never re-sent. Relying only on the inpage provider's
+   * own de-dupe is not enough: it cannot de-dupe against a value it has not
+   * received yet.
+   */
+  shouldPushMessage = (event: BroadcastEvent, data: any) => {
+    if (event !== BroadcastEvent.chainChanged) {
+      return true;
+    }
+
+    const chainId = data?.chainId;
+    if (typeof chainId !== 'string') {
+      // Malformed payload, leave delivery behaviour unchanged.
+      return true;
+    }
+    const networkVersion =
+      typeof data?.networkVersion === 'string' ? data.networkVersion : null;
+
+    if (
+      this.#lastChainIdSent === chainId &&
+      this.#lastNetworkVersionSent === networkVersion
+    ) {
+      return false;
+    }
+
+    this.#lastChainIdSent = chainId;
+    this.#lastNetworkVersionSent = networkVersion;
+
+    return true;
+  };
 
   isUnlocked() {
     return isKeyringUnlockedSnapshot();

--- a/apps/mobile/src/core/controllers/internalMethod.ts
+++ b/apps/mobile/src/core/controllers/internalMethod.ts
@@ -1,5 +1,4 @@
 import { keyBy } from 'lodash';
-import { CHAINS_ENUM } from '@/constant/chains';
 import { autoConnectServiceApi } from '@/core/serviceApi/autoConnect';
 import {
   addDappSync,
@@ -9,14 +8,10 @@ import {
 import { getKeyringMemStoreStateSnapshot } from '@/core/serviceApi/keyring';
 import { metamaskModeServiceApi } from '@/core/serviceApi/metamaskMode';
 import providerController from './provider';
-import { findChain, findChainByEnum } from '@/utils/chain';
+import { getProviderNetworkState } from '@/core/utils/providerNetworkState';
 import type { ProviderRequest } from './type';
 import { createDappBySession } from '@/core/utils/createDappBySession';
 import { openapi } from '../request';
-
-const networkIdMap: {
-  [key: string]: string;
-} = {};
 
 const tabCheckin = ({
   data: {
@@ -57,31 +52,15 @@ const getProviderState = async (req: ProviderRequest) => {
   const {
     session: { origin },
   } = req;
-  const chainEnum = getDappSnapshot(origin)?.chainId || CHAINS_ENUM.ETH;
   const isUnlocked = getKeyringMemStoreStateSnapshot()?.isUnlocked || false;
-  let networkVersion = '1';
-  if (networkIdMap[chainEnum]) {
-    networkVersion = networkIdMap[chainEnum];
-  } else {
-    // TODO: it maybe throw error
-    networkVersion = await providerController.netVersion(req);
-    networkIdMap[chainEnum] = networkVersion;
-  }
 
-  // TODO: should we throw error here?
-  let chainItem = findChainByEnum(chainEnum);
-
-  if (!chainItem) {
-    console.warn(
-      `[internalMethod::getProviderState] chain ${chainEnum} not found`,
-    );
-    chainItem = findChain({
-      enum: CHAINS_ENUM.ETH,
-    })!;
-  }
+  // Must stay on `getProviderNetworkState`: the `chainChanged` notification the
+  // BackgroundBridge pushes is derived from the same function, and the two
+  // disagreeing makes the inpage provider emit a spurious `chainChanged`.
+  const { chainId, networkVersion } = getProviderNetworkState(origin);
 
   return {
-    chainId: chainItem.hex,
+    chainId,
     isUnlocked,
     accounts: isUnlocked ? await providerController.ethAccounts(req) : [],
     networkVersion,

--- a/apps/mobile/src/core/services/session.pushMessage.test.ts
+++ b/apps/mobile/src/core/services/session.pushMessage.test.ts
@@ -1,0 +1,68 @@
+import { BroadcastEvent } from '@/constant/event';
+import { Session } from './session';
+
+const makePort = () => {
+  const postMessage = jest.fn();
+  return { port: { postMessage }, postMessage };
+};
+
+describe('Session.pushMessage', () => {
+  it('delivers to ports that do not implement the gate', () => {
+    const session = new Session({
+      origin: 'https://a.test',
+      icon: '',
+      name: '',
+    });
+    const pm = makePort();
+    session.setPortMessage(pm);
+
+    session.pushMessage(BroadcastEvent.chainChanged, { chainId: '0x1' });
+
+    expect(pm.postMessage).toHaveBeenCalledTimes(1);
+    expect(pm.postMessage).toHaveBeenCalledWith(
+      {
+        name: 'rabby-provider',
+        data: {
+          method: BroadcastEvent.chainChanged,
+          params: { chainId: '0x1' },
+        },
+      },
+      'https://a.test',
+    );
+  });
+
+  it('drops the push when the gate returns false', () => {
+    const session = new Session({
+      origin: 'https://a.test',
+      icon: '',
+      name: '',
+    });
+    const pm = { ...makePort(), shouldPushMessage: jest.fn(() => false) };
+    session.setPortMessage(pm);
+
+    session.pushMessage(BroadcastEvent.chainChanged, { chainId: '0x1' });
+
+    expect(pm.shouldPushMessage).toHaveBeenCalledWith(
+      BroadcastEvent.chainChanged,
+      { chainId: '0x1' },
+    );
+    expect(pm.port.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('gates each port independently', () => {
+    const session = new Session({
+      origin: 'https://a.test',
+      icon: '',
+      name: '',
+    });
+    const allowed = makePort();
+    const blocked = { ...makePort(), shouldPushMessage: () => false };
+    session.setPortMessage(allowed);
+    session.setPortMessage(blocked);
+
+    session.pushMessage(BroadcastEvent.accountsChanged, []);
+
+    expect(allowed.postMessage).toHaveBeenCalledTimes(1);
+    expect(blocked.port.postMessage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/core/services/session.ts
+++ b/apps/mobile/src/core/services/session.ts
@@ -19,6 +19,12 @@ type SessionPort = {
   port: {
     postMessage: (message: any, origin: string) => void;
   };
+  /**
+   * Optional gate the port owner (see `BackgroundBridge`) can implement to drop
+   * a broadcast before it reaches the page — e.g. a `chainChanged` carrying
+   * values the page already holds.
+   */
+  shouldPushMessage?: (event: BroadcastEvent, data: any) => boolean;
 };
 type SessionKey = SessionPort;
 export class Session {
@@ -32,6 +38,10 @@ export class Session {
 
   pushMessage(event: BroadcastEvent, data: any) {
     this.pms.forEach(pm => {
+      if (pm.shouldPushMessage && !pm.shouldPushMessage(event, data)) {
+        return;
+      }
+
       pm.port.postMessage(
         {
           name: 'rabby-provider',

--- a/apps/mobile/src/core/utils/providerNetworkState.ts
+++ b/apps/mobile/src/core/utils/providerNetworkState.ts
@@ -1,0 +1,49 @@
+import { CHAINS_ENUM } from '@/constant/chains';
+import { getDappSnapshot } from '@/core/serviceApi/dapp';
+import { findChainByEnum } from '@/utils/chain';
+
+export type ProviderNetworkState = {
+  chainId: string;
+  networkVersion: string;
+};
+
+/**
+ * Last-resort value, only used when the chain list is empty (which should never
+ * happen once the app has booted). Keeps callers non-nullable so the dapp page
+ * always receives a valid `chainId`.
+ */
+const ETH_FALLBACK_NETWORK_STATE: ProviderNetworkState = {
+  chainId: '0x1',
+  networkVersion: '1',
+};
+
+/**
+ * Single source of truth for the network state a dapp page sees.
+ *
+ * Both `rabby_getProviderState` (the state the inpage provider bootstraps from)
+ * and the `chainChanged` notification pushed when a BackgroundBridge is created
+ * must be derived from here. If the two are computed independently they can
+ * disagree, the inpage provider then observes a chain change that never
+ * happened and emits `chainChanged` on every page load — dapps following the
+ * `chainChanged -> location.reload()` pattern reload forever.
+ */
+export function getProviderNetworkState(origin: string): ProviderNetworkState {
+  const chainEnum = getDappSnapshot(origin)?.chainId || CHAINS_ENUM.ETH;
+
+  let chain = findChainByEnum(chainEnum);
+  if (!chain) {
+    console.warn(
+      `[getProviderNetworkState] chain ${chainEnum} not found, fallback to ETH`,
+    );
+    chain = findChainByEnum(CHAINS_ENUM.ETH);
+  }
+
+  if (!chain) {
+    return ETH_FALLBACK_NETWORK_STATE;
+  }
+
+  return {
+    chainId: chain.hex,
+    networkVersion: chain.network,
+  };
+}


### PR DESCRIPTION
## Problem

A dapp page can get stuck in an endless reload loop in the in-app browser — the page reloads roughly every two seconds, resetting scroll position and wallet connection state each time.

Reproduced on `corruptedquotrons.fun/desk`, which wires the MetaMask-documented pattern:

```js
window.ethereum.on("accountsChanged", () => location.reload());
window.ethereum.on("chainChanged",   () => location.reload());
```

Its sibling pages (`/`, `/art`) don't register those handlers and don't reload — which is what pins the cause to an EIP-1193 event we push, not to the page itself. Every page load produced a `chainChanged` the page had no reason to receive, so the page reloaded, which produced another one.

## Root cause

`BackgroundBridge`'s constructor sends a `rabby_chainChanged` shortly after it is created. That send is **not** a chain state update — it is the readiness beacon added in #935. The inpage bridge treats the first `rabby_chainChanged` it receives as "the background pipeline is up" and answers with `RABBY_EXTENSION_CONNECT_CAN_RETRY`, which makes the stream middleware replay requests dropped before the pipeline was wired (`backgroundBridgeStreamMessageListener` in `@rabby-wallet/rn-webview-bridge`). #935 also removed the 200 ms `Promise.race` fallback in `_initializeStateAsync`, so this beacon is now the only thing rescuing an early `rabby_getProviderState` lost on Android.

The beacon is harmless as long as it carries the state the page already has — the provider de-dupes it and no event reaches the page. Two problems broke that.

**1. Two separate computations of the same chain state.** The beacon did its own `findChain` lookup, while `rabby_getProviderState` did another one *and* additionally awaited a `net_version` RPC. When they disagreed, the inpage provider saw a chain change that never happened and emitted `chainChanged`.

**2. No wallet-side record of what was already delivered.** De-duplication relied entirely on the inpage provider's `_handleChainChanged` guard, which cannot de-dupe against a value it has not received yet.

## Changes

- **New `core/utils/providerNetworkState.ts`** — single source of truth for the network state a dapp page sees. Both the beacon and `rabby_getProviderState` now derive from it, so they cannot disagree. The value is resolved outside the beacon's timer so the two cannot drift apart.
- **`BackgroundBridge`** — tracks `#lastChainIdSent` / `#lastNetworkVersionSent`, seeded from the value actually sent. Cancels a pending beacon in `onDisconnect`: a bridge is torn down at the start of the next navigation, so a beacon still in flight would land in the document the *next* bridge serves, carrying a stale origin and chain.
- **`SessionPort` / `Session.pushMessage`** — new optional `shouldPushMessage(event, data)` gate. `BackgroundBridge` implements it to drop a `chainChanged` carrying values the page already holds. The gate covers **every** `sessionService.broadcastEvent` path (`ethRequestAccounts`, `walletSwitchEthereumChain`, `walletAddEthereumChain`, `updateDappChain`, …), not just the beacon. Other events pass through unchanged.
- **`rabby_getProviderState`** — now reads from the shared helper.

The beacon's 50 ms delay is **kept** (now named `READINESS_BEACON_DELAY` and documented). It must land in the document the navigation is loading, but the bridge is constructed from `onLoadStart`, before the navigation commits — sending it synchronously injects it into the outgoing document and the #935 retry never fires. The delay was never the bug; the two independent chain lookups were. (An earlier revision of this branch made the send synchronous; `8e0c8ea` reverts that and explains why.)

## Prior art

`metamask-mobile` sends the same ping on bridge creation (`// Ensures the inpage provider receives a message indicating background liveliness…`) from the same `getProviderNetworkState` that backs `metamask_getProviderState`, and keeps `lastChainIdSent` / `networkVersionSent` on the bridge so later state-driven updates only fire when something actually changed. It can send it synchronously because it creates the bridge *after* navigation commit — see the follow-up note below.

## Reviewer notes

⚠️ **One behaviour change worth a look:** `rabby_getProviderState` no longer issues a `net_version` RPC to compute `networkVersion` — it uses `chain.network`, which is already what every other `chainChanged` broadcast in the codebase sends (`provider.ts:686 / 1941 / 2044`). `getProviderState` was the only outlier, and that inconsistency was part of the divergence. Side benefit: one fewer RPC round trip per page load. The `networkIdMap` cache that existed only for this call is removed. If you'd rather stay conservative, the alternative is feeding the RPC result into the shared helper's cache instead — happy to switch.

**Not addressed here (follow-up):** the bridge is still created in `onLoadStart`, before the navigation commits, which is why the beacon needs a guessed delay at all. `metamask-mobile` explicitly moved this to after commit:

> `// The background bridge is intentionally not initialized here.`
> `// `onLoadStart` fires before the navigation has committed, so the bridge`
> `// is initialized and the active account sent only once the navigation has committed`

Doing the same would let us drop `READINESS_BEACON_DELAY` entirely and would remove the interaction with `treatAsReload = IS_IOS || ...` recreating the bridge on every navigation. Worth its own PR.

**Spotted in passing, not fixed here:** `BackgroundBridge.#disconnected` is initialised to `true` and never set back to `false`, so `onUnlock()` / `onLock()` always early-return and the `disconnected` getter always reports `true`.

## Testing

Full `apps/mobile` validation set, each compared against a `git stash` baseline on the same tree:

| Command | Result |
|---|---|
| `lint:cycles` | ✅ No circular dependency found |
| `lint:cycles:eslint` | ✅ clean |
| `typecheck` | 34 errors — **line-for-line identical to baseline** (pre-existing `@rabby-wallet/hyperliquid-sdk` / `react-native-iap` typings; none in touched files) |
| `test --runInBand` | 3059 passed / 19 failed — **same failing suites as baseline** (13 pre-existing PerpsPro suites) |
| `test:integration:ci` | 99 passed / 1 failed — **same as baseline** (`positionOrderLifecycle.integration.test.ts`) |

New `core/services/session.pushMessage.test.ts` (3 cases, passing) covers the gate semantics: ports without a gate still receive pushes, a gate returning `false` drops the push, and ports are gated independently.

**Still needs a device check, on both platforms:**
- iOS: open `corruptedquotrons.fun/desk` and confirm the reload loop is gone.
- Android: confirm a dapp still connects on a cold page load, i.e. the #935 retry path is intact.
