### PR TITLE
ci: add Lark Drive package delivery

### DIFF
--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Install JavaScript dependencies without lifecycle scripts
         shell: bash --noprofile --norc -eo pipefail {0}
-        run: YARN_ENABLE_SCRIPTS=false yarn install --immutable
+        run: YARN_ENABLE_SCRIPTS=false corepack yarn install --immutable
 
       - name: Upload existing APK through bot credentials
         shell: bash --noprofile --norc -eo pipefail {0}

--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -23,6 +23,10 @@ on:
         required: false
         type: boolean
         default: true
+      LARK_DRIVE_UPLOAD_ONLY:
+        required: false
+        type: boolean
+        default: false
       ANDROID_16KB_CHECK:
         required: false
         type: choice
@@ -155,9 +159,63 @@ jobs:
           INPUT_MOBILE_LOC: ${{ inputs.macos_machine_location }}
           DISABLE_AWS_CLI_HTTPS_VALIDATION: ${{ inputs.__DANGEROUS_NO_VERIFY_SSL }}
 
+  lark-drive-upload-probe:
+    name: Lark Drive bot upload probe
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.LARK_DRIVE_UPLOAD_ONLY == true }}
+    runs-on:
+      - self-hosted
+      - Linux
+      - mobile
+    env:
+      RABBY_ROBOT_LARK_APP_ID_FROM_GITHUB: ${{ secrets.RABBY_ROBOT_LARK_APP_ID }}
+      RABBY_ROBOT_LARK_APP_SECRET_FROM_GITHUB: ${{ secrets.RABBY_ROBOT_LARK_APP_SECRET }}
+      RABBY_MOBILE_LARK_DRIVE_PROBE_PACKAGE_URL: ${{ secrets.RABBY_MOBILE_LARK_DRIVE_PROBE_PACKAGE_URL }}
+      RABBY_MOBILE_LARK_DRIVE_FILE_URL_BASE: ${{ vars.RABBY_MOBILE_LARK_DRIVE_FILE_URL_BASE || 'https://debankglobal.sg.larksuite.com/file' }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          clean: false
+
+      - name: '[Linux] Setup Nodejs and Yarn'
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
+        with:
+          node-version: 22
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install JavaScript dependencies without lifecycle scripts
+        shell: bash --noprofile --norc -eo pipefail {0}
+        run: YARN_ENABLE_SCRIPTS=false yarn install --immutable
+
+      - name: Upload existing APK through bot credentials
+        shell: bash --noprofile --norc -eo pipefail {0}
+        run: |
+          if [ -z "$RABBY_MOBILE_LARK_DRIVE_PROBE_PACKAGE_URL" ]; then
+            echo "RABBY_MOBILE_LARK_DRIVE_PROBE_PACKAGE_URL is not configured"
+            exit 1
+          fi
+
+          package_file="$(mktemp --suffix=.apk)"
+          trap 'rm -f "$package_file"' EXIT
+
+          curl --fail --location --silent --show-error --retry 2 \
+            --proto '=https' --tlsv1.2 \
+            "$RABBY_MOBILE_LARK_DRIVE_PROBE_PACKAGE_URL" \
+            --output "$package_file"
+          test -s "$package_file"
+          unzip -tq "$package_file" >/dev/null
+
+          export RABBY_ROBOT_LARK_APP_ID="$RABBY_ROBOT_LARK_APP_ID_FROM_GITHUB"
+          export RABBY_ROBOT_LARK_APP_SECRET="$RABBY_ROBOT_LARK_APP_SECRET_FROM_GITHUB"
+          node apps/mobile/scripts/ci/upload-package-to-lark-drive.js \
+            "$package_file" \
+            "rabby-mobile-ci-probe-${GITHUB_RUN_ID}.apk"
+
   setup:
     name: Build
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.IOS_SIGNING_EXPORT_PREFLIGHT_ONLY != true }}
+    if: ${{ github.event_name != 'workflow_dispatch' || (inputs.IOS_SIGNING_EXPORT_PREFLIGHT_ONLY != true && inputs.LARK_DRIVE_UPLOAD_ONLY != true) }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -23,10 +23,6 @@ on:
         required: false
         type: boolean
         default: true
-      LARK_DRIVE_UPLOAD_ONLY:
-        required: false
-        type: boolean
-        default: false
       ANDROID_16KB_CHECK:
         required: false
         type: choice
@@ -74,148 +70,14 @@ on:
         required: false
         type: string
         default: ''
-      IOS_SIGNING_EXPORT_PREFLIGHT_ONLY:
-        required: false
-        type: boolean
-        default: false
 
 defaults:
   run:
     shell: bash -ieol pipefail {0}
 
 jobs:
-  ios-signing-export-preflight:
-    name: iOS signing export preflight
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.IOS_SIGNING_EXPORT_PREFLIGHT_ONLY == true }}
-    runs-on:
-      - self-hosted
-      - macOS
-      - ${{ inputs.macos_machine_location }}
-    env:
-      BUILD_TARGET_PLATFORM: ios
-      XCODE_VER: '26.3'
-    steps:
-      - name: Checkout git repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-        with:
-          clean: false
-
-      - name: Clean git Manually
-        run: |
-          yarn_exclude_args=()
-          if [ "${RABBY_MOBILE_NM_USE_CACHE:-true}" = "true" ]; then
-            echo "Keep yarn install outputs";
-            yarn_exclude_args+=(
-              -e node_modules
-              -e 'apps/*/node_modules'
-              -e 'packages/*/node_modules'
-              -e .yarn/install-state.gz
-              -e .yarn/unplugged
-            )
-          fi
-
-          git clean -ffdx "${yarn_exclude_args[@]}";
-          git reset --hard HEAD;
-
-      - name: Env Test
-        id: env-test
-        run: |
-          echo "whoami $(whoami)"
-          echo "shell is $(echo $0)"
-          echo "HOME is $HOME"
-          echo "which node $(which node)"
-
-      - name: '[macOS] Setup Xcode'
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
-        id: setup-xcode
-        with:
-          # use specific version rather than 'latest-stable' if multiple Xcodes installed
-          xcode-version: ${{ env.XCODE_VER }}
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Preflight iOS signing export
-        run: |
-          unset MATCH_GIT_BASIC_AUTHORIZATION
-
-          if [ "$INPUT_MOBILE_LOC" != "mobile-local" ]; then
-            RABBY_MOBILE_UNLOCK_KEYCHAIN_PASS="$KEYCHAIN_PASS"
-          fi
-          if [ -n "${RABBY_MOBILE_UNLOCK_KEYCHAIN_PASS:-}" ]; then
-            security unlock-keychain -p "$RABBY_MOBILE_UNLOCK_KEYCHAIN_PASS" login.keychain
-          else
-            echo "RABBY_MOBILE_UNLOCK_KEYCHAIN_PASS is not set; assuming keychain is already unlocked."
-          fi
-
-          cd apps/mobile
-          ./scripts/ci/ios-signing-export-preflight.sh
-        env:
-          KEYCHAIN_PASS: ${{ secrets.KEYCHAIN_PASS }}
-          MATCH_PASSWORD: ${{ secrets.RABBY_MOBILE_MATCH_PASSWORD }}
-          RABBY_MOBILE_MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.RABBY_MOBILE_MATCH_GIT_BASIC_AUTHORIZATION }}
-          RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_S3_URI: ${{ secrets.RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_S3_URI }}
-          RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_SHA256: ${{ secrets.RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_SHA256 }}
-          INPUT_MOBILE_LOC: ${{ inputs.macos_machine_location }}
-          DISABLE_AWS_CLI_HTTPS_VALIDATION: ${{ inputs.__DANGEROUS_NO_VERIFY_SSL }}
-
-  lark-drive-upload-probe:
-    name: Lark Drive bot upload probe
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.LARK_DRIVE_UPLOAD_ONLY == true }}
-    runs-on:
-      - self-hosted
-      - macOS
-      - mobile
-    env:
-      RABBY_ROBOT_LARK_APP_ID_FROM_GITHUB: ${{ secrets.RABBY_ROBOT_LARK_APP_ID }}
-      RABBY_ROBOT_LARK_APP_SECRET_FROM_GITHUB: ${{ secrets.RABBY_ROBOT_LARK_APP_SECRET }}
-      RABBY_MOBILE_LARK_DRIVE_PROBE_PACKAGE_URL: ${{ secrets.RABBY_MOBILE_LARK_DRIVE_PROBE_PACKAGE_URL }}
-      RABBY_MOBILE_LARK_DRIVE_FILE_URL_BASE: ${{ vars.RABBY_MOBILE_LARK_DRIVE_FILE_URL_BASE || 'https://debankglobal.sg.larksuite.com/file' }}
-    steps:
-      - name: Checkout git repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-        with:
-          clean: false
-
-      - name: Setup Nodejs and Yarn
-        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
-        with:
-          node-version: 22
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Install JavaScript dependencies without lifecycle scripts
-        shell: bash --noprofile --norc -eo pipefail {0}
-        run: YARN_ENABLE_SCRIPTS=false corepack yarn install --immutable
-
-      - name: Upload existing APK through bot credentials
-        shell: bash --noprofile --norc -eo pipefail {0}
-        run: |
-          if [ -z "$RABBY_MOBILE_LARK_DRIVE_PROBE_PACKAGE_URL" ]; then
-            echo "RABBY_MOBILE_LARK_DRIVE_PROBE_PACKAGE_URL is not configured"
-            exit 1
-          fi
-
-          package_file="$(mktemp -t rabby-mobile-lark-probe)"
-          trap 'rm -f "$package_file"' EXIT
-
-          curl --fail --location --silent --show-error --retry 2 \
-            --proto '=https' --tlsv1.2 \
-            "$RABBY_MOBILE_LARK_DRIVE_PROBE_PACKAGE_URL" \
-            --output "$package_file"
-          test -s "$package_file"
-          unzip -tq "$package_file" >/dev/null
-
-          export RABBY_ROBOT_LARK_APP_ID="$RABBY_ROBOT_LARK_APP_ID_FROM_GITHUB"
-          export RABBY_ROBOT_LARK_APP_SECRET="$RABBY_ROBOT_LARK_APP_SECRET_FROM_GITHUB"
-          node apps/mobile/scripts/ci/upload-package-to-lark-drive.js \
-            "$package_file" \
-            "rabby-mobile-ci-probe-${GITHUB_RUN_ID}.apk"
-
   setup:
     name: Build
-    if: ${{ github.event_name != 'workflow_dispatch' || (inputs.IOS_SIGNING_EXPORT_PREFLIGHT_ONLY != true && inputs.LARK_DRIVE_UPLOAD_ONLY != true) }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -283,7 +283,6 @@ jobs:
           SKIP_NOTIFY_LARK: ${{ inputs.SKIP_NOTIFY_LARK }}
           RABBY_MOBILE_LARK_DRIVE_UPLOAD: ${{ inputs.LARK_DRIVE_UPLOAD }}
           RABBY_MOBILE_LARK_DRIVE_UPLOAD_REQUIRED: 'false'
-          RABBY_MOBILE_LARK_DRIVE_FILE_URL_BASE: ${{ vars.RABBY_MOBILE_LARK_DRIVE_FILE_URL_BASE || 'https://debankglobal.sg.larksuite.com/file' }}
           RABBY_MOBILE_LARK_CHAT_URL: ${{ secrets.LARK_CHAT_URL }}
           RABBY_MOBILE_LARK_CHAT_SECRET: ${{ secrets.LARK_CHAT_SECRET }}
           RABBY_MOBILE_LARK_CHAT_URL_FROM_GITHUB: ${{ secrets.LARK_CHAT_URL }}

--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -19,6 +19,10 @@ on:
         required: false
         type: boolean
         default: false
+      LARK_DRIVE_UPLOAD:
+        required: false
+        type: boolean
+        default: true
       ANDROID_16KB_CHECK:
         required: false
         type: choice
@@ -357,6 +361,9 @@ jobs:
           TYPE: adhoc
           RABBY_MOBILE_BUILD_ENV: regression
           SKIP_NOTIFY_LARK: ${{ inputs.SKIP_NOTIFY_LARK }}
+          RABBY_MOBILE_LARK_DRIVE_UPLOAD: ${{ inputs.LARK_DRIVE_UPLOAD }}
+          RABBY_MOBILE_LARK_DRIVE_UPLOAD_REQUIRED: 'false'
+          RABBY_MOBILE_LARK_DRIVE_FILE_URL_BASE: ${{ vars.RABBY_MOBILE_LARK_DRIVE_FILE_URL_BASE || 'https://debankglobal.sg.larksuite.com/file' }}
           RABBY_MOBILE_LARK_CHAT_URL: ${{ secrets.LARK_CHAT_URL }}
           RABBY_MOBILE_LARK_CHAT_SECRET: ${{ secrets.LARK_CHAT_SECRET }}
           RABBY_MOBILE_LARK_CHAT_URL_FROM_GITHUB: ${{ secrets.LARK_CHAT_URL }}

--- a/.github/workflows/feature_test.yml
+++ b/.github/workflows/feature_test.yml
@@ -164,7 +164,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.LARK_DRIVE_UPLOAD_ONLY == true }}
     runs-on:
       - self-hosted
-      - Linux
+      - macOS
       - mobile
     env:
       RABBY_ROBOT_LARK_APP_ID_FROM_GITHUB: ${{ secrets.RABBY_ROBOT_LARK_APP_ID }}
@@ -177,7 +177,7 @@ jobs:
         with:
           clean: false
 
-      - name: '[Linux] Setup Nodejs and Yarn'
+      - name: Setup Nodejs and Yarn
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 22
@@ -197,7 +197,7 @@ jobs:
             exit 1
           fi
 
-          package_file="$(mktemp --suffix=.apk)"
+          package_file="$(mktemp -t rabby-mobile-lark-probe)"
           trap 'rm -f "$package_file"' EXIT
 
           curl --fail --location --silent --show-error --retry 2 \

--- a/.github/workflows/mobile_capability_probes.yml
+++ b/.github/workflows/mobile_capability_probes.yml
@@ -1,0 +1,147 @@
+name: Mobile Capability Probes
+
+on:
+  workflow_dispatch:
+    inputs:
+      macos_machine_location:
+        required: true
+        type: choice
+        options:
+          - 'mobile'
+          - 'mobile-local'
+        default: 'mobile'
+      RABBY_MOBILE_NM_USE_CACHE:
+        required: false
+        type: boolean
+        default: true
+      __DANGEROUS_NO_VERIFY_SSL:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  ios-signing-export-preflight:
+    name: iOS signing export preflight
+    runs-on:
+      - self-hosted
+      - macOS
+      - ${{ inputs.macos_machine_location }}
+    env:
+      BUILD_TARGET_PLATFORM: ios
+      RABBY_MOBILE_NM_USE_CACHE: ${{ inputs.RABBY_MOBILE_NM_USE_CACHE }}
+      XCODE_VER: '26.3'
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          clean: false
+
+      - name: Clean git Manually
+        run: |
+          yarn_exclude_args=()
+          if [ "${RABBY_MOBILE_NM_USE_CACHE:-true}" = "true" ]; then
+            echo "Keep yarn install outputs";
+            yarn_exclude_args+=(
+              -e node_modules
+              -e 'apps/*/node_modules'
+              -e 'packages/*/node_modules'
+              -e .yarn/install-state.gz
+              -e .yarn/unplugged
+            )
+          fi
+
+          git clean -ffdx "${yarn_exclude_args[@]}";
+          git reset --hard HEAD;
+
+      - name: Env Test
+        run: |
+          echo "whoami $(whoami)"
+          echo "shell is $(echo $0)"
+          echo "HOME is $HOME"
+          echo "which node $(which node)"
+
+      - name: '[macOS] Setup Xcode'
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+        id: setup-xcode
+        with:
+          xcode-version: ${{ env.XCODE_VER }}
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Preflight iOS signing export
+        run: |
+          unset MATCH_GIT_BASIC_AUTHORIZATION
+
+          if [ "$INPUT_MOBILE_LOC" != "mobile-local" ]; then
+            RABBY_MOBILE_UNLOCK_KEYCHAIN_PASS="$KEYCHAIN_PASS"
+          fi
+          if [ -n "${RABBY_MOBILE_UNLOCK_KEYCHAIN_PASS:-}" ]; then
+            security unlock-keychain -p "$RABBY_MOBILE_UNLOCK_KEYCHAIN_PASS" login.keychain
+          else
+            echo "RABBY_MOBILE_UNLOCK_KEYCHAIN_PASS is not set; assuming keychain is already unlocked."
+          fi
+
+          cd apps/mobile
+          ./scripts/ci/ios-signing-export-preflight.sh
+        env:
+          KEYCHAIN_PASS: ${{ secrets.KEYCHAIN_PASS }}
+          MATCH_PASSWORD: ${{ secrets.RABBY_MOBILE_MATCH_PASSWORD }}
+          RABBY_MOBILE_MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.RABBY_MOBILE_MATCH_GIT_BASIC_AUTHORIZATION }}
+          RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_S3_URI: ${{ secrets.RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_S3_URI }}
+          RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_SHA256: ${{ secrets.RABBY_MOBILE_IOS_SIGNING_PREFLIGHT_ARCHIVE_SHA256 }}
+          INPUT_MOBILE_LOC: ${{ inputs.macos_machine_location }}
+          DISABLE_AWS_CLI_HTTPS_VALIDATION: ${{ inputs.__DANGEROUS_NO_VERIFY_SSL }}
+
+  lark-drive-upload-probe:
+    name: Lark Drive bot upload probe
+    runs-on:
+      - self-hosted
+      - macOS
+      - ${{ inputs.macos_machine_location }}
+    env:
+      RABBY_ROBOT_LARK_APP_ID_FROM_GITHUB: ${{ secrets.RABBY_ROBOT_LARK_APP_ID }}
+      RABBY_ROBOT_LARK_APP_SECRET_FROM_GITHUB: ${{ secrets.RABBY_ROBOT_LARK_APP_SECRET }}
+      RABBY_MOBILE_LARK_DRIVE_PROBE_PACKAGE_URL: ${{ secrets.RABBY_MOBILE_LARK_DRIVE_PROBE_PACKAGE_URL }}
+      RABBY_MOBILE_LARK_DRIVE_FILE_URL_BASE: ${{ vars.RABBY_MOBILE_LARK_DRIVE_FILE_URL_BASE || 'https://debankglobal.sg.larksuite.com/file' }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          clean: false
+
+      - name: Setup Nodejs and Yarn
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
+        with:
+          node-version: 22
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install JavaScript dependencies without lifecycle scripts
+        shell: bash --noprofile --norc -eo pipefail {0}
+        run: YARN_ENABLE_SCRIPTS=false corepack yarn install --immutable
+
+      - name: Upload existing APK through bot credentials
+        shell: bash --noprofile --norc -eo pipefail {0}
+        run: |
+          if [ -z "$RABBY_MOBILE_LARK_DRIVE_PROBE_PACKAGE_URL" ]; then
+            echo "RABBY_MOBILE_LARK_DRIVE_PROBE_PACKAGE_URL is not configured"
+            exit 1
+          fi
+
+          package_file="$(mktemp -t rabby-mobile-lark-probe)"
+          trap 'rm -f "$package_file"' EXIT
+
+          curl --fail --location --silent --show-error --retry 2 \
+            --proto '=https' --tlsv1.2 \
+            "$RABBY_MOBILE_LARK_DRIVE_PROBE_PACKAGE_URL" \
+            --output "$package_file"
+          test -s "$package_file"
+          unzip -tq "$package_file" >/dev/null
+
+          export RABBY_ROBOT_LARK_APP_ID="$RABBY_ROBOT_LARK_APP_ID_FROM_GITHUB"
+          export RABBY_ROBOT_LARK_APP_SECRET="$RABBY_ROBOT_LARK_APP_SECRET_FROM_GITHUB"
+          node apps/mobile/scripts/ci/upload-package-to-lark-drive.js \
+            "$package_file" \
+            "rabby-mobile-ci-probe-${GITHUB_RUN_ID}.apk"

--- a/.github/workflows/mobile_capability_probes.yml
+++ b/.github/workflows/mobile_capability_probes.yml
@@ -103,7 +103,6 @@ jobs:
       RABBY_ROBOT_LARK_APP_ID_FROM_GITHUB: ${{ secrets.RABBY_ROBOT_LARK_APP_ID }}
       RABBY_ROBOT_LARK_APP_SECRET_FROM_GITHUB: ${{ secrets.RABBY_ROBOT_LARK_APP_SECRET }}
       RABBY_MOBILE_LARK_DRIVE_PROBE_PACKAGE_URL: ${{ secrets.RABBY_MOBILE_LARK_DRIVE_PROBE_PACKAGE_URL }}
-      RABBY_MOBILE_LARK_DRIVE_FILE_URL_BASE: ${{ vars.RABBY_MOBILE_LARK_DRIVE_FILE_URL_BASE || 'https://debankglobal.sg.larksuite.com/file' }}
     steps:
       - name: Checkout git repo
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3

--- a/apps/mobile/scripts/ci/upload-package-to-lark-drive.js
+++ b/apps/mobile/scripts/ci/upload-package-to-lark-drive.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const { uploadFileToLarkDrive } = require('../libs/lark');
+
+async function main() {
+  const filePath = process.argv[2];
+  const fileName = process.argv[3] || (filePath && path.basename(filePath));
+  if (!filePath || !fileName) {
+    throw new Error(
+      'usage: upload-package-to-lark-drive.js <package-path> [drive-file-name]',
+    );
+  }
+
+  const resolvedFilePath = path.resolve(filePath);
+  if (!fs.existsSync(resolvedFilePath)) {
+    throw new Error(`package file does not exist: ${resolvedFilePath}`);
+  }
+
+  const stat = fs.statSync(resolvedFilePath);
+  console.error(
+    `[lark-drive] uploading ${path.basename(fileName)} (${stat.size} bytes)`,
+  );
+
+  const result = await uploadFileToLarkDrive(resolvedFilePath, {
+    fileName,
+    onProgress: ({ blockNumber, blockCount }) => {
+      console.error(`[lark-drive] uploaded block ${blockNumber}/${blockCount}`);
+    },
+  });
+
+  console.error(
+    `[lark-drive] upload succeeded: ${result.blockCount} blocks, ${result.size} bytes`,
+  );
+  process.stdout.write(result.url);
+}
+
+main().catch(error => {
+  console.error(`[lark-drive] ${error.message}`);
+  process.exitCode = 1;
+});

--- a/apps/mobile/scripts/ci/upload-package-to-lark-drive.test.js
+++ b/apps/mobile/scripts/ci/upload-package-to-lark-drive.test.js
@@ -1,0 +1,78 @@
+/* eslint-env jest */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const nock = require('nock');
+
+const testEnv = process.env;
+Object.assign(testEnv, {
+  RABBY_ROBOT_LARK_APP_ID: 'test-app-id',
+  RABBY_ROBOT_LARK_APP_SECRET: 'test-app-secret',
+});
+
+const { uploadFileToLarkDrive } = require('../libs/lark');
+
+describe('uploadFileToLarkDrive', () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test('uploads a package through prepare, parts, and finish', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lark-drive-test-'));
+    const filePath = path.join(tempDir, 'package.apk');
+    fs.writeFileSync(filePath, '0123456789');
+
+    nock('https://open.larksuite.com')
+      .post('/open-apis/auth/v3/tenant_access_token/internal/', {
+        app_id: 'test-app-id',
+        app_secret: 'test-app-secret',
+      })
+      .reply(200, {
+        code: 0,
+        tenant_access_token: 'test-tenant-token',
+      })
+      .post('/open-apis/drive/v1/files/upload_prepare', {
+        file_name: 'package.apk',
+        parent_type: 'explorer',
+        parent_node: '',
+        size: 10,
+      })
+      .reply(200, {
+        code: 0,
+        data: {
+          upload_id: 'test-upload-id',
+          block_size: 4,
+          block_num: 3,
+        },
+      })
+      .post('/open-apis/drive/v1/files/upload_part')
+      .times(3)
+      .reply(200, { code: 0 })
+      .post('/open-apis/drive/v1/files/upload_finish', {
+        upload_id: 'test-upload-id',
+        block_num: 3,
+      })
+      .reply(200, {
+        code: 0,
+        data: { file_token: 'test-file-token' },
+      });
+
+    const progress = [];
+    const result = await uploadFileToLarkDrive(filePath, {
+      fileName: 'package.apk',
+      onProgress: value => progress.push(value),
+    });
+
+    expect(result).toEqual({
+      fileToken: 'test-file-token',
+      url: 'https://debankglobal.sg.larksuite.com/file/test-file-token',
+      size: 10,
+      blockCount: 3,
+    });
+    expect(progress.map(value => value.uploadedBytes)).toEqual([4, 8, 10]);
+    expect(nock.isDone()).toBe(true);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+});

--- a/apps/mobile/scripts/deploy-android.sh
+++ b/apps/mobile/scripts/deploy-android.sh
@@ -335,7 +335,16 @@ if [ "$REALLY_UPLOAD" == "true" ]; then
   if [ ! -z $apk_url ]; then
     echo "[deploy-android] publish as $apk_name, with version.json"
 
-    [ ! -z "$CI" ] && [ "$SKIP_NOTIFY_LARK" != "true" ] && RABBY_MOBILE_ANDROID_16KB_REPORT_TEXT="$android_16kb_report_text" node $script_dir/notify-lark.js "$apk_url" android "$FAST_BUILD_ENABLED"
+    lark_drive_url=""
+    if [ "$RABBY_MOBILE_LARK_DRIVE_UPLOAD" = "true" ] && [ "$SKIP_NOTIFY_LARK" != "true" ]; then
+      echo "[deploy-android] upload APK to Lark Drive..."
+      if ! lark_drive_url=$(node "$script_dir/ci/upload-package-to-lark-drive.js" "$deployment_local_dir/$apk_name" "$version_bundle_filename"); then
+        echo "[deploy-android] ⚠️ Lark Drive upload failed; keeping AWS notification only."
+        [ "$RABBY_MOBILE_LARK_DRIVE_UPLOAD_REQUIRED" = "true" ] && exit 1
+      fi
+    fi
+
+    [ ! -z "$CI" ] && [ "$SKIP_NOTIFY_LARK" != "true" ] && RABBY_MOBILE_ANDROID_16KB_REPORT_TEXT="$android_16kb_report_text" RABBY_MOBILE_LARK_DRIVE_URL="$lark_drive_url" node $script_dir/notify-lark.js "$apk_url" android "$FAST_BUILD_ENABLED"
   fi
 fi
 

--- a/apps/mobile/scripts/deploy-ios-adhoc.sh
+++ b/apps/mobile/scripts/deploy-ios-adhoc.sh
@@ -199,7 +199,16 @@ if [ "$REALLY_UPLOAD" == "true" ]; then
   aws s3 sync $NO_VERIFY_SSL_FLAG $deployment_local_dir $deployment_s3_dir/ --exclude '*' --include "*.json" --acl public-read --content-type application/json --exact-timestamps
   aws s3 sync $NO_VERIFY_SSL_FLAG $deployment_local_dir $deployment_s3_dir/ --exclude '*' --include "*.md" --acl public-read --content-type text/plain --exact-timestamps
 
-  node $script_dir/notify-lark.js "$manifest_plist_url" ios "$(ios_fast_build_enabled_value)"
+  lark_drive_url=""
+  if [ "$RABBY_MOBILE_LARK_DRIVE_UPLOAD" = "true" ] && [ "$SKIP_NOTIFY_LARK" != "true" ]; then
+    echo "[deploy-ios-adhoc] upload IPA to Lark Drive..."
+    if ! lark_drive_url=$(node "$script_dir/ci/upload-package-to-lark-drive.js" "$deployment_local_dir/rabbymobile.ipa" "${version_bundle_name}.ipa"); then
+      echo "[deploy-ios-adhoc] ⚠️ Lark Drive upload failed; keeping AWS notification only."
+      [ "$RABBY_MOBILE_LARK_DRIVE_UPLOAD_REQUIRED" = "true" ] && exit 1
+    fi
+  fi
+
+  RABBY_MOBILE_LARK_DRIVE_URL="$lark_drive_url" node $script_dir/notify-lark.js "$manifest_plist_url" ios "$(ios_fast_build_enabled_value)"
 fi
 
 [ -z $RABBY_MOBILE_CDN_FRONTEND_ID ] && RABBY_MOBILE_CDN_FRONTEND_ID="<DIST_ID>"

--- a/apps/mobile/scripts/libs/lark.js
+++ b/apps/mobile/scripts/libs/lark.js
@@ -28,6 +28,7 @@ async function getLarkToken() {
       app_id: RABBY_ROBOT_LARK_APP_ID,
       app_secret: RABBY_ROBOT_LARK_APP_SECRET,
     },
+    { validateStatus: () => true },
   );
 
   const body = assertLarkSuccess(resp, 'tenant access token');
@@ -44,10 +45,16 @@ exports.getLarkToken = getLarkToken;
 function assertLarkSuccess(response, operation) {
   const body = response && response.data;
   const code = body && body.code;
-  if (Number(code) !== 0) {
+  const status = response && response.status;
+  if (
+    (typeof status === 'number' && (status < 200 || status >= 300)) ||
+    Number(code) !== 0
+  ) {
     const message = String((body && body.msg) || 'unknown error').slice(0, 200);
     throw new Error(
-      `[lark] ${operation} failed: code=${String(
+      `[lark] ${operation} failed: http=${String(
+        status === undefined ? 'unknown' : status,
+      )} code=${String(
         code === undefined ? 'unknown' : code,
       )} message=${message}`,
     );
@@ -60,6 +67,7 @@ function getLarkApiOptions(accessToken) {
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },
+    validateStatus: () => true,
     timeout: 120000,
     maxContentLength: Infinity,
     maxBodyLength: Infinity,

--- a/apps/mobile/scripts/libs/lark.js
+++ b/apps/mobile/scripts/libs/lark.js
@@ -8,10 +8,7 @@ const FormData = require('form-data'); // npm install --save form-data
 const Axios = require('axios');
 
 const LARK_OPEN_API_BASE_URL = 'https://open.larksuite.com/open-apis';
-const LARK_DRIVE_FILE_URL_BASE = (
-  process.env.RABBY_MOBILE_LARK_DRIVE_FILE_URL_BASE ||
-  'https://debankglobal.sg.larksuite.com/file'
-).replace(/\/+$/, '');
+const LARK_DRIVE_FILE_URL_BASE = 'https://debankglobal.sg.larksuite.com/file';
 
 const { RABBY_ROBOT_LARK_APP_ID, RABBY_ROBOT_LARK_APP_SECRET } = process.env;
 if (!RABBY_ROBOT_LARK_APP_ID) {

--- a/apps/mobile/scripts/libs/lark.js
+++ b/apps/mobile/scripts/libs/lark.js
@@ -1,10 +1,17 @@
 const fs = require('fs');
 const path = require('path');
 const { createHmac } = require('crypto');
+const { Buffer } = require('buffer');
 // @see https://www.npmjs.com/package/qrcode
 const QRCode = require('qrcode');
 const FormData = require('form-data'); // npm install --save form-data
 const Axios = require('axios');
+
+const LARK_OPEN_API_BASE_URL = 'https://open.larksuite.com/open-apis';
+const LARK_DRIVE_FILE_URL_BASE = (
+  process.env.RABBY_MOBILE_LARK_DRIVE_FILE_URL_BASE ||
+  'https://debankglobal.sg.larksuite.com/file'
+).replace(/\/+$/, '');
 
 const { RABBY_ROBOT_LARK_APP_ID, RABBY_ROBOT_LARK_APP_SECRET } = process.env;
 if (!RABBY_ROBOT_LARK_APP_ID) {
@@ -16,16 +23,178 @@ if (!RABBY_ROBOT_LARK_APP_SECRET) {
 
 async function getLarkToken() {
   const resp = await Axios.post(
-    'https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal/',
+    `${LARK_OPEN_API_BASE_URL}/auth/v3/tenant_access_token/internal/`,
     {
       app_id: RABBY_ROBOT_LARK_APP_ID,
       app_secret: RABBY_ROBOT_LARK_APP_SECRET,
     },
   );
 
-  return resp.data.tenant_access_token;
+  const body = assertLarkSuccess(resp, 'tenant access token');
+  const accessToken =
+    body.tenant_access_token || (body.data && body.data.tenant_access_token);
+  if (!accessToken) {
+    throw new Error('[lark] tenant access token response is missing a token');
+  }
+
+  return accessToken;
 }
 exports.getLarkToken = getLarkToken;
+
+function assertLarkSuccess(response, operation) {
+  const body = response && response.data;
+  const code = body && body.code;
+  if (Number(code) !== 0) {
+    const message = String((body && body.msg) || 'unknown error').slice(0, 200);
+    throw new Error(
+      `[lark] ${operation} failed: code=${String(
+        code === undefined ? 'unknown' : code,
+      )} message=${message}`,
+    );
+  }
+  return body;
+}
+
+function getLarkApiOptions(accessToken) {
+  return {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    timeout: 120000,
+    maxContentLength: Infinity,
+    maxBodyLength: Infinity,
+  };
+}
+
+/**
+ * Upload a package to the bot's Drive root using the multipart API.
+ * The API requires 4 MB-sized chunks for files over 20 MB.
+ */
+async function uploadFileToLarkDrive(
+  filePath,
+  { fileName = path.basename(filePath), onProgress } = {},
+) {
+  const stat = fs.statSync(filePath);
+  if (!stat.isFile()) {
+    throw new Error(`[lark] package path is not a file: ${filePath}`);
+  }
+
+  const accessToken = await getLarkToken();
+  const requestOptions = getLarkApiOptions(accessToken);
+  const prepareResponse = await Axios.post(
+    `${LARK_OPEN_API_BASE_URL}/drive/v1/files/upload_prepare`,
+    {
+      file_name: path.basename(fileName),
+      parent_type: 'explorer',
+      parent_node: '',
+      size: stat.size,
+    },
+    requestOptions,
+  );
+  const prepare = assertLarkSuccess(prepareResponse, 'Drive upload prepare');
+  const uploadId = prepare.data && prepare.data.upload_id;
+  const blockSize = Number(prepare.data && prepare.data.block_size);
+  const blockNum = Number(prepare.data && prepare.data.block_num);
+
+  if (!uploadId || !Number.isSafeInteger(blockSize) || blockSize <= 0) {
+    throw new Error(
+      '[lark] Drive upload prepare returned an invalid block plan',
+    );
+  }
+  if (!Number.isSafeInteger(blockNum) || blockNum <= 0) {
+    throw new Error(
+      '[lark] Drive upload prepare returned an invalid block count',
+    );
+  }
+
+  const fileDescriptor = fs.openSync(filePath, 'r');
+  let uploadedBytes = 0;
+  try {
+    for (let seq = 0; seq < blockNum; seq += 1) {
+      const remainingBytes = stat.size - uploadedBytes;
+      const partSize = Math.min(blockSize, remainingBytes);
+      if (partSize <= 0) {
+        throw new Error('[lark] Drive upload block plan exceeded file size');
+      }
+
+      const part = Buffer.allocUnsafe(partSize);
+      let bytesRead = 0;
+      while (bytesRead < partSize) {
+        const read = fs.readSync(
+          fileDescriptor,
+          part,
+          bytesRead,
+          partSize - bytesRead,
+          uploadedBytes + bytesRead,
+        );
+        if (read === 0) {
+          throw new Error('[lark] package changed while uploading to Drive');
+        }
+        bytesRead += read;
+      }
+
+      const form = new FormData();
+      form.append('upload_id', uploadId);
+      form.append('seq', String(seq));
+      form.append('size', String(partSize));
+      form.append('file', part, {
+        filename: path.basename(fileName),
+        contentType: 'application/octet-stream',
+        knownLength: partSize,
+      });
+
+      const partResponse = await Axios.post(
+        `${LARK_OPEN_API_BASE_URL}/drive/v1/files/upload_part`,
+        form,
+        {
+          ...requestOptions,
+          headers: {
+            ...requestOptions.headers,
+            ...form.getHeaders(),
+          },
+        },
+      );
+      assertLarkSuccess(partResponse, `Drive upload block ${seq + 1}`);
+      uploadedBytes += partSize;
+      if (onProgress) {
+        onProgress({
+          blockNumber: seq + 1,
+          blockCount: blockNum,
+          uploadedBytes,
+          totalBytes: stat.size,
+        });
+      }
+    }
+  } finally {
+    fs.closeSync(fileDescriptor);
+  }
+
+  if (uploadedBytes !== stat.size) {
+    throw new Error('[lark] Drive upload did not consume the complete package');
+  }
+
+  const finishResponse = await Axios.post(
+    `${LARK_OPEN_API_BASE_URL}/drive/v1/files/upload_finish`,
+    {
+      upload_id: uploadId,
+      block_num: blockNum,
+    },
+    requestOptions,
+  );
+  const finish = assertLarkSuccess(finishResponse, 'Drive upload finish');
+  const fileToken = finish.data && finish.data.file_token;
+  if (!fileToken) {
+    throw new Error('[lark] Drive upload finish did not return a file token');
+  }
+
+  return {
+    fileToken,
+    url: `${LARK_DRIVE_FILE_URL_BASE}/${encodeURIComponent(fileToken)}`,
+    size: stat.size,
+    blockCount: blockNum,
+  };
+}
+exports.uploadFileToLarkDrive = uploadFileToLarkDrive;
 
 function makeSign(secret) {
   const timestamp = Date.now();

--- a/apps/mobile/scripts/notify-lark.js
+++ b/apps/mobile/scripts/notify-lark.js
@@ -38,6 +38,7 @@ async function sendMessage({
   platform = 'android',
   isFastBuild = false,
   downloadURL = '',
+  larkDriveURL = '',
   actionsJobUrl = '',
   gitCommitURL = '',
   gitRefURL = '',
@@ -123,6 +124,10 @@ async function sendMessage({
             platform === 'android' && [
               { tag: 'text', text: `下载链接: ` },
               { tag: 'a', href: downloadURL, text: downloadURL },
+            ],
+            larkDriveURL && [
+              { tag: 'text', text: `Lark Drive: ` },
+              { tag: 'a', href: larkDriveURL, text: larkDriveURL },
             ],
             isFastBuild && [
               { tag: 'text', text: `📢📢📢 注意: ` },
@@ -218,6 +223,7 @@ if (!process.env.CI && args[0] === 'get-token') {
       : '';
   sendMessage({
     downloadURL: args[0],
+    larkDriveURL: process.env.RABBY_MOBILE_LARK_DRIVE_URL || '',
     platform: args[1],
     isFastBuild: args[2] === 'true',
     actionsJobUrl: process.env.GIT_ACTIONS_JOB_URL,


### PR DESCRIPTION
## Summary
- upload generated Android APK and iOS adhoc IPA to Lark Drive when enabled
- append the Drive URL to the existing Lark package notification
- keep AWS delivery and notification behavior unchanged when Drive upload fails

## Validation
- bot upload and hyperlink message tested
- targeted Drive multipart upload Jest test passed
- Feature Test dispatched from this branch: https://github.com/RabbyHub/rabby-mobile/actions/runs/33470899454