### PR TITLE
fix: 修复 dapp 请求来源伪造问题

### DIFF
--- a/.yarn/patches/react-native-webview-npm-13.10.5-714eb41569.patch
+++ b/.yarn/patches/react-native-webview-npm-13.10.5-714eb41569.patch
@@ -335,7 +335,7 @@ index 6664b6f6eacb37743d049556dc55f613c0244517..315d954165153852fc65c1ad1378a66e
      }
 
 diff --git a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
-index d59e19ce82a5a03a60c558b35171af713719af4a..1179dc4d407a6faac186ee60cc7b7c55bb61f261 100644
+index d59e19ce82a5a03a60c558b35171af713719af4a..ceb0d2c6e3ef5376523aa0cb4f5ea0e81b3dc804 100644
 --- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
 +++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
 @@ -1,7 +1,9 @@
@@ -405,7 +405,15 @@ index d59e19ce82a5a03a60c558b35171af713719af4a..1179dc4d407a6faac186ee60cc7b7c55
      }
 
      @Override
-@@ -121,7 +143,18 @@ public class RNCWebViewClient extends WebViewClient {
+@@ -95,6 +117,7 @@ public class RNCWebViewClient extends WebViewClient {
+             final AtomicReference<RNCWebViewModuleImpl.ShouldOverrideUrlLoadingLock.ShouldOverrideCallbackState> lockObject = lock.second;
+
+             final WritableMap event = createWebViewEvent(view, url);
++            event.putString("sourceDocumentURL", view.getUrl() != null ? view.getUrl() : "");
+             event.putDouble("lockIdentifier", lockIdentifier);
+             rncWebView.dispatchDirectShouldStartLoadWithRequest(event);
+
+@@ -121,14 +145,27 @@ public class RNCWebViewClient extends WebViewClient {
              RNCWebViewModuleImpl.shouldOverrideUrlLoadingLock.removeLock(lockIdentifier);
 
              return shouldOverride;
@@ -425,7 +433,17 @@ index d59e19ce82a5a03a60c558b35171af713719af4a..1179dc4d407a6faac186ee60cc7b7c55
              FLog.w(TAG, "Couldn't use blocking synchronous call for onShouldStartLoadWithRequest due to debugging or missing Catalyst instance, falling back to old event-and-load.");
              progressChangedFilter.setWaitingForCommandLoadUrl(true);
 
-@@ -136,6 +169,21 @@ public class RNCWebViewClient extends WebViewClient {
+             int reactTag = RNCWebViewWrapper.getReactTagFromWebView(view);
++            WritableMap event = createWebViewEvent(view, url);
++            event.putString("sourceDocumentURL", view.getUrl() != null ? view.getUrl() : "");
+             UIManagerHelper.getEventDispatcherForReactTag((ReactContext) view.getContext(), reactTag).dispatchEvent(new TopShouldStartLoadWithRequestEvent(
+                     reactTag,
+-                    createWebViewEvent(view, url)));
++                    event));
+             return true;
+         }
+     }
+@@ -136,8 +172,23 @@ public class RNCWebViewClient extends WebViewClient {
      @TargetApi(Build.VERSION_CODES.N)
      @Override
      public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
@@ -447,7 +465,9 @@ index d59e19ce82a5a03a60c558b35171af713719af4a..1179dc4d407a6faac186ee60cc7b7c55
          final String url = request.getUrl().toString();
          return this.shouldOverrideUrlLoading(view, url);
      }
-@@ -205,7 +253,7 @@ public class RNCWebViewClient extends WebViewClient {
+
+     @Override
+@@ -205,7 +256,7 @@ public class RNCWebViewClient extends WebViewClient {
                  code,
                  description,
                  failingUrl
@@ -456,7 +476,7 @@ index d59e19ce82a5a03a60c558b35171af713719af4a..1179dc4d407a6faac186ee60cc7b7c55
      }
 
      @Override
-@@ -300,12 +348,26 @@ public class RNCWebViewClient extends WebViewClient {
+@@ -300,12 +351,26 @@ public class RNCWebViewClient extends WebViewClient {
      }
 
      protected WritableMap createWebViewEvent(WebView webView, String url) {
@@ -896,10 +916,20 @@ index 709117a91e44c2e32a263c638b0c092185d76e94..92e698594e0fdc650b8c59c8d3a41c24
      public void setUserAgent(RNCWebViewWrapper view, @Nullable String value) {
          mRNCWebViewManagerImpl.setUserAgent(view, value);
 diff --git a/apple/RNCWebView.mm b/apple/RNCWebView.mm
-index 1ae84c89237f2133378b35a75f6b48a538a1502f..f1067770db645778fec82f8942e3eaafd7d96ac1 100644
+index 1ae84c89237f2133378b35a75f6b48a538a1502f..c02421e0e3b8da34776544f54698b91699ebce1c 100644
 --- a/apple/RNCWebView.mm
 +++ b/apple/RNCWebView.mm
-@@ -90,6 +90,7 @@ - (instancetype)initWithFrame:(CGRect)frame
+@@ -80,7 +80,8 @@ - (instancetype)initWithFrame:(CGRect)frame
+                     .canGoForward = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
+                     .isTopFrame = static_cast<bool>([[dictionary valueForKey:@"isTopFrame"] boolValue]),
+                     .loading = static_cast<bool>([[dictionary valueForKey:@"loading"] boolValue]),
+-                    .mainDocumentURL = std::string([[dictionary valueForKey:@"mainDocumentURL"] UTF8String])
++                    .mainDocumentURL = std::string([[dictionary valueForKey:@"mainDocumentURL"] UTF8String]),
++                    .sourceDocumentURL = std::string([[dictionary valueForKey:@"sourceDocumentURL"] UTF8String])
+                 };
+                 webViewEventEmitter->onShouldStartLoadWithRequest(data);
+             };
+@@ -90,6 +91,7 @@ - (instancetype)initWithFrame:(CGRect)frame
                  auto webViewEventEmitter = std::static_pointer_cast<RNCWebViewEventEmitter const>(_eventEmitter);
                  facebook::react::RNCWebViewEventEmitter::OnLoadingStart data = {
                      .url = std::string([[dictionary valueForKey:@"url"] UTF8String]),
@@ -907,7 +937,7 @@ index 1ae84c89237f2133378b35a75f6b48a538a1502f..f1067770db645778fec82f8942e3eaaf
                      .lockIdentifier = [[dictionary valueForKey:@"lockIdentifier"] doubleValue],
                      .title = std::string([[dictionary valueForKey:@"title"] UTF8String]),
                      .navigationType = stringToOnLoadingStartNavigationTypeEnum(std::string([[dictionary valueForKey:@"navigationType"] UTF8String])),
-@@ -263,9 +264,20 @@ - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &
+@@ -263,9 +265,20 @@ - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &
          _view.name = RCTNSStringFromString(newViewProps.name);      \
      }
 
@@ -928,7 +958,7 @@ index 1ae84c89237f2133378b35a75f6b48a538a1502f..f1067770db645778fec82f8942e3eaaf
      REMAP_WEBVIEW_PROP(injectedJavaScriptForMainFrameOnly)
      REMAP_WEBVIEW_PROP(injectedJavaScriptBeforeContentLoadedForMainFrameOnly)
      REMAP_WEBVIEW_STRING_PROP(injectedJavaScriptObject)
-@@ -275,6 +287,7 @@ - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &
+@@ -275,6 +288,7 @@ - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &
      REMAP_WEBVIEW_PROP(allowUniversalAccessFromFileURLs)
      REMAP_WEBVIEW_PROP(allowsInlineMediaPlayback)
      REMAP_WEBVIEW_PROP(webviewDebuggingEnabled)
@@ -959,7 +989,7 @@ index ba9adf749d3874b74952a8f7d7044d939672a6b3..3bc7975e654fba288e1307f4556be53c
  @property (nonatomic, assign) BOOL bounces;
  @property (nonatomic, assign) BOOL mediaPlaybackRequiresUserAction;
 diff --git a/apple/RNCWebViewImpl.m b/apple/RNCWebViewImpl.m
-index 77abeafb502f717550434a286d2611380949157b..33dfa70f5c710a6452af9ca0808e460a91b3c04b 100644
+index 77abeafb502f717550434a286d2611380949157b..6e61e5d57e0569b2e6e865d2069b6c6d4308e014 100644
 --- a/apple/RNCWebViewImpl.m
 +++ b/apple/RNCWebViewImpl.m
 @@ -25,6 +25,301 @@
@@ -1454,7 +1484,15 @@ index 77abeafb502f717550434a286d2611380949157b..33dfa70f5c710a6452af9ca0808e460a
                              @"navigationType": navigationTypes[@(navigationType)]
                          }];
                          self->_onLoadingStart(event);
-@@ -1370,6 +1716,7 @@ - (void)                  webView:(WKWebView *)webView
+@@ -1354,6 +1700,7 @@ - (void)                  webView:(WKWebView *)webView
+         }
+         [event addEntriesFromDictionary: @{
+             @"url": (request.URL).absoluteString,
++            @"sourceDocumentURL": webView.URL.absoluteString ?: @"",
+             @"navigationType": navigationTypes[@(navigationType)],
+             @"isTopFrame": @(isTopFrame),
+             @"hasTargetFrame": @(hasTargetFrame),
+@@ -1370,6 +1717,7 @@ - (void)                  webView:(WKWebView *)webView
              NSMutableDictionary<NSString *, id> *event = [self baseEvent];
              [event addEntriesFromDictionary: @{
                  @"url": (request.URL).absoluteString,
@@ -1462,7 +1500,7 @@ index 77abeafb502f717550434a286d2611380949157b..33dfa70f5c710a6452af9ca0808e460a
                  @"navigationType": navigationTypes[@(navigationType)]
              }];
              _onLoadingStart(event);
-@@ -1535,6 +1882,7 @@ - (void)webView:(WKWebView *)webView
+@@ -1535,6 +1883,7 @@ - (void)webView:(WKWebView *)webView
    }
 
    if (_onLoadingFinish) {
@@ -1470,7 +1508,7 @@ index 77abeafb502f717550434a286d2611380949157b..33dfa70f5c710a6452af9ca0808e460a
      _onLoadingFinish([self baseEvent]);
    }
  }
-@@ -1667,8 +2015,9 @@ - (void)setBounces:(BOOL)bounces
+@@ -1667,8 +2016,9 @@ - (void)setBounces:(BOOL)bounces
 
  - (void)setInjectedJavaScript:(NSString *)source {
    _injectedJavaScript = source;
@@ -1481,7 +1519,7 @@ index 77abeafb502f717550434a286d2611380949157b..33dfa70f5c710a6452af9ca0808e460a
                                                                    injectionTime:WKUserScriptInjectionTimeAtDocumentEnd
                                                                 forMainFrameOnly:_injectedJavaScriptForMainFrameOnly];
 
-@@ -1677,6 +2026,11 @@ - (void)setInjectedJavaScript:(NSString *)source {
+@@ -1677,6 +2027,11 @@ - (void)setInjectedJavaScript:(NSString *)source {
    }
  }
 
@@ -1493,7 +1531,7 @@ index 77abeafb502f717550434a286d2611380949157b..33dfa70f5c710a6452af9ca0808e460a
  - (void)setInjectedJavaScriptObject:(NSString *)source
  {
    self.injectedObjectJsonScript = [
-@@ -1706,8 +2060,9 @@ - (void)setEnableApplePay:(BOOL)enableApplePay {
+@@ -1706,8 +2061,9 @@ - (void)setEnableApplePay:(BOOL)enableApplePay {
 
  - (void)setInjectedJavaScriptBeforeContentLoaded:(NSString *)source {
    _injectedJavaScriptBeforeContentLoaded = source;
@@ -1504,7 +1542,7 @@ index 77abeafb502f717550434a286d2611380949157b..33dfa70f5c710a6452af9ca0808e460a
                                                                      injectionTime:WKUserScriptInjectionTimeAtDocumentStart
                                                                   forMainFrameOnly:_injectedJavaScriptBeforeContentLoadedForMainFrameOnly];
 
-@@ -1716,6 +2071,11 @@ - (void)setInjectedJavaScriptBeforeContentLoaded:(NSString *)source {
+@@ -1716,6 +2072,11 @@ - (void)setInjectedJavaScriptBeforeContentLoaded:(NSString *)source {
    }
  }
 
@@ -1539,10 +1577,18 @@ index 1d22028a1c44d18f8bf333265dd6781ff3df4250..98a8ecaa47c470d0b6725da9bd96d140
  RCT_EXPORT_VIEW_PROPERTY(mediaPlaybackRequiresUserAction, BOOL)
  RCT_EXPORT_VIEW_PROPERTY(dataDetectorTypes, WKDataDetectorTypes)
 diff --git a/lib/RNCWebViewNativeComponent.d.ts b/lib/RNCWebViewNativeComponent.d.ts
-index d898feb33b08830382a565b1503f0c3ffebd8bb5..1550510cac52c869d749174cf84987c7284e7d4e 100644
+index d898feb33b08830382a565b1503f0c3ffebd8bb5..fa36235daba17195cb9bfc025f9d7e1d2f67b3e4 100644
 --- a/lib/RNCWebViewNativeComponent.d.ts
 +++ b/lib/RNCWebViewNativeComponent.d.ts
-@@ -188,7 +188,9 @@ export interface NativeProps extends ViewProps {
+@@ -75,6 +75,7 @@ export type ShouldStartLoadRequestEvent = Readonly<{
+     navigationType: 'click' | 'formsubmit' | 'backforward' | 'reload' | 'formresubmit' | 'other';
+     mainDocumentURL?: string;
+     isTopFrame: boolean;
++    sourceDocumentURL: string;
+ }>;
+ type ScrollEvent = Readonly<{
+     contentInset: {
+@@ -188,7 +189,9 @@ export interface NativeProps extends ViewProps {
      cacheEnabled?: boolean;
      incognito?: boolean;
      injectedJavaScript?: string;
@@ -1582,7 +1628,7 @@ index 37344a794b0cffd2e748e04f6827e732a7b4117b..3975335120549d725a1d1e24522f280a
      onLoadProgress?: ((event: WebViewProgressEvent) => void) | undefined;
      onLoadEnd?: ((event: WebViewNavigationEvent | WebViewErrorEvent) => void) | undefined;
 diff --git a/lib/WebViewTypes.d.ts b/lib/WebViewTypes.d.ts
-index 7cbd83521257c1a730cca632a712737253dcddab..f4dec97dfaf0240d9e1b665610480e9dd12ad93b 100644
+index 7cbd83521257c1a730cca632a712737253dcddab..80c87559df58df078f990efed31d8c7c5a421fb3 100644
 --- a/lib/WebViewTypes.d.ts
 +++ b/lib/WebViewTypes.d.ts
 @@ -45,6 +45,7 @@ export interface ContentInsetProp {
@@ -1593,7 +1639,7 @@ index 7cbd83521257c1a730cca632a712737253dcddab..f4dec97dfaf0240d9e1b665610480e9d
      url: string;
      loading: boolean;
      title: string;
-@@ -56,9 +57,15 @@ export interface WebViewNativeProgressEvent extends WebViewNativeEvent {
+@@ -56,11 +57,18 @@ export interface WebViewNativeProgressEvent extends WebViewNativeEvent {
      progress: number;
  }
  export interface WebViewNavigation extends WebViewNativeEvent {
@@ -1608,8 +1654,11 @@ index 7cbd83521257c1a730cca632a712737253dcddab..f4dec97dfaf0240d9e1b665610480e9d
 +}
  export interface ShouldStartLoadRequest extends WebViewNavigation {
      isTopFrame: boolean;
++    sourceDocumentURL: string;
  }
-@@ -90,6 +97,7 @@ export interface WebViewOpenWindow {
+ export interface FileDownload {
+     downloadUrl: string;
+@@ -90,6 +98,7 @@ export interface WebViewOpenWindow {
  export type WebViewEvent = NativeSyntheticEvent<WebViewNativeEvent>;
  export type WebViewProgressEvent = NativeSyntheticEvent<WebViewNativeProgressEvent>;
  export type WebViewNavigationEvent = NativeSyntheticEvent<WebViewNavigation>;
@@ -1617,7 +1666,7 @@ index 7cbd83521257c1a730cca632a712737253dcddab..f4dec97dfaf0240d9e1b665610480e9d
  export type ShouldStartLoadRequestEvent = NativeSyntheticEvent<ShouldStartLoadRequest>;
  export type FileDownloadEvent = NativeSyntheticEvent<FileDownload>;
  export type WebViewMessageEvent = NativeSyntheticEvent<WebViewMessage>;
-@@ -183,7 +191,9 @@ export interface CommonNativeWebViewProps extends ViewProps {
+@@ -183,7 +192,9 @@ export interface CommonNativeWebViewProps extends ViewProps {
      cacheEnabled?: boolean;
      incognito?: boolean;
      injectedJavaScript?: string;
@@ -1627,7 +1676,7 @@ index 7cbd83521257c1a730cca632a712737253dcddab..f4dec97dfaf0240d9e1b665610480e9d
      injectedJavaScriptForMainFrameOnly?: boolean;
      injectedJavaScriptBeforeContentLoadedForMainFrameOnly?: boolean;
      javaScriptCanOpenWindowsAutomatically?: boolean;
-@@ -961,7 +971,7 @@ export interface WebViewSharedProps extends ViewProps {
+@@ -961,7 +972,7 @@ export interface WebViewSharedProps extends ViewProps {
      /**
       * Function that is invoked when the `WebView` starts loading.
       */
@@ -1636,7 +1685,7 @@ index 7cbd83521257c1a730cca632a712737253dcddab..f4dec97dfaf0240d9e1b665610480e9d
      /**
       * Function that is invoked when the `WebView` load fails.
       */
-@@ -997,11 +1007,19 @@ export interface WebViewSharedProps extends ViewProps {
+@@ -997,11 +1008,19 @@ export interface WebViewSharedProps extends ViewProps {
       * when the view loads.
       */
      injectedJavaScript?: string;
@@ -1656,7 +1705,7 @@ index 7cbd83521257c1a730cca632a712737253dcddab..f4dec97dfaf0240d9e1b665610480e9d
      /**
       * If `true` (default; mandatory for Android), loads the `injectedJavaScript` only into the main frame.
       * If `false` (only supported on iOS and macOS), loads it into all frames (e.g. iframes).
-@@ -1066,5 +1084,9 @@ export interface WebViewSharedProps extends ViewProps {
+@@ -1066,5 +1085,9 @@ export interface WebViewSharedProps extends ViewProps {
       * Enables WebView remote debugging using Chrome (Android) or Safari (iOS).
       */
      webviewDebuggingEnabled?: boolean;
@@ -1667,10 +1716,18 @@ index 7cbd83521257c1a730cca632a712737253dcddab..f4dec97dfaf0240d9e1b665610480e9d
  }
  export {};
 diff --git a/src/RNCWebViewNativeComponent.ts b/src/RNCWebViewNativeComponent.ts
-index 682ab39b9136598f62666e4f89a069702e654499..db75f6aada6d755f85b2a5e87191db064b62d646 100644
+index 682ab39b9136598f62666e4f89a069702e654499..d89c40daf944c2a67295f58179b5663078d499f0 100644
 --- a/src/RNCWebViewNativeComponent.ts
 +++ b/src/RNCWebViewNativeComponent.ts
-@@ -256,7 +256,9 @@ export interface NativeProps extends ViewProps {
+@@ -99,6 +99,7 @@ export type ShouldStartLoadRequestEvent = Readonly<{
+     | 'other';
+   mainDocumentURL?: string;
+   isTopFrame: boolean;
++  sourceDocumentURL: string;
+ }>;
+
+ type ScrollEvent = Readonly<{
+@@ -256,7 +257,9 @@ export interface NativeProps extends ViewProps {
    cacheEnabled?: boolean;
    incognito?: boolean;
    injectedJavaScript?: string;
@@ -1681,10 +1738,18 @@ index 682ab39b9136598f62666e4f89a069702e654499..db75f6aada6d755f85b2a5e87191db06
    injectedJavaScriptBeforeContentLoadedForMainFrameOnly?: boolean;
    javaScriptCanOpenWindowsAutomatically?: boolean;
 diff --git a/src/WebViewTypes.ts b/src/WebViewTypes.ts
-index 1bc55cbe5aaa69ee82db0efac18dd97dade63a7b..cc3e507bf91c9da76a37f748ae6b6a76181b1b83 100644
+index 1bc55cbe5aaa69ee82db0efac18dd97dade63a7b..495b6d277b8dbef460144c0b17364cb4e8354fe2 100644
 --- a/src/WebViewTypes.ts
 +++ b/src/WebViewTypes.ts
-@@ -289,7 +289,9 @@ export interface CommonNativeWebViewProps extends ViewProps {
+@@ -100,6 +100,7 @@ export interface WebViewNavigation extends WebViewNativeEvent {
+
+ export interface ShouldStartLoadRequest extends WebViewNavigation {
+   isTopFrame: boolean;
++  sourceDocumentURL: string;
+ }
+
+ export interface FileDownload {
+@@ -289,7 +290,9 @@ export interface CommonNativeWebViewProps extends ViewProps {
    cacheEnabled?: boolean;
    incognito?: boolean;
    injectedJavaScript?: string;
@@ -1694,7 +1759,7 @@ index 1bc55cbe5aaa69ee82db0efac18dd97dade63a7b..cc3e507bf91c9da76a37f748ae6b6a76
    injectedJavaScriptForMainFrameOnly?: boolean;
    injectedJavaScriptBeforeContentLoadedForMainFrameOnly?: boolean;
    javaScriptCanOpenWindowsAutomatically?: boolean;
-@@ -1223,12 +1225,22 @@ export interface WebViewSharedProps extends ViewProps {
+@@ -1223,12 +1226,22 @@ export interface WebViewSharedProps extends ViewProps {
     */
    injectedJavaScript?: string;
 

--- a/apps/mobile/src/components/WebView/DappWebViewControl.tsx
+++ b/apps/mobile/src/components/WebView/DappWebViewControl.tsx
@@ -349,7 +349,7 @@ const DappWebViewControl = ({
         webviewRef={webviewRef}
         webviewIdRef={webviewIdRef}
         siteInfoRefs={{ urlRef, titleRef, iconRef }}>
-        {({ onLoadStart, onMessage: onBridgeMessage }) => {
+        {({ bridgeHardenScript, onLoadStart, onMessage: onBridgeMessage }) => {
           if (!entryScriptWeb3Loaded) {
             return null;
           }
@@ -383,6 +383,9 @@ const DappWebViewControl = ({
               injectedJavaScriptBeforeContentLoadedBuiltinScriptIds={
                 beforeContentLoadedBuiltinScriptIds
               }
+              injectedJavaScriptBeforeContentLoaded={`${bridgeHardenScript}\n${
+                webviewProps?.injectedJavaScriptBeforeContentLoaded ?? ''
+              }`}
               injectedJavaScriptBeforeContentLoadedForMainFrameOnly={true}
               injectedJavaScriptBuiltinScriptIds={documentEndBuiltinScriptIds}
               onNavigationStateChange={webviewActions.onNavigationStateChange}

--- a/apps/mobile/src/components/WebView/DappWebViewControl2/DappWebViewControl2.tsx
+++ b/apps/mobile/src/components/WebView/DappWebViewControl2/DappWebViewControl2.tsx
@@ -373,6 +373,9 @@ const DappWebViewControl2 = ({
               onShouldStartLoadWithRequest={nativeEvent => {
                 return checkShouldStartLoadingWithRequestForDappWebView(
                   nativeEvent,
+                  {
+                    enforceWalletConnectOrigin: true,
+                  },
                 );
               }}
               onError={errorLog}

--- a/apps/mobile/src/components/WebView/DappWebViewControl2/DappWebViewControl2.tsx
+++ b/apps/mobile/src/components/WebView/DappWebViewControl2/DappWebViewControl2.tsx
@@ -325,7 +325,7 @@ const DappWebViewControl2 = ({
         webviewRef={webviewRef}
         webviewIdRef={webviewIdRef}
         siteInfoRefs={{ urlRef, titleRef, iconRef }}>
-        {({ onLoadStart, onMessage: onBridgeMessage }) => {
+        {({ bridgeHardenScript, onLoadStart, onMessage: onBridgeMessage }) => {
           if (!entryScriptWeb3Loaded) {
             return null;
           }
@@ -359,6 +359,9 @@ const DappWebViewControl2 = ({
               injectedJavaScriptBeforeContentLoadedBuiltinScriptIds={
                 beforeContentLoadedBuiltinScriptIds
               }
+              injectedJavaScriptBeforeContentLoaded={`${bridgeHardenScript}\n${
+                webviewProps?.injectedJavaScriptBeforeContentLoaded ?? ''
+              }`}
               injectedJavaScriptBeforeContentLoadedForMainFrameOnly={true}
               injectedJavaScriptBuiltinScriptIds={documentEndBuiltinScriptIds}
               onNavigationStateChange={webviewActions.onNavigationStateChange}

--- a/apps/mobile/src/components/WebView/DappWebViewCore.tsx
+++ b/apps/mobile/src/components/WebView/DappWebViewCore.tsx
@@ -169,19 +169,22 @@ function DappWebViewCore({
     documentEndBuiltinScriptIds,
   } = useJavaScriptBeforeContentLoaded();
 
-  const { onLoadStart: onBridgeLoadStart, onMessage: onBridgeMessage } =
-    useSetupWebviewWithServices({
-      dappOrigin,
-      webviewRef,
-      webviewIdRef,
-      siteInfoRefs: {
-        urlRef,
-        titleRef,
-        iconRef,
-      },
-      isFromMobileInnerDapp: true,
-      coreServices,
-    });
+  const {
+    bridgeHardenScript,
+    onLoadStart: onBridgeLoadStart,
+    onMessage: onBridgeMessage,
+  } = useSetupWebviewWithServices({
+    dappOrigin,
+    webviewRef,
+    webviewIdRef,
+    siteInfoRefs: {
+      urlRef,
+      titleRef,
+      iconRef,
+    },
+    isFromMobileInnerDapp: true,
+    coreServices,
+  });
 
   const resolvedUrl = useMemo(() => {
     if (embedHtml) return undefined;
@@ -209,6 +212,8 @@ function DappWebViewCore({
     onLoadProgress: webviewOnLoadProgress,
     onShouldStartLoadWithRequest: webviewOnShouldStartLoadWithRequest,
     onMessage: webviewOnMessage,
+    injectedJavaScriptBeforeContentLoaded:
+      webviewInjectedJavaScriptBeforeContentLoaded,
     onError: webviewOnError,
     onOpenWindow: webviewOnOpenWindow,
     onNavigationStateChange: webviewOnNavigationStateChange,
@@ -531,6 +536,9 @@ function DappWebViewCore({
         injectedJavaScriptBeforeContentLoadedBuiltinScriptIds={
           beforeContentLoadedBuiltinScriptIds
         }
+        injectedJavaScriptBeforeContentLoaded={`${bridgeHardenScript}\n${
+          webviewInjectedJavaScriptBeforeContentLoaded ?? ''
+        }`}
         injectedJavaScriptBeforeContentLoadedForMainFrameOnly={true}
         injectedJavaScriptBuiltinScriptIds={documentEndBuiltinScriptIds}
         injectedJavaScript={autoRunnerInjected}

--- a/apps/mobile/src/components/WebView/utils.test.ts
+++ b/apps/mobile/src/components/WebView/utils.test.ts
@@ -1,0 +1,68 @@
+import { pairWalletConnectUri } from '@/core/walletconnect';
+import { checkShouldStartLoadingWithRequestForDappWebView } from './utils';
+
+const mockWcUri =
+  'wc:topic@2?relay-protocol=irn&symKey=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+jest.mock('@/constant/dappView', () => ({
+  allowLinkOpen: jest.fn(),
+  getAlertMessage: jest.fn(() => ({ needAlert: false, allowOpenLink: false })),
+  protocolAllowList: ['http:', 'https:'],
+  trustedProtocolToDeeplink: ['wc:'],
+}));
+
+jest.mock('@/core/walletconnect/uri', () => ({
+  isRabbyWalletConnectDeeplink: jest.fn((url: string) =>
+    url.startsWith('rabby://walletconnect'),
+  ),
+  parseWalletConnectUriFromLink: jest.fn(() => mockWcUri),
+}));
+
+jest.mock('@/core/walletconnect', () => ({
+  pairWalletConnectUri: jest.fn(() => Promise.resolve()),
+}));
+
+describe('dapp WebView WalletConnect deeplinks', () => {
+  beforeEach(() => {
+    jest.mocked(pairWalletConnectUri).mockClear();
+  });
+
+  it('ignores strict WalletConnect deeplinks without a source document', () => {
+    checkShouldStartLoadingWithRequestForDappWebView(
+      {
+        url: 'rabby://walletconnect?uri=wc',
+      },
+      { enforceWalletConnectOrigin: true },
+    );
+
+    expect(pairWalletConnectUri).not.toHaveBeenCalled();
+  });
+
+  it('uses the native source document for a strict top-frame deeplink', () => {
+    checkShouldStartLoadingWithRequestForDappWebView(
+      {
+        url: 'rabby://walletconnect?uri=wc',
+        sourceDocumentURL: 'https://app.example/page',
+      },
+      { enforceWalletConnectOrigin: true },
+    );
+
+    expect(pairWalletConnectUri).toHaveBeenCalledWith({
+      uri: mockWcUri,
+      source: 'inner-webview',
+      browserOrigin: 'https://app.example/page',
+    });
+  });
+
+  it('preserves legacy handling when strict checking is not enabled', () => {
+    checkShouldStartLoadingWithRequestForDappWebView({
+      url: 'rabby://walletconnect?uri=wc',
+    });
+
+    expect(pairWalletConnectUri).toHaveBeenCalledWith({
+      uri: mockWcUri,
+      source: 'inner-webview',
+      browserOrigin: undefined,
+    });
+  });
+});

--- a/apps/mobile/src/components/WebView/utils.ts
+++ b/apps/mobile/src/components/WebView/utils.ts
@@ -19,7 +19,10 @@ import { pairWalletConnectUri } from '@/core/walletconnect';
  *  Return `true` to continue loading the request and `false` to stop loading.
  */
 export function checkShouldStartLoadingWithRequestForDappWebView(
-  evt: Pick<ShouldStartLoadRequestEvent, 'url'>,
+  evt: Pick<ShouldStartLoadRequestEvent, 'url'> & {
+    sourceDocumentURL?: string;
+  },
+  options?: { enforceWalletConnectOrigin?: boolean },
 ): boolean /* should allow */ {
   const url = evt.url;
   const { protocol = '' } = urlUtils.safeParseURL(url) || {};
@@ -35,13 +38,18 @@ export function checkShouldStartLoadingWithRequestForDappWebView(
   }
 
   if (isRabbyWalletConnectDeeplink(url)) {
+    const shouldCheckOrigin = options?.enforceWalletConnectOrigin === true;
+    if (shouldCheckOrigin && !evt.sourceDocumentURL) {
+      return false;
+    }
     const uri = parseWalletConnectUriFromLink(url);
     if (!uri) {
       return false;
     }
     pairWalletConnectUri({
-      uri: uri,
+      uri,
       source: 'inner-webview',
+      browserOrigin: shouldCheckOrigin ? evt.sourceDocumentURL : undefined,
     }).catch(() => {});
     return false;
   }

--- a/apps/mobile/src/core/bridges/useBackgroundBridge.ts
+++ b/apps/mobile/src/core/bridges/useBackgroundBridge.ts
@@ -203,17 +203,17 @@ export function useSetupWebviewWithServices({
             return;
           }
 
-          let msgHost = '';
-          let bridgeHost = '';
+          let normalizedMsgOrigin = '';
+          let normalizedBridgeOrigin = '';
           try {
-            msgHost = new URL(msgOrigin).host;
-            bridgeHost = new URL(bridgeOrigin).host;
+            normalizedMsgOrigin = new URL(msgOrigin).origin;
+            normalizedBridgeOrigin = new URL(bridgeOrigin).origin;
           } catch {
             return;
           }
-          if (msgHost !== bridgeHost) {
+          if (normalizedMsgOrigin !== normalizedBridgeOrigin) {
             console.warn(
-              `[onMessage] host mismatch: msgHost=${msgHost},bridgeHost=${bridgeHost}`,
+              `[onMessage] origin mismatch: msgOrigin=${normalizedMsgOrigin},bridgeOrigin=${normalizedBridgeOrigin}`,
             );
             return;
           }

--- a/apps/mobile/src/core/bridges/useBackgroundBridge.ts
+++ b/apps/mobile/src/core/bridges/useBackgroundBridge.ts
@@ -7,7 +7,11 @@ import type { WebViewNavigation } from 'react-native-webview';
 import { type BackgroundBridgeServices } from './backgroundBridgeServices';
 import { createDappBySession } from '@/core/utils/createDappBySession';
 import { useRefState } from '@/hooks/common/useRefState';
-import { RABBY_DECLARED_PREFIX } from '@rabby-wallet/rn-webview-bridge';
+import {
+  BRIDGE_FRAME_CAPABILITY_KEY,
+  JSBridgeHarden,
+  RABBY_DECLARED_PREFIX,
+} from '@rabby-wallet/rn-webview-bridge';
 
 export const BLANK_PAGE = 'about:blank';
 export const BLANK_RABBY_PAGE = 'about:rabby';
@@ -29,6 +33,7 @@ type WebViewDataPayload<P = any> = {
   type: string;
   name?: string;
   payload?: P;
+  [BRIDGE_FRAME_CAPABILITY_KEY]?: string;
 };
 
 export type SetupWebviewParams = {
@@ -55,6 +60,25 @@ export function useSetupWebviewWithServices({
 }) {
   const { setRefState: putBackgroundBridge, stateRef: currentBridgeRef } =
     useRefState<BackgroundBridge | null>(null);
+  const bridgeFrameCapabilityRef = useRef<{
+    value: string;
+    injectedJavaScript: string;
+  } | null>(null);
+
+  if (!bridgeFrameCapabilityRef.current) {
+    const randomBytes = new Uint8Array(32);
+    crypto.getRandomValues(randomBytes);
+    const value = Array.from(randomBytes, byte =>
+      byte.toString(16).padStart(2, '0'),
+    ).join('');
+
+    bridgeFrameCapabilityRef.current = {
+      value,
+      injectedJavaScript: JSBridgeHarden(value),
+    };
+  }
+
+  const bridgeFrameCapability = bridgeFrameCapabilityRef.current;
 
   const destroyCurrentBridge = useCallback(() => {
     if (currentBridgeRef.current) {
@@ -134,6 +158,13 @@ export function useSetupWebviewWithServices({
 
         const data = fromData as WebViewDataPayload;
         if (data.name) {
+          if (
+            data[BRIDGE_FRAME_CAPABILITY_KEY] !== bridgeFrameCapability.value
+          ) {
+            return;
+          }
+          delete data[BRIDGE_FRAME_CAPABILITY_KEY];
+
           const msgOrigin =
             typeof (data as any).origin === 'string'
               ? (data as any).origin
@@ -168,7 +199,12 @@ export function useSetupWebviewWithServices({
         console.error(e, `Browser::onMessage on ${urlRef.current}`);
       }
     },
-    [currentBridgeRef, onRabbyDeclaredMessage, urlRef],
+    [
+      bridgeFrameCapability.value,
+      currentBridgeRef,
+      onRabbyDeclaredMessage,
+      urlRef,
+    ],
   );
 
   const changeUrl = useCallback(
@@ -247,6 +283,7 @@ export function useSetupWebviewWithServices({
   }, [destroyCurrentBridge]);
 
   return {
+    bridgeHardenScript: bridgeFrameCapability.injectedJavaScript,
     onLoadStart,
     onMessage,
   };

--- a/apps/mobile/src/core/bridges/useBackgroundBridge.ts
+++ b/apps/mobile/src/core/bridges/useBackgroundBridge.ts
@@ -9,6 +9,7 @@ import { createDappBySession } from '@/core/utils/createDappBySession';
 import { useRefState } from '@/hooks/common/useRefState';
 import {
   BRIDGE_FRAME_CAPABILITY_KEY,
+  BRIDGE_FRAME_PAYLOAD_KEY,
   JSBridgeHarden,
   RABBY_DECLARED_PREFIX,
 } from '@rabby-wallet/rn-webview-bridge';
@@ -33,7 +34,11 @@ type WebViewDataPayload<P = any> = {
   type: string;
   name?: string;
   payload?: P;
-  [BRIDGE_FRAME_CAPABILITY_KEY]?: string;
+};
+
+type WebViewCapabilityEnvelope = {
+  [BRIDGE_FRAME_CAPABILITY_KEY]?: unknown;
+  [BRIDGE_FRAME_PAYLOAD_KEY]?: unknown;
 };
 
 export type SetupWebviewParams = {
@@ -152,18 +157,41 @@ export function useSetupWebviewWithServices({
       try {
         fromData =
           typeof fromData === 'string' ? JSON.parse(fromData) : fromData;
-        if (!fromData || (!fromData.type && !fromData.name)) {
+        const hasCapabilityEnvelope =
+          fromData != null &&
+          typeof fromData === 'object' &&
+          Object.prototype.hasOwnProperty.call(
+            fromData,
+            BRIDGE_FRAME_CAPABILITY_KEY,
+          ) &&
+          Object.prototype.hasOwnProperty.call(
+            fromData,
+            BRIDGE_FRAME_PAYLOAD_KEY,
+          );
+        const capabilityEnvelope = hasCapabilityEnvelope
+          ? (fromData as WebViewCapabilityEnvelope)
+          : null;
+        const messageData = capabilityEnvelope
+          ? capabilityEnvelope[BRIDGE_FRAME_PAYLOAD_KEY]
+          : fromData;
+
+        if (
+          !messageData ||
+          typeof messageData !== 'object' ||
+          (!(messageData as WebViewDataPayload).type &&
+            !(messageData as WebViewDataPayload).name)
+        ) {
           return;
         }
 
-        const data = fromData as WebViewDataPayload;
+        const data = messageData as WebViewDataPayload;
         if (data.name) {
           if (
-            data[BRIDGE_FRAME_CAPABILITY_KEY] !== bridgeFrameCapability.value
+            capabilityEnvelope?.[BRIDGE_FRAME_CAPABILITY_KEY] !==
+            bridgeFrameCapability.value
           ) {
             return;
           }
-          delete data[BRIDGE_FRAME_CAPABILITY_KEY];
 
           const msgOrigin =
             typeof (data as any).origin === 'string'

--- a/apps/mobile/src/core/walletconnect/client.test.ts
+++ b/apps/mobile/src/core/walletconnect/client.test.ts
@@ -1,0 +1,164 @@
+import type { IWalletKit, WalletKitTypes } from '@reown/walletkit';
+import { handleWalletConnectSessionProposal } from './client';
+import {
+  forgetWalletConnectPairingBrowserOrigin,
+  getWalletConnectPairingBrowserOrigin,
+  rememberWalletConnectPairingBrowserOrigin,
+} from './pairingBrowserOrigin';
+import { storeWalletConnectProposal } from './proposal';
+import type { WalletConnectDebugState } from './types';
+
+let mockState: WalletConnectDebugState;
+
+jest.mock('@/utils/i18n', () => ({
+  __esModule: true,
+  default: { t: (key: string) => key },
+}));
+jest.mock('@/constant/env', () => ({
+  RABBY_MOBILE_WALLETCONNECT_PROJECT_ID: 'test-project-id',
+}));
+jest.mock('./autoDisconnect', () => ({
+  clearWalletConnectAutoDisconnectTopic: jest.fn(),
+  disconnectRestoredWalletConnectSessionsForAutoDisconnect: jest.fn(),
+}));
+jest.mock('./debugLog', () => ({ addWalletConnectLog: jest.fn() }));
+jest.mock('./error', () => ({
+  getWalletConnectErrorMessage: jest.fn((error: Error) => error.message),
+}));
+jest.mock('./metadata', () => ({ WALLETCONNECT_CLIENT_METADATA: {} }));
+jest.mock('./proposal', () => ({
+  clearWalletConnectProposal: jest.fn(),
+  storeWalletConnectProposal: jest.fn(),
+}));
+jest.mock('./accountPersistence', () => ({
+  forgetWalletConnectAccountForTopic: jest.fn(),
+}));
+jest.mock('./redirectState', () => ({
+  clearWalletConnectDappRedirectPending: jest.fn(),
+}));
+jest.mock('./requestBridge', () => ({
+  handleWalletConnectSessionRequest: jest.fn(),
+}));
+jest.mock('./sessions', () => ({
+  syncWalletConnectSessionsFromClient: jest.fn(),
+}));
+jest.mock('./state', () => ({
+  getWalletConnectDebugState: () => mockState,
+  setWalletConnectClientStatus: jest.fn(),
+  setWalletConnectDebugState: jest.fn(),
+}));
+jest.mock('./storage', () => ({ walletConnectStorage: {} }));
+jest.mock('./uiEvents', () => ({ emitWalletConnectUiEvent: jest.fn() }));
+jest.mock('../utils/androidTrace', () => ({
+  traceAndroidInstant: jest.fn(),
+}));
+
+function makeProposal(
+  pairingTopic: string,
+  dappUrl: string,
+): WalletKitTypes.SessionProposal {
+  return {
+    id: 1,
+    params: {
+      pairingTopic,
+      proposer: {
+        publicKey: 'public-key',
+        metadata: {
+          name: 'Example',
+          description: '',
+          url: dappUrl,
+          icons: [],
+        },
+      },
+      requiredNamespaces: {},
+      optionalNamespaces: {},
+    },
+    verifyContext: {
+      verified: {
+        origin: dappUrl,
+        validation: 'UNKNOWN',
+        verifyUrl: '',
+      },
+    },
+  } as unknown as WalletKitTypes.SessionProposal;
+}
+
+function makeWalletKit() {
+  return {
+    rejectSession: jest.fn().mockResolvedValue(undefined),
+    core: {
+      pairing: {
+        disconnect: jest.fn().mockResolvedValue(undefined),
+      },
+    },
+  } as unknown as IWalletKit;
+}
+
+describe('WalletConnect browser-origin proposals', () => {
+  const topic = 'browser-origin-topic';
+
+  beforeEach(() => {
+    mockState = {
+      projectId: 'test-project-id',
+      client: { status: 'ready' },
+      pairing: { status: 'pairing', source: 'inner-webview' },
+      sessions: [],
+      log: [],
+    };
+    jest.mocked(storeWalletConnectProposal).mockClear();
+    forgetWalletConnectPairingBrowserOrigin(topic);
+    expect(
+      rememberWalletConnectPairingBrowserOrigin({
+        topic,
+        browserOrigin: 'https://app.example',
+      }),
+    ).toBe(true);
+  });
+
+  afterEach(() => {
+    forgetWalletConnectPairingBrowserOrigin(topic);
+  });
+
+  it('stores a proposal with the same declared origin', () => {
+    const walletKit = makeWalletKit();
+    handleWalletConnectSessionProposal(
+      walletKit,
+      makeProposal(topic, 'https://app.example/path'),
+    );
+
+    expect(walletKit.rejectSession).not.toHaveBeenCalled();
+    expect(storeWalletConnectProposal).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'inner-webview' }),
+    );
+  });
+
+  it('keeps a QR proposal on the original path', () => {
+    forgetWalletConnectPairingBrowserOrigin(topic);
+    mockState.pairing.source = 'qr';
+    const walletKit = makeWalletKit();
+
+    handleWalletConnectSessionProposal(
+      walletKit,
+      makeProposal(topic, 'https://app.example'),
+    );
+
+    expect(walletKit.rejectSession).not.toHaveBeenCalled();
+    expect(storeWalletConnectProposal).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'qr' }),
+    );
+  });
+
+  it('rejects and disconnects a proposal with a different origin', async () => {
+    const walletKit = makeWalletKit();
+    handleWalletConnectSessionProposal(
+      walletKit,
+      makeProposal(topic, 'https://other.example'),
+    );
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(storeWalletConnectProposal).not.toHaveBeenCalled();
+    expect(walletKit.rejectSession).toHaveBeenCalled();
+    expect(walletKit.core.pairing.disconnect).toHaveBeenCalledWith({ topic });
+    expect(getWalletConnectPairingBrowserOrigin(topic)).toBeNull();
+  });
+});

--- a/apps/mobile/src/core/walletconnect/client.ts
+++ b/apps/mobile/src/core/walletconnect/client.ts
@@ -1,4 +1,5 @@
-import type { IWalletKit } from '@reown/walletkit';
+import type { IWalletKit, WalletKitTypes } from '@reown/walletkit';
+import { getSdkError } from '@walletconnect/utils';
 import i18n from '@/utils/i18n';
 import { RABBY_MOBILE_WALLETCONNECT_PROJECT_ID } from '@/constant/env';
 import {
@@ -8,6 +9,11 @@ import {
 import { addWalletConnectLog } from './debugLog';
 import { getWalletConnectErrorMessage } from './error';
 import { WALLETCONNECT_CLIENT_METADATA } from './metadata';
+import {
+  forgetWalletConnectPairingBrowserOrigin,
+  getWalletConnectPairingBrowserOrigin,
+  isWalletConnectOriginMismatch,
+} from './pairingBrowserOrigin';
 import {
   clearWalletConnectProposal,
   storeWalletConnectProposal,
@@ -31,8 +37,8 @@ type WalletConnectCore = InstanceType<
   pairing?: {
     events?: {
       on?: (
-        event: 'pairing_expire',
-        listener: (event: unknown) => void,
+        event: 'pairing_expire' | 'pairing_delete',
+        listener: (event: { topic: string }) => void,
       ) => void;
     };
   };
@@ -47,19 +53,99 @@ type WalletConnectCore = InstanceType<
 let walletKitClient: IWalletKit | null = null;
 let initPromise: Promise<IWalletKit> | null = null;
 
+async function rejectAndDisconnectWalletConnectPairing(
+  walletKit: IWalletKit,
+  event: WalletKitTypes.SessionProposal,
+  pairingTopic: string,
+) {
+  try {
+    await walletKit.rejectSession({
+      id: event.id,
+      reason: getSdkError('USER_REJECTED'),
+    });
+  } catch (error) {
+    addWalletConnectLog(
+      'proposal',
+      'failed to reject origin-mismatched proposal',
+      error,
+      'error',
+    );
+  }
+
+  try {
+    await walletKit.core.pairing.disconnect({ topic: pairingTopic });
+    forgetWalletConnectPairingBrowserOrigin(pairingTopic);
+  } catch (error) {
+    addWalletConnectLog(
+      'pairing',
+      'failed to disconnect origin-mismatched pairing',
+      error,
+      'error',
+    );
+  }
+}
+
+export function handleWalletConnectSessionProposal(
+  walletKit: IWalletKit,
+  event: WalletKitTypes.SessionProposal,
+) {
+  const pairingTopic = event.params?.pairingTopic;
+  const browserOrigin = getWalletConnectPairingBrowserOrigin(pairingTopic);
+  const source = browserOrigin
+    ? 'inner-webview'
+    : getWalletConnectDebugState().pairing.source || ('manual' as const);
+
+  const dappUrl = event.params?.proposer?.metadata?.url;
+  if (
+    browserOrigin &&
+    pairingTopic &&
+    isWalletConnectOriginMismatch({
+      browserOrigin,
+      dappUrl,
+    })
+  ) {
+    addWalletConnectLog(
+      'proposal',
+      'session proposal rejected: browser origin mismatch',
+      { browserOrigin, dappUrl },
+      'warn',
+    );
+    void rejectAndDisconnectWalletConnectPairing(
+      walletKit,
+      event,
+      pairingTopic,
+    );
+
+    const message = i18n.t('page.walletConnect.pairingFailed');
+    setWalletConnectDebugState(prev => ({
+      ...prev,
+      pairing: {
+        ...prev.pairing,
+        status: 'error',
+        error: message,
+      },
+    }));
+    emitWalletConnectUiEvent({
+      type: 'pairingError',
+      message,
+    });
+    return;
+  }
+
+  storeWalletConnectProposal({
+    id: event.id,
+    proposal: event.params,
+    source,
+    verifyContext: event.verifyContext,
+  });
+}
+
 function bindWalletConnectEvents(
   walletKit: IWalletKit,
   core: WalletConnectCore,
 ) {
   walletKit.on('session_proposal', event => {
-    const source =
-      getWalletConnectDebugState().pairing.source || ('manual' as const);
-    storeWalletConnectProposal({
-      id: event.id,
-      proposal: event.params,
-      source,
-      verifyContext: event.verifyContext,
-    });
+    handleWalletConnectSessionProposal(walletKit, event);
   });
 
   walletKit.on('session_request', event => {
@@ -106,6 +192,7 @@ function bindWalletConnectEvents(
   });
 
   core?.pairing?.events?.on?.('pairing_expire', event => {
+    forgetWalletConnectPairingBrowserOrigin(event.topic);
     const pairingStatus = getWalletConnectDebugState().pairing.status;
     if (pairingStatus !== 'pairing') {
       addWalletConnectLog('pairing', 'stale pairing expired', event, 'warn');
@@ -133,6 +220,9 @@ function bindWalletConnectEvents(
   });
   core?.relayer?.on?.('relayer_disconnect', () => {
     addWalletConnectLog('relay', 'relay disconnected', undefined, 'warn');
+  });
+  core?.pairing?.events?.on?.('pairing_delete', event => {
+    forgetWalletConnectPairingBrowserOrigin(event.topic);
   });
 }
 

--- a/apps/mobile/src/core/walletconnect/pairing.test.ts
+++ b/apps/mobile/src/core/walletconnect/pairing.test.ts
@@ -1,5 +1,9 @@
 import { initWalletConnect } from './client';
 import { pairWalletConnectUri } from './pairing';
+import {
+  forgetWalletConnectPairingBrowserOrigin,
+  getWalletConnectPairingBrowserOrigin,
+} from './pairingBrowserOrigin';
 import type { WalletConnectDebugState } from './types';
 
 const WC_URI =
@@ -50,6 +54,10 @@ describe('walletconnect pairing', () => {
     jest.mocked(initWalletConnect).mockReset();
   });
 
+  afterEach(() => {
+    forgetWalletConnectPairingBrowserOrigin('abc123');
+  });
+
   it('keeps pairing pending after WalletKit accepts the URI', async () => {
     const walletKit = {
       pair: jest.fn().mockResolvedValue(undefined),
@@ -69,6 +77,37 @@ describe('walletconnect pairing', () => {
       uri: WC_URI,
       source: 'qr',
     });
+    expect(getWalletConnectPairingBrowserOrigin('abc123')).toBeNull();
+  });
+
+  it('binds a strict WebView pairing to its source origin', async () => {
+    const walletKit = {
+      pair: jest.fn().mockResolvedValue(undefined),
+    } as unknown as Awaited<ReturnType<typeof initWalletConnect>>;
+    jest.mocked(initWalletConnect).mockResolvedValue(walletKit);
+
+    await pairWalletConnectUri({
+      uri: WC_URI,
+      source: 'inner-webview',
+      browserOrigin: 'https://app.example/path',
+    });
+
+    expect(getWalletConnectPairingBrowserOrigin('abc123')).toBe(
+      'https://app.example',
+    );
+  });
+
+  it('fails before pairing when a WebView origin is invalid', async () => {
+    await expect(
+      pairWalletConnectUri({
+        uri: WC_URI,
+        source: 'inner-webview',
+        browserOrigin: '',
+      }),
+    ).rejects.toThrow();
+
+    expect(initWalletConnect).not.toHaveBeenCalled();
+    expect(getWalletConnectPairingBrowserOrigin('abc123')).toBeNull();
   });
 
   it('does not overwrite proposal state when proposal arrives before pair resolves', async () => {

--- a/apps/mobile/src/core/walletconnect/pairing.ts
+++ b/apps/mobile/src/core/walletconnect/pairing.ts
@@ -3,6 +3,11 @@ import { initWalletConnect } from './client';
 import { addWalletConnectLog } from './debugLog';
 import { getWalletConnectErrorMessage } from './error';
 import {
+  forgetWalletConnectPairingBrowserOrigin,
+  getWalletConnectPairingTopicFromUri,
+  rememberWalletConnectPairingBrowserOrigin,
+} from './pairingBrowserOrigin';
+import {
   clearWalletConnectDappRedirectPending,
   markWalletConnectDappRedirectPending,
 } from './redirectState';
@@ -40,10 +45,26 @@ function formatPairingError(error: unknown) {
 export async function pairWalletConnectUri(input: {
   uri: string;
   source: WalletConnectPairingSource;
+  browserOrigin?: string;
 }) {
   let parsed: ReturnType<typeof parseWalletConnectUri>;
+  let browserPairingTopic: string | null = null;
   try {
     parsed = parseWalletConnectUri(input.uri);
+    if (input.browserOrigin !== undefined) {
+      const topic = getWalletConnectPairingTopicFromUri(parsed.uri);
+      if (input.source !== 'inner-webview' || !topic) {
+        throw new Error(i18n.t('page.walletConnect.pairingFailed'));
+      }
+      const didRememberOrigin = rememberWalletConnectPairingBrowserOrigin({
+        topic,
+        browserOrigin: input.browserOrigin,
+      });
+      if (!didRememberOrigin) {
+        throw new Error(i18n.t('page.walletConnect.pairingFailed'));
+      }
+      browserPairingTopic = topic;
+    }
   } catch (error) {
     const message = formatPairingError(error);
     setWalletConnectDebugState(prev => ({
@@ -90,6 +111,9 @@ export async function pairWalletConnectUri(input: {
     });
     addWalletConnectLog('pairing', 'pairing submitted');
   } catch (error) {
+    if (browserPairingTopic) {
+      forgetWalletConnectPairingBrowserOrigin(browserPairingTopic);
+    }
     if (input.source === 'deeplink') {
       clearWalletConnectDappRedirectPending('pairing failed');
     }

--- a/apps/mobile/src/core/walletconnect/pairingBrowserOrigin.test.ts
+++ b/apps/mobile/src/core/walletconnect/pairingBrowserOrigin.test.ts
@@ -1,0 +1,65 @@
+import {
+  forgetWalletConnectPairingBrowserOrigin,
+  getWalletConnectPairingBrowserOrigin,
+  isWalletConnectOriginMismatch,
+  rememberWalletConnectPairingBrowserOrigin,
+} from './pairingBrowserOrigin';
+
+const trackedTopics = new Set<string>();
+
+function remember(topic: string, browserOrigin = 'https://app.example') {
+  trackedTopics.add(topic);
+  return rememberWalletConnectPairingBrowserOrigin({
+    topic,
+    browserOrigin,
+  });
+}
+
+afterEach(() => {
+  for (const topic of trackedTopics) {
+    forgetWalletConnectPairingBrowserOrigin(topic);
+  }
+  trackedTopics.clear();
+});
+
+describe('walletconnect pairing browser origin', () => {
+  it('compares the complete normalized origin', () => {
+    expect(
+      isWalletConnectOriginMismatch({
+        browserOrigin: 'https://APP.example:443/path',
+        dappUrl: 'https://app.example/another-path',
+      }),
+    ).toBe(false);
+    expect(
+      isWalletConnectOriginMismatch({
+        browserOrigin: 'https://app.example',
+        dappUrl: 'http://app.example',
+      }),
+    ).toBe(true);
+    expect(
+      isWalletConnectOriginMismatch({
+        browserOrigin: 'https://app.example',
+        dappUrl: 'not-a-url',
+      }),
+    ).toBe(true);
+  });
+
+  it('refuses to overwrite an existing topic binding', () => {
+    expect(remember('immutable-topic')).toBe(true);
+    expect(remember('immutable-topic', 'https://other.example')).toBe(false);
+    expect(getWalletConnectPairingBrowserOrigin('immutable-topic')).toBe(
+      'https://app.example',
+    );
+  });
+
+  it('fails closed at capacity instead of evicting an existing binding', () => {
+    for (let index = 0; index < 50; index += 1) {
+      expect(remember(`capacity-topic-${index}`)).toBe(true);
+    }
+
+    expect(remember('capacity-overflow')).toBe(false);
+    expect(getWalletConnectPairingBrowserOrigin('capacity-topic-0')).toBe(
+      'https://app.example',
+    );
+  });
+});

--- a/apps/mobile/src/core/walletconnect/pairingBrowserOrigin.ts
+++ b/apps/mobile/src/core/walletconnect/pairingBrowserOrigin.ts
@@ -1,0 +1,63 @@
+import { safeParseURL } from '@rabby-wallet/base-utils/dist/isomorphic/url';
+
+const PAIRING_BROWSER_ORIGIN_MAX_ENTRIES = 50;
+
+const pairingBrowserOrigins = new Map<string, string>();
+
+export function getWalletConnectPairingTopicFromUri(uri: string) {
+  const match = /^wc:([^@]+)@2\?/i.exec(uri.trim());
+  return match?.[1] || null;
+}
+
+function normalizeWalletConnectOrigin(urlOrOrigin: string) {
+  const url = safeParseURL(urlOrOrigin);
+  if (!url || (url.protocol !== 'https:' && url.protocol !== 'http:')) {
+    return null;
+  }
+  return url.origin;
+}
+
+export function rememberWalletConnectPairingBrowserOrigin(input: {
+  topic: string;
+  browserOrigin: string;
+}) {
+  const origin = normalizeWalletConnectOrigin(input.browserOrigin);
+  if (!input.topic || !origin) {
+    return false;
+  }
+
+  if (
+    pairingBrowserOrigins.has(input.topic) ||
+    pairingBrowserOrigins.size >= PAIRING_BROWSER_ORIGIN_MAX_ENTRIES
+  ) {
+    return false;
+  }
+
+  pairingBrowserOrigins.set(input.topic, origin);
+  return true;
+}
+
+export function getWalletConnectPairingBrowserOrigin(
+  topic: string | undefined,
+) {
+  return topic ? pairingBrowserOrigins.get(topic) || null : null;
+}
+
+export function forgetWalletConnectPairingBrowserOrigin(topic: string) {
+  pairingBrowserOrigins.delete(topic);
+}
+
+export function isWalletConnectOriginMismatch(input: {
+  browserOrigin: string;
+  dappUrl?: string | null;
+}) {
+  const browserOrigin = normalizeWalletConnectOrigin(input.browserOrigin);
+  if (!browserOrigin) {
+    return true;
+  }
+
+  const declaredOrigin = input.dappUrl
+    ? normalizeWalletConnectOrigin(input.dappUrl)
+    : null;
+  return browserOrigin !== declaredOrigin;
+}

--- a/apps/mobile/src/hooks/useBootstrap.ts
+++ b/apps/mobile/src/hooks/useBootstrap.ts
@@ -51,7 +51,6 @@ const syncCustomTestChainList = () => {
 };
 
 const WEBVIEW_BEFORE_CONTENT_LOADED_BUILTIN_SCRIPT_IDS = [
-  'rabby-jsbridge-harden',
   'rabby-inpage-web3',
   'rabby-browser-script-base',
   ...(__DEV__ ? ['rabby-dev-window-info-after-load'] : []),

--- a/apps/mobile/src/screens/Browser/BrowserScreen/components/BrowserTab/index.tsx
+++ b/apps/mobile/src/screens/Browser/BrowserScreen/components/BrowserTab/index.tsx
@@ -601,7 +601,11 @@ export const BrowserTab = ({
                 webviewRef={webviewRef}
                 webviewIdRef={webviewIdRef}
                 siteInfoRefs={{ urlRef, titleRef, iconRef }}>
-                {({ onLoadStart, onMessage: onWebViewMessage }) =>
+                {({
+                  bridgeHardenScript,
+                  onLoadStart,
+                  onMessage: onWebViewMessage,
+                }) =>
                   !url ||
                   !/^https?:\/\//.test(url) ||
                   !entryScriptWeb3Loaded ? null : (
@@ -643,6 +647,10 @@ export const BrowserTab = ({
                         injectedJavaScriptBeforeContentLoadedBuiltinScriptIds={
                           beforeContentLoadedBuiltinScriptIds
                         }
+                        injectedJavaScriptBeforeContentLoaded={`${bridgeHardenScript}\n${
+                          webviewProps?.injectedJavaScriptBeforeContentLoaded ??
+                          ''
+                        }`}
                         injectedJavaScriptBeforeContentLoadedForMainFrameOnly={
                           true
                         }

--- a/apps/mobile/src/screens/Browser/BrowserScreen/components/BrowserTab/index.tsx
+++ b/apps/mobile/src/screens/Browser/BrowserScreen/components/BrowserTab/index.tsx
@@ -785,6 +785,9 @@ export const BrowserTab = ({
                           }
                           return checkShouldStartLoadingWithRequestForDappWebView(
                             nativeEvent,
+                            {
+                              enforceWalletConnectOrigin: true,
+                            },
                           );
                         }}
                         onContentProcessDidTerminate={syntheticEvent => {

--- a/packages/rn-webview-bridge/src/browserScripts.ts
+++ b/packages/rn-webview-bridge/src/browserScripts.ts
@@ -206,50 +206,72 @@ export const JS_IFRAME_POST_MESSAGE_TO_PROVIDER = (
 })()`;
  */
 
-export const JSBridgeHarden = /* js */`(function () {
-    function safeStartsWith(str, search) {
-        if (typeof str !== 'string' || typeof search !== 'string') {
-            return false;
-        }
+export const BRIDGE_FRAME_CAPABILITY_KEY = '__rabbyFrameCapability';
 
-        for (let i = 0; i < search.length; i++) {
-          if (str[i] !== search[i]) {
-            return false;
-          }
-        }
-
-        return true;
+export const JSBridgeHarden = (capability: string) => /* js */`
+;(function () {
+  function safeStartsWith(str, search) {
+    if (typeof str !== 'string' || typeof search !== 'string') {
+      return false;
     }
 
-    if (window.ReactNativeWebView == null) {
+    for (var i = 0; i < search.length; i++) {
+      if (str[i] !== search[i]) return false;
+    }
+
+    return true;
+  }
+
+  var bridge = window.ReactNativeWebView;
+  if (bridge == null) return;
+
+  var parse = JSON.parse;
+  var stringify = JSON.stringify;
+  var apply = Reflect.apply;
+  var originalPostMessage = bridge.postMessage;
+  var capability = ${JSON.stringify(capability)};
+  var capabilityKey = ${JSON.stringify(BRIDGE_FRAME_CAPABILITY_KEY)};
+
+  function send(message) {
+    return apply(originalPostMessage, bridge, [message]);
+  }
+
+  function postMessageWithHarden(message) {
+    try {
+      var data = parse(message);
+      if (
+        data &&
+        data.name != null &&
+        !(
+          location.origin === data.origin ||
+          location.origin === data.origin + '/' ||
+          safeStartsWith(data.origin, location.origin + '/')
+        )
+      ) {
+        console.warn(
+          'Origin mismatch in postMessage: expected ' +
+            location.origin +
+            ', got ' +
+            data.origin
+        );
         return;
-    }
-    const parse = JSON.parse;
-    const realPost = window.ReactNativeWebView.postMessage.bind(window.ReactNativeWebView);
-    function myPostMessage(msg) {
-        try {
-            const json = parse(msg);
-            if (json &&
-                json.name != null &&
-                !(location.origin === json.origin ||
-                    location.origin === json.origin + '/' || safeStartsWith(json.origin, location.origin + '/'))) {
-                console.warn('Origin mismatch in postMessage: expected ' +
-                    location.origin +
-                    ', got ' +
-                    json.origin);
-                return;
-            }
-        }
-        catch (_a) { }
-        return realPost(msg);
-    }
-    window.ReactNativeWebView = new Proxy(window.ReactNativeWebView || {}, {
-        get: function (target, prop) {
-            if (prop === 'postMessage') {
-                return myPostMessage;
-            }
-            const f = Reflect.get(target, prop);
-            return typeof f === 'function' ? f.bind(target) : f;
-        },
-    });
-})();`;
+      }
+
+      if (data && data.name) {
+        data[capabilityKey] = capability;
+        return send(stringify(data));
+      }
+    } catch (_error) {}
+    return send(message);
+  }
+
+  var facade = Object.create(null);
+  Object.defineProperty(facade, 'postMessage', {
+    value: postMessageWithHarden,
+    enumerable: true,
+    writable: false,
+    configurable: false,
+  });
+  Object.freeze(facade);
+  window.ReactNativeWebView = facade;
+})();true;`;

--- a/packages/rn-webview-bridge/src/browserScripts.ts
+++ b/packages/rn-webview-bridge/src/browserScripts.ts
@@ -207,8 +207,14 @@ export const JS_IFRAME_POST_MESSAGE_TO_PROVIDER = (
  */
 
 export const BRIDGE_FRAME_CAPABILITY_KEY = '__rabbyFrameCapability';
+export const BRIDGE_FRAME_PAYLOAD_KEY = '__rabbyFramePayload';
 
-export const JSBridgeHarden = (capability: string) => /* js */`
+export const JSBridgeHarden = (capability: string) => {
+  const envelopePrefix = `${JSON.stringify({
+    [BRIDGE_FRAME_CAPABILITY_KEY]: capability,
+  }).slice(0, -1)},${JSON.stringify(BRIDGE_FRAME_PAYLOAD_KEY)}:`;
+
+  return /* js */`
 ;(function () {
   function safeStartsWith(str, search) {
     if (typeof str !== 'string' || typeof search !== 'string') {
@@ -228,38 +234,54 @@ export const JSBridgeHarden = (capability: string) => /* js */`
   var parse = JSON.parse;
   var stringify = JSON.stringify;
   var apply = Reflect.apply;
-  var originalPostMessage = bridge.postMessage;
-  var capability = ${JSON.stringify(capability)};
-  var capabilityKey = ${JSON.stringify(BRIDGE_FRAME_CAPABILITY_KEY)};
+  var nativeReceiver;
+  var nativePostMessage;
+  var iosHandler =
+    window.webkit &&
+    window.webkit.messageHandlers &&
+    window.webkit.messageHandlers.ReactNativeWebView;
+
+  if (iosHandler && typeof iosHandler.postMessage === 'function') {
+    nativeReceiver = iosHandler;
+    nativePostMessage = iosHandler.postMessage;
+  } else if (typeof bridge.postMessage === 'function') {
+    nativeReceiver = bridge;
+    nativePostMessage = bridge.postMessage;
+  } else {
+    return;
+  }
+
+  var envelopePrefix = ${JSON.stringify(envelopePrefix)};
 
   function send(message) {
-    return apply(originalPostMessage, bridge, [message]);
+    return apply(nativePostMessage, nativeReceiver, [message]);
   }
 
   function postMessageWithHarden(message) {
     try {
       var data = parse(message);
-      if (
-        data &&
-        data.name != null &&
-        !(
-          location.origin === data.origin ||
-          location.origin === data.origin + '/' ||
-          safeStartsWith(data.origin, location.origin + '/')
-        )
-      ) {
-        console.warn(
-          'Origin mismatch in postMessage: expected ' +
-            location.origin +
-            ', got ' +
-            data.origin
-        );
-        return;
-      }
-
       if (data && data.name) {
-        data[capabilityKey] = capability;
-        return send(stringify(data));
+        var payload = stringify(data);
+        data = parse(payload);
+
+        if (!data || !data.name) return;
+        if (
+          !(
+            location.origin === data.origin ||
+            location.origin === data.origin + '/' ||
+            safeStartsWith(data.origin, location.origin + '/')
+          )
+        ) {
+          console.warn(
+            'Origin mismatch in postMessage: expected ' +
+              location.origin +
+              ', got ' +
+              data.origin
+          );
+          return;
+        }
+
+        return send(envelopePrefix + payload + '}');
       }
     } catch (_error) {}
     return send(message);
@@ -275,3 +297,4 @@ export const JSBridgeHarden = (capability: string) => /* js */`
   Object.freeze(facade);
   window.ReactNativeWebView = facade;
 })();true;`;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -40121,14 +40121,14 @@ __metadata:
 
 "react-native-webview@patch:react-native-webview@npm%3A13.10.5#./.yarn/patches/react-native-webview-npm-13.10.5-714eb41569.patch::locator=%40rabby-wallet%2Fmobile-monorepo%40workspace%3A.":
   version: 13.10.5
-  resolution: "react-native-webview@patch:react-native-webview@npm%3A13.10.5#./.yarn/patches/react-native-webview-npm-13.10.5-714eb41569.patch::version=13.10.5&hash=24e9bc&locator=%40rabby-wallet%2Fmobile-monorepo%40workspace%3A."
+  resolution: "react-native-webview@patch:react-native-webview@npm%3A13.10.5#./.yarn/patches/react-native-webview-npm-13.10.5-714eb41569.patch::version=13.10.5&hash=6cee3d&locator=%40rabby-wallet%2Fmobile-monorepo%40workspace%3A."
   dependencies:
     escape-string-regexp: "npm:2.0.0"
     invariant: "npm:2.2.4"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10/bb5c1d040acccdd62d42dea2fec804ac6ba66fb5bea32faa9eb63569c1f5b14875673bacd83228b16ecafd92a76fb28edee0a116d40bd8ef5dba01cd5721f704
+  checksum: 10/73ee83d50ca809b73e640f860b8d29b24cf6b714e79c9483aa6d2b8fcff21f9f1901179c1d3159f4480ddb9db2615471c475e1e47c238f217344496a316c1c0b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- 引入仅注入 main frame 的随机 token，并校验消息 origin，阻止 iframe 越权通信及页面跳转期间的来源伪造

- 内置 DApp 浏览器通过 DeepLink 导航发起 WC 配对时，要求 WC 声明的 origin 与 WebView origin 一致，否则拒绝连接

- 由 RN WebView 原生层提供发起导航的页面 URL，使 RN JS 层能够准确识别请求来源，不受跳转的条件竞争问题影响