### PR TITLE
fix: restore iOS import pager gestures

### DIFF
--- a/apps/mobile/src/screens/Address/ImportSecret.tsx
+++ b/apps/mobile/src/screens/Address/ImportSecret.tsx
@@ -8,13 +8,7 @@ import { useScanner } from '../Scanner/ScannerScreen';
 import PasteButton from '@/components2024/PasteButton';
 import { NextInput } from '@/components2024/Form/Input';
 import { createGetStyles2024 } from '@/utils/styles';
-import {
-  Keyboard,
-  Platform,
-  Pressable,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { Keyboard, Pressable, TouchableOpacity, View } from 'react-native';
 import { validateAndCleanPrivateKey } from '@/core/apis/privateKey';
 import { apiPrivateKey, apiMnemonic } from '@/core/apis';
 import { validateAndCleanMnemonic } from '@/core/apis/mnemonic';
@@ -35,9 +29,13 @@ import * as SecretVault from '@/core/utils/secretVault';
 import { E2E_ID } from '@/constant/e2e';
 import { makeTestIDProps } from '@/utils/makeTestIDProps';
 import { ensureWalletUnlockedForAction } from '@/utils/walletUnlock';
+import { IS_ANDROID } from '@/core/native/utils';
 
 /** Toast position at the top of screen */
 const TOAST_POSITION_TOP = 30;
+
+// Android needs touch-start dismissal without Pressable claiming the swipe.
+const Container = IS_ANDROID ? View : Pressable;
 
 type TabType = 'seedPhrase' | 'privateKey';
 
@@ -71,6 +69,7 @@ export const ImportSecret = ({ route }: ScreenProps) => {
 
   // Clear errors when switching tabs
   const handleTabChange = React.useCallback((tab: TabType) => {
+    Keyboard.dismiss();
     setActiveTab(tab);
     setMnemonicError(undefined);
     setPrivateKeyError(undefined);
@@ -140,6 +139,7 @@ export const ImportSecret = ({ route }: ScreenProps) => {
                 textContentType: 'none',
                 blurOnSubmit: true,
                 returnKeyType: 'done',
+                rejectResponderTermination: false,
                 ...makeTestIDProps(
                   !isSeedPhrase ? E2E_ID.onboarding.privateKeyInput : null,
                 ),
@@ -433,12 +433,15 @@ export const ImportSecret = ({ route }: ScreenProps) => {
       }}
       style={styles.screen}
       footerBottomOffset={48}>
-      <View
+      <Container
+        accessible={false}
         style={styles.container}
-        onTouchStart={Platform.OS === 'android' ? Keyboard.dismiss : undefined}>
+        onTouchStart={IS_ANDROID ? Keyboard.dismiss : undefined}
+        onPress={IS_ANDROID ? undefined : Keyboard.dismiss}>
         <View style={styles.content}>
           <PagerView
             ref={pagerRef}
+            keyboardDismissMode="on-drag"
             style={styles.pager}
             initialPage={initialTab === 'privateKey' ? 1 : 0}
             onPageSelected={({ nativeEvent }) => {
@@ -474,7 +477,7 @@ export const ImportSecret = ({ route }: ScreenProps) => {
             </Text>
           </View>
         )}
-      </View>
+      </Container>
     </FooterButtonScreenContainer>
   );
 };

--- a/apps/mobile/src/screens/Address/ImportSecret.tsx
+++ b/apps/mobile/src/screens/Address/ImportSecret.tsx
@@ -8,7 +8,13 @@ import { useScanner } from '../Scanner/ScannerScreen';
 import PasteButton from '@/components2024/PasteButton';
 import { NextInput } from '@/components2024/Form/Input';
 import { createGetStyles2024 } from '@/utils/styles';
-import { Keyboard, Pressable, TouchableOpacity, View } from 'react-native';
+import {
+  Keyboard,
+  Platform,
+  Pressable,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { validateAndCleanPrivateKey } from '@/core/apis/privateKey';
 import { apiPrivateKey, apiMnemonic } from '@/core/apis';
 import { validateAndCleanMnemonic } from '@/core/apis/mnemonic';
@@ -427,7 +433,9 @@ export const ImportSecret = ({ route }: ScreenProps) => {
       }}
       style={styles.screen}
       footerBottomOffset={48}>
-      <View style={styles.container} onTouchStart={() => Keyboard.dismiss()}>
+      <View
+        style={styles.container}
+        onTouchStart={Platform.OS === 'android' ? Keyboard.dismiss : undefined}>
         <View style={styles.content}>
           <PagerView
             ref={pagerRef}


### PR DESCRIPTION
Fix swiping between Seed Phrase and Private Key while editing on iOS, retaining native PagerView transitions. Use press-based keyboard dismissal on iOS and allow the text input to yield its responder; preserve Android's View container with touch-start dismissal. Dismiss the keyboard when selecting a tab or dragging the pager.

Validation:
- On this branch: changed-file ESLint, Prettier, commit hooks and whitespace checks passed.
