### PR TITLE
fix: require password before enabling app launch lock

### DIFF
--- a/apps/mobile/src/navigation-type.ts
+++ b/apps/mobile/src/navigation-type.ts
@@ -466,7 +466,11 @@ export type SettingNavigatorParamList = {
     | {
         actionAfterSetup: 'testkits:fromSettings';
         // actionType: (SettingNavigatorParamList['Settings'] & object)['enterActionType'];
-        actionType: 'setBiometrics' | 'setAutoLockExpireTime' | 'lockWallet';
+        actionType:
+          | 'setBiometrics'
+          | 'setAutoLockExpireTime'
+          | 'setAppLaunchLock'
+          | 'lockWallet';
       };
   [RootNames.SetBiometricsAuthentication]: {};
   [RootNames.CustomTestnet]?: {};

--- a/apps/mobile/src/screens/ManagePassword/SetPassword.tsx
+++ b/apps/mobile/src/screens/ManagePassword/SetPassword.tsx
@@ -135,6 +135,8 @@ function useSetupPasswordForm() {
                 sheetModalRefsNeedLock.switchBiometricsRef.current?.toggle();
               } else if (navParams.actionType === 'setAutoLockExpireTime') {
                 sheetModalRefsNeedLock.selectAutolockTimeRef.current?.present();
+              } else if (navParams.actionType === 'setAppLaunchLock') {
+                apisLock.setAppLaunchLockEnabled(true);
               } else if (navParams.actionType === 'lockWallet') {
                 await requestLockWalletAndBackToUnlockScreen();
                 break;

--- a/apps/mobile/src/screens/Settings/Settings.tsx
+++ b/apps/mobile/src/screens/Settings/Settings.tsx
@@ -563,6 +563,15 @@ function SettingsBlocks() {
     });
   }, []);
 
+  const allowAppLaunchLockToggle = useCallback(
+    (nextEnabled: boolean) =>
+      !nextEnabled ||
+      !shouldRedirectToSetPasswordBefore({
+        onSettingsAction: 'setAppLaunchLock',
+      }),
+    [shouldRedirectToSetPasswordBefore],
+  );
+
   const toggleDataAnalysisRef = useRef<SwitchToggleType>(null);
   const switchAppLaunchLockRef = useRef<SwitchToggleType>(null);
 
@@ -669,7 +678,12 @@ function SettingsBlocks() {
           {
             label: t('page.setting.appLaunchLock'),
             icon: RcAutolock,
-            rightNode: <SwitchAppLaunchLock ref={switchAppLaunchLockRef} />,
+            rightNode: (
+              <SwitchAppLaunchLock
+                ref={switchAppLaunchLockRef}
+                onBeforeToggle={allowAppLaunchLockToggle}
+              />
+            ),
             onPress: () => {
               switchAppLaunchLockRef.current?.toggle();
             },

--- a/apps/mobile/src/screens/Settings/components/SwitchAppLaunchLock.test.tsx
+++ b/apps/mobile/src/screens/Settings/components/SwitchAppLaunchLock.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { act, render } from '@testing-library/react-native';
+
+import { SwitchAppLaunchLock } from './SwitchAppLaunchLock';
+
+jest.mock('@/components/customized/Switch2024', () => {
+  const ReactModule = require('react');
+  const { View } = require('react-native');
+
+  return {
+    AppSwitch2024: (props: Record<string, unknown>) =>
+      ReactModule.createElement(View, {
+        ...props,
+        testID: 'app-launch-lock-switch',
+      }),
+  };
+});
+
+jest.mock('@/core/apis/lock', () => ({
+  appLaunchLockEvent: {
+    addListener: jest.fn(),
+    off: jest.fn(),
+  },
+  isAppLaunchLockEnabled: jest.fn(() => false),
+  setAppLaunchLockEnabled: jest.fn(),
+}));
+
+const mockLockApi = jest.requireMock('@/core/apis/lock') as {
+  isAppLaunchLockEnabled: jest.Mock;
+  setAppLaunchLockEnabled: jest.Mock;
+};
+
+describe('SwitchAppLaunchLock', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLockApi.isAppLaunchLockEnabled.mockReturnValue(false);
+  });
+
+  it('does not persist an enabled state when the pre-toggle guard rejects it', () => {
+    const onBeforeToggle = jest.fn(() => false);
+    const screen = render(
+      <SwitchAppLaunchLock onBeforeToggle={onBeforeToggle} />,
+    );
+
+    act(() => {
+      screen.getByTestId('app-launch-lock-switch').props.onValueChange(true);
+    });
+
+    expect(onBeforeToggle).toHaveBeenCalledWith(true);
+    expect(mockLockApi.setAppLaunchLockEnabled).not.toHaveBeenCalled();
+  });
+
+  it('persists the requested state when the pre-toggle guard allows it', () => {
+    const onBeforeToggle = jest.fn(() => true);
+    const screen = render(
+      <SwitchAppLaunchLock onBeforeToggle={onBeforeToggle} />,
+    );
+
+    act(() => {
+      screen.getByTestId('app-launch-lock-switch').props.onValueChange(true);
+    });
+
+    expect(mockLockApi.setAppLaunchLockEnabled).toHaveBeenCalledWith(true);
+  });
+});

--- a/apps/mobile/src/screens/Settings/components/SwitchAppLaunchLock.tsx
+++ b/apps/mobile/src/screens/Settings/components/SwitchAppLaunchLock.tsx
@@ -26,9 +26,11 @@ function subscribeAppLaunchLock(onStoreChange: () => void) {
 
 export const SwitchAppLaunchLock = ({
   ref,
+  onBeforeToggle,
   ...props
 }: React.ComponentProps<typeof AppSwitch2024> & {
   ref?: Ref<SwitchToggleType>;
+  onBeforeToggle?: (nextEnabled: boolean) => boolean;
 }) => {
   const enabled = useSyncExternalStore(
     subscribeAppLaunchLock,
@@ -38,6 +40,10 @@ export const SwitchAppLaunchLock = ({
 
   const toggle = useCallback(
     (nextEnabled = !enabled) => {
+      if (onBeforeToggle && !onBeforeToggle(nextEnabled)) {
+        return;
+      }
+
       try {
         setAppLaunchLockEnabled(nextEnabled);
       } catch (error) {
@@ -45,7 +51,7 @@ export const SwitchAppLaunchLock = ({
         console.error('setAppLaunchLockEnabled failed', error);
       }
     },
-    [enabled],
+    [enabled, onBeforeToggle],
   );
 
   useImperativeHandle(ref, () => ({ toggle }), [toggle]);


### PR DESCRIPTION
## Summary

- Guide users to set a password before enabling startup lock.
- Enable startup lock after password setup succeeds.
- Add regression coverage for the switch guard.

## Validation

- Focused Jest test passed.
- Cycle lint and startup-governance checks passed.
- Full Jest/integration runs retain unrelated Perps SDK failures.