### PR TITLE
perf: skip empty Warden runtime sandboxes

### DIFF
--- a/.yarn/patches/warden.rn-npm-2.2.1-c1350e5489.patch
+++ b/.yarn/patches/warden.rn-npm-2.2.1-c1350e5489.patch
@@ -1,0 +1,386 @@
+diff --git a/dist/index.js b/dist/index.js
+index 6e0be540a56b1874e60de7a5e392102070c569f7..aa138d921c5e5035210bd7961090cae92770f233 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -143,6 +143,42 @@ function hasExecutableJavaScriptOutput(module) {
+ function isJavaScriptSourcePath(modulePath) {
+     return /\.(?:[cm]?[jt]sx?|json)$/i.test(modulePath);
+ }
++function referencesSandboxGlobalAlias(fn) {
++    const factoryGlobal = fn.node.params[0];
++    if (!t.isIdentifier(factoryGlobal)) {
++        throw new Error("The first parameter of the function must be an identifier");
++    }
++    const implicitAliases = new Set([
++        "globalThis",
++        "self",
++        "window",
++        "global",
++        "g",
++        "__mkGb",
++    ]);
++    let referenced = false;
++    fn.traverse({
++        Identifier(path) {
++            if (referenced || !path.isReferencedIdentifier()) {
++                return;
++            }
++            const name = path.node.name;
++            if (name === factoryGlobal.name) {
++                if (path.scope.getBinding(name)?.identifier === factoryGlobal) {
++                    referenced = true;
++                    path.stop();
++                }
++                return;
++            }
++            if (implicitAliases.has(name) &&
++                !path.scope.hasBinding(name, { noGlobals: true })) {
++                referenced = true;
++                path.stop();
++            }
++        },
++    });
++    return referenced;
++}
+ function assertNoThirdPartyImportsFirstParty(graph, rootDir, override) {
+     const violations = new Map();
+     const boundaryTargets = new Map();
+@@ -234,6 +270,7 @@ async function serializeModulesIndividually({ serializer, entryPoint, preModules
+     let staticGlobalFastPathCount = 0;
+     let normalizedGlobalCount = 0;
+     let runtimeGlobalSandboxCount = 0;
++    let emptyGlobalRuntimePassthroughCount = 0;
+     let trustedRuntimePassthroughCount = 0;
+     const globalPrefix = options.globalPrefix ??
+         "";
+@@ -294,6 +331,7 @@ async function serializeModulesIndividually({ serializer, entryPoint, preModules
+                 globals: {},
+             };
+         const moduleAst = (0, parser_1.parse)(output.data.code, { sourceType: "module" });
++        let preserveOriginalModuleOutput = isTrustedRuntimeModule;
+         const statement = moduleAst.program.body.find((node) => t.isExpressionStatement(node) &&
+             t.isCallExpression(node.expression) &&
+             t.isIdentifier(node.expression.callee, { name: "__d" }));
+@@ -315,6 +353,7 @@ async function serializeModulesIndividually({ serializer, entryPoint, preModules
+                     }
+                     const moduleFnPath = moduleCallPath.get("arguments")[0];
+                     if (item != null) {
++                        const usesSandboxGlobalAlias = referencesSandboxGlobalAlias(moduleFnPath);
+                         const detectedGlobals = (0, globals_1.analyzeGlobals)(moduleCallPath, false, forceProtectedGlobals);
+                         for (const name of protectedModuleGlobals) {
+                             delete detectedGlobals[name];
+@@ -330,9 +369,21 @@ async function serializeModulesIndividually({ serializer, entryPoint, preModules
+                                 effectiveGlobals[name] === "rw"));
+                         const shouldNormalizeGlobals = !isTrustedRuntimeModule &&
+                             !policyAllowsDirectAccess;
++                        const canPassthroughEmptyGlobalModule = !isTrustedRuntimeModule &&
++                            !dev &&
++                            !protectModuleImports &&
++                            !hardenDynamicCode &&
++                            !isHardenAfterModule &&
++                            Object.keys(detectedAccessModes).length === 0 &&
++                            !usesSandboxGlobalAlias &&
++                            Object.keys(effectiveGlobals).length === 0;
+                         if (isTrustedRuntimeModule) {
+                             trustedRuntimePassthroughCount++;
+                         }
++                        else if (canPassthroughEmptyGlobalModule) {
++                            emptyGlobalRuntimePassthroughCount++;
++                            preserveOriginalModuleOutput = true;
++                        }
+                         else if (shouldNormalizeGlobals) {
+                             normalizedGlobalCount++;
+                             (0, globals_1.analyzeGlobals)(moduleCallPath, true);
+@@ -340,7 +391,8 @@ async function serializeModulesIndividually({ serializer, entryPoint, preModules
+                         else {
+                             staticGlobalFastPathCount++;
+                         }
+-                        if (!isTrustedRuntimeModule) {
++                        if (!isTrustedRuntimeModule &&
++                            !canPassthroughEmptyGlobalModule) {
+                             runtimeGlobalSandboxCount++;
+                         }
+                         if (protectModuleImports &&
+@@ -355,7 +407,8 @@ async function serializeModulesIndividually({ serializer, entryPoint, preModules
+                                 dev,
+                             });
+                         }
+-                        if (!isTrustedRuntimeModule) {
++                        if (!isTrustedRuntimeModule &&
++                            !canPassthroughEmptyGlobalModule) {
+                             (0, globals_1.rewriteGlobalFunctionBind)(moduleFnPath, shouldNormalizeGlobals);
+                             (0, globals_1.hardenGlobals)(moduleCallPath, effectiveGlobals, path.relative(rootDir, module.path), dev, hardenDynamicCode, protectedModuleGlobals);
+                         }
+@@ -371,11 +424,12 @@ async function serializeModulesIndividually({ serializer, entryPoint, preModules
+         finally {
+             traverse_1.default.cache.clear();
+         }
+-        if (isTrustedRuntimeModule) {
+-            // Reanimated-style JSI/worklet packages can depend on the exact
+-            // transformed source bytes and factory scope produced by Metro.
+-            // Analysis is read-only for trusted runtimes: preserve their
+-            // module output, mappings, and function metadata verbatim.
++        if (preserveOriginalModuleOutput) {
++            // Trusted runtimes and release modules that neither need a global
++            // capability nor reference Warden's implicit global aliases keep
++            // Metro's output, mappings, and function metadata byte-for-byte.
++            // Empty-policy passthrough is valid only when the optional runtime
++            // guards are disabled and collection mode is off.
+             continue;
+         }
+         const inputMap = output.data.map.length === 0
+@@ -415,7 +469,7 @@ async function serializeModulesIndividually({ serializer, entryPoint, preModules
+     if (hardenAfterModulePath != null && !hardenAfterModuleFound) {
+         throw new Error(`hardenAfterModule was not found in the Metro graph: ${hardenAfterModulePath}`);
+     }
+-    console.log(`[Warden] compatible global fast path: ${staticGlobalFastPathCount} modules; normalized globals: ${normalizedGlobalCount} modules; runtime sandbox: ${runtimeGlobalSandboxCount} modules; trusted runtime passthrough: ${trustedRuntimePassthroughCount} modules`);
++    console.log(`[Warden] compatible global fast path: ${staticGlobalFastPathCount} modules; normalized globals: ${normalizedGlobalCount} modules; runtime sandbox: ${runtimeGlobalSandboxCount} modules; empty global runtime passthrough: ${emptyGlobalRuntimePassthroughCount} modules; trusted runtime passthrough: ${trustedRuntimePassthroughCount} modules`);
+     const runtimeAst = t.file(t.program([]));
+     (0, globals_1.refactorRuntime)(runtimeAst, dev);
+     const runtimeCode = (0, generator_1.default)(runtimeAst).code;
+diff --git a/src/index.ts b/src/index.ts
+index 19fa4e45c60842e8102f71fc485bc0474485f53b..0cd80ee7a547d048ad0329f7408d758fd37f2138 100644
+--- a/src/index.ts
++++ b/src/index.ts
+@@ -199,6 +199,54 @@ function isJavaScriptSourcePath(modulePath: string) {
+     return /\.(?:[cm]?[jt]sx?|json)$/i.test(modulePath);
+ }
+ 
++function referencesSandboxGlobalAlias(fn: NodePath<t.FunctionExpression>) {
++    const factoryGlobal = fn.node.params[0];
++    if (!t.isIdentifier(factoryGlobal)) {
++        throw new Error(
++            "The first parameter of the function must be an identifier"
++        );
++    }
++
++    const implicitAliases = new Set([
++        "globalThis",
++        "self",
++        "window",
++        "global",
++        "g",
++        "__mkGb",
++    ]);
++    let referenced = false;
++
++    fn.traverse({
++        Identifier(path) {
++            if (referenced || !path.isReferencedIdentifier()) {
++                return;
++            }
++
++            const name = path.node.name;
++            if (name === factoryGlobal.name) {
++                if (
++                    path.scope.getBinding(name)?.identifier === factoryGlobal
++                ) {
++                    referenced = true;
++                    path.stop();
++                }
++                return;
++            }
++
++            if (
++                implicitAliases.has(name) &&
++                !path.scope.hasBinding(name, { noGlobals: true })
++            ) {
++                referenced = true;
++                path.stop();
++            }
++        },
++    });
++
++    return referenced;
++}
++
+ function assertNoThirdPartyImportsFirstParty(
+     graph: SerializerArguments[2],
+     rootDir: string,
+@@ -357,6 +405,7 @@ async function serializeModulesIndividually({
+     let staticGlobalFastPathCount = 0;
+     let normalizedGlobalCount = 0;
+     let runtimeGlobalSandboxCount = 0;
++    let emptyGlobalRuntimePassthroughCount = 0;
+     let trustedRuntimePassthroughCount = 0;
+     const globalPrefix =
+         (options as typeof options & { globalPrefix?: string }).globalPrefix ??
+@@ -436,6 +485,7 @@ async function serializeModulesIndividually({
+                   globals: {},
+               };
+         const moduleAst = parse(output.data.code, { sourceType: "module" });
++        let preserveOriginalModuleOutput = isTrustedRuntimeModule;
+         const statement = moduleAst.program.body.find(
+             (node): node is t.ExpressionStatement =>
+                 t.isExpressionStatement(node) &&
+@@ -473,6 +523,8 @@ async function serializeModulesIndividually({
+                         "arguments"
+                     )[0] as NodePath<t.FunctionExpression>;
+                     if (item != null) {
++                        const usesSandboxGlobalAlias =
++                            referencesSandboxGlobalAlias(moduleFnPath);
+                         const detectedGlobals = analyzeGlobals(
+                             moduleCallPath,
+                             false,
+@@ -501,16 +553,31 @@ async function serializeModulesIndividually({
+                         const shouldNormalizeGlobals =
+                             !isTrustedRuntimeModule &&
+                             !policyAllowsDirectAccess;
++                        const canPassthroughEmptyGlobalModule =
++                            !isTrustedRuntimeModule &&
++                            !dev &&
++                            !protectModuleImports &&
++                            !hardenDynamicCode &&
++                            !isHardenAfterModule &&
++                            Object.keys(detectedAccessModes).length === 0 &&
++                            !usesSandboxGlobalAlias &&
++                            Object.keys(effectiveGlobals).length === 0;
+ 
+                         if (isTrustedRuntimeModule) {
+                             trustedRuntimePassthroughCount++;
++                        } else if (canPassthroughEmptyGlobalModule) {
++                            emptyGlobalRuntimePassthroughCount++;
++                            preserveOriginalModuleOutput = true;
+                         } else if (shouldNormalizeGlobals) {
+                             normalizedGlobalCount++;
+                             analyzeGlobals(moduleCallPath, true);
+                         } else {
+                             staticGlobalFastPathCount++;
+                         }
+-                        if (!isTrustedRuntimeModule) {
++                        if (
++                            !isTrustedRuntimeModule &&
++                            !canPassthroughEmptyGlobalModule
++                        ) {
+                             runtimeGlobalSandboxCount++;
+                         }
+                         if (
+@@ -531,7 +598,10 @@ async function serializeModulesIndividually({
+                                 dev,
+                             });
+                         }
+-                        if (!isTrustedRuntimeModule) {
++                        if (
++                            !isTrustedRuntimeModule &&
++                            !canPassthroughEmptyGlobalModule
++                        ) {
+                             rewriteGlobalFunctionBind(
+                                 moduleFnPath,
+                                 shouldNormalizeGlobals
+@@ -561,11 +631,12 @@ async function serializeModulesIndividually({
+             traverse.cache.clear();
+         }
+ 
+-        if (isTrustedRuntimeModule) {
+-            // Reanimated-style JSI/worklet packages can depend on the exact
+-            // transformed source bytes and factory scope produced by Metro.
+-            // Analysis is read-only for trusted runtimes: preserve their
+-            // module output, mappings, and function metadata verbatim.
++        if (preserveOriginalModuleOutput) {
++            // Trusted runtimes and release modules that neither need a global
++            // capability nor reference Warden's implicit global aliases keep
++            // Metro's output, mappings, and function metadata byte-for-byte.
++            // Empty-policy passthrough is valid only when the optional runtime
++            // guards are disabled and collection mode is off.
+             continue;
+         }
+ 
+@@ -613,7 +684,7 @@ async function serializeModulesIndividually({
+     }
+ 
+     console.log(
+-        `[Warden] compatible global fast path: ${staticGlobalFastPathCount} modules; normalized globals: ${normalizedGlobalCount} modules; runtime sandbox: ${runtimeGlobalSandboxCount} modules; trusted runtime passthrough: ${trustedRuntimePassthroughCount} modules`
++        `[Warden] compatible global fast path: ${staticGlobalFastPathCount} modules; normalized globals: ${normalizedGlobalCount} modules; runtime sandbox: ${runtimeGlobalSandboxCount} modules; empty global runtime passthrough: ${emptyGlobalRuntimePassthroughCount} modules; trusted runtime passthrough: ${trustedRuntimePassthroughCount} modules`
+     );
+ 
+     const runtimeAst = t.file(t.program([]));
+diff --git a/test/serializer.test.js b/test/serializer.test.js
+index 9ec0f5802f0a7d4a7f52ab10b37cbfb1046933c3..9cd812009499eea6f7f8f4330c6ce365da78fa3c 100644
+--- a/test/serializer.test.js
++++ b/test/serializer.test.js
+@@ -210,6 +210,85 @@ test('trusted runtime passthrough preserves Metro module output byte-for-byte',
+   assert.match(dependencyCode, /__mkGb\(/);
+ });
+ 
++test('release empty-global passthrough preserves Metro output when aliases and optional guards are absent', async t => {
++  const harness = makeHarness({
++    wardenOptions: {
++      hardenDynamicCode: false,
++      protectModuleImports: false,
++    },
++  });
++  t.after(() => fs.rmSync(harness.root, { force: true, recursive: true }));
++
++  const originalPackageOutput = harness.graph.dependencies
++    .get(harness.packagePath)
++    .output[0];
++
++  await harness.serializer(
++    harness.entryPath,
++    [],
++    harness.graph,
++    harness.options,
++  );
++
++  const packageOutput = harness.getSerializedGraph().dependencies
++    .get(harness.packagePath)
++    .output[0];
++  assert.strictEqual(packageOutput, originalPackageOutput);
++  assert.doesNotMatch(packageOutput.data.code, /__mkGb\(/);
++});
++
++test('release global access still receives a runtime sandbox', async t => {
++  const harness = makeHarness({
++    wardenOptions: {
++      hardenDynamicCode: false,
++      protectModuleImports: false,
++    },
++  });
++  t.after(() => fs.rmSync(harness.root, { force: true, recursive: true }));
++
++  const packageModule = harness.graph.dependencies.get(harness.packagePath);
++  packageModule.output[0].data.code =
++    '__d(function(global, require, importDefault, importAll, module) { module.exports = global.console; });';
++
++  await harness.serializer(
++    harness.entryPath,
++    [],
++    harness.graph,
++    harness.options,
++  );
++
++  const packageCode = harness.getSerializedGraph().dependencies
++    .get(harness.packagePath)
++    .output[0].data.code;
++  assert.match(packageCode, /__mkGb\(/);
++});
++
++test('release implicit global alias still receives a runtime sandbox', async t => {
++  const harness = makeHarness({
++    wardenOptions: {
++      hardenDynamicCode: false,
++      protectModuleImports: false,
++    },
++  });
++  t.after(() => fs.rmSync(harness.root, { force: true, recursive: true }));
++
++  const packageModule = harness.graph.dependencies.get(harness.packagePath);
++  packageModule.output[0].data.code =
++    '__d(function(global, require, importDefault, importAll, module) { module.exports = typeof window; });';
++
++  await harness.serializer(
++    harness.entryPath,
++    [],
++    harness.graph,
++    harness.options,
++  );
++
++  const packageCode = harness.getSerializedGraph().dependencies
++    .get(harness.packagePath)
++    .output[0].data.code;
++  assert.match(packageCode, /__mkGb\(/);
++});
++
+ test('trusted runtime passthrough rejects paths instead of package names', () => {
+   assert.throws(
+     () =>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -313,7 +313,7 @@
     "tinycolor2": "^1.6.0",
     "ts-toolbelt": "^9.6.0",
     "typescript": "5.7.3",
-    "warden.rn": "2.2.1"
+    "warden.rn": "patch:warden.rn@npm%3A2.2.1#~/.yarn/patches/warden.rn-npm-2.2.1-c1350e5489.patch"
   },
   "engines": {
     "node": ">=22"

--- a/yarn.lock
+++ b/yarn.lock
@@ -38731,7 +38731,7 @@ __metadata:
     typescript: "npm:5.7.3"
     use-count-up: "npm:^3.0.1"
     viem: "npm:2.47.6"
-    warden.rn: "npm:2.2.1"
+    warden.rn: "patch:warden.rn@npm%3A2.2.1#~/.yarn/patches/warden.rn-npm-2.2.1-c1350e5489.patch"
     web3: "npm:^4.3.0"
     web3-eth-abi: "npm:1.7.0"
     web3-utils: "npm:1.7.0"
@@ -46692,6 +46692,19 @@ __metadata:
     "@babel/types": "npm:7.28.5"
     metro-source-map: "npm:0.83.3"
   checksum: 10/8c3f67065497d8e24e7bccde7f642bf3f35e0c37d8a6aede3a606640de36cdb310645e31f6cc811b38d2c550d484e1efdc5b3ffbdef2d9547f2247dfeea26db5
+  languageName: node
+  linkType: hard
+
+"warden.rn@patch:warden.rn@npm%3A2.2.1#~/.yarn/patches/warden.rn-npm-2.2.1-c1350e5489.patch":
+  version: 2.2.1
+  resolution: "warden.rn@patch:warden.rn@npm%3A2.2.1#~/.yarn/patches/warden.rn-npm-2.2.1-c1350e5489.patch::version=2.2.1&hash=c7649d"
+  dependencies:
+    "@babel/generator": "npm:7.28.5"
+    "@babel/parser": "npm:7.28.5"
+    "@babel/traverse": "npm:7.28.5"
+    "@babel/types": "npm:7.28.5"
+    metro-source-map: "npm:0.83.3"
+  checksum: 10/4cbe5907ced34a1bfebd0fd428204e522af63f43d145dc1efefb5ae3edbf1675bbe8975d204ac1f0bfd889240812b10ce37ea3d7d3a488a684def9668dc8c56b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- preserve Metro's original output for release modules that have no detected or effective global capabilities
- keep the Warden runtime sandbox for modules that access globals or implicit global aliases
- disable the passthrough whenever import protection, dynamic-code hardening, or the harden-after boundary requires instrumentation
- add focused serializer coverage and bundle-time counters for the new path

## Why

On the original `sec/warden` build, every non-trusted module received a runtime global sandbox even when the module did not use any global capability. That added substantial code and runtime work to the first entry of Send, Swap, and Bridge.

The optimized Android bundle kept 1,635 main-bundle modules in the runtime sandbox and passed through 14,398 empty-global modules. The worker bundle passed through another 421 empty-global modules.

## Pixel performance comparison

Same Pixel, same wallet state, real taps from Home, 8 paired first/second visits per route:

| Route | Original Warden first visible | Optimized first visible | Improvement | Original interactive | Optimized interactive |
| --- | ---: | ---: | ---: | ---: | ---: |
| Send | 278.5 ms | 180.5 ms | 98 ms (35%) | 562 ms | 322.5 ms |
| Swap | 276 ms | 184.5 ms | 91.5 ms (33%) | 587.5 ms | 332.5 ms |
| Bridge | 272.5 ms | 181.5 ms | 91 ms (33%) | 531 ms | 323.5 ms |

Navigation dispatch and route-render timing were unchanged. The gain appears between route render and content render/visibility, which is consistent with avoiding unnecessary module sandboxes.

Bundle size also decreased:

- main Hermes bundle: 47.5 MB → 43.5 MB (-8.5%)
- worker Hermes bundle: 1.76 MB → 1.43 MB (-18.8%)

## Security boundary / trade-off to review

A module is passed through only when all of the following hold:

- production/release transformation (`dev === false`)
- no detected global access and no effective global policy
- no reference to Metro's factory global or Warden's implicit aliases (`globalThis`, `self`, `window`, `global`, `g`, `__mkGb`)
- module import protection is disabled
- dynamic-code hardening is disabled
- the module is not the configured harden-after module

Modules that use a global capability continue through the existing Warden rewrite and sandbox. The main trade-off is that an empty-global module keeps Metro's byte-for-byte output instead of receiving a dormant sandbox wrapper.

## Validation

- full Android Regression build succeeded
- Regression APK installed and exercised on Pixel
- `warden.rn` test suite: 21 passed
- new tests cover empty-global passthrough, real global access, and implicit global aliases
