### PR TITLE
fix: guard address removal and handle unlock cancellation

### DIFF
--- a/apps/mobile/src/core/apis/address.test.ts
+++ b/apps/mobile/src/core/apis/address.test.ts
@@ -4,6 +4,7 @@ const KEYRING_TYPE = {
   WalletConnectKeyring: 'WalletConnectKeyring',
   SimpleKeyring: 'SimpleKeyring',
   HdKeyring: 'HdKeyring',
+  LedgerKeyring: 'LedgerKeyring',
 } as const;
 
 type Account = {
@@ -193,9 +194,12 @@ function loadAddressModule({
   }));
 
   const addressModule = require('./address') as typeof import('./address');
+  const { setWalletUnlockRequester } =
+    require('@/utils/walletUnlockGuard') as typeof import('@/utils/walletUnlockGuard');
 
   return {
     ...addressModule,
+    setWalletUnlockRequester,
     mocks: {
       mockAddNewAccount,
       mockAddNewWatchAccounts,
@@ -382,7 +386,7 @@ describe('core/apis/address', () => {
 
     await removeAddress(walletConnectAccount);
 
-    expect(mocks.mockIsUnlocked).not.toHaveBeenCalled();
+    expect(mocks.mockIsUnlocked).toHaveBeenCalledTimes(1);
     expect(mocks.mockRemoveAccount).toHaveBeenCalledWith(
       '0xwalletconnect',
       KEYRING_TYPE.WalletConnectKeyring,
@@ -401,22 +405,67 @@ describe('core/apis/address', () => {
     expect(mocks.mockSetCurrentAccount).not.toHaveBeenCalled();
   });
 
-  it('requires an unlocked wallet before removing sensitive keyring accounts', async () => {
-    const { removeAddress, mocks } = loadAddressModule({
-      isUnlocked: false,
+  it.each(Object.values(KEYRING_TYPE))(
+    'requires an unlocked wallet before removing %s accounts',
+    async type => {
+      const { removeAddress, mocks } = loadAddressModule({
+        isUnlocked: false,
+      });
+
+      await expect(removeAddress(createAccount({ type }))).rejects.toThrow(
+        'background.error.unlock',
+      );
+
+      expect(mocks.mockRemoveAccount).not.toHaveBeenCalled();
+      expect(mocks.mockRemoveAgentWallet).not.toHaveBeenCalled();
+      expect(
+        mocks.mockDisconnectWalletConnectSessionsForRemovedAccount,
+      ).not.toHaveBeenCalled();
+    },
+  );
+
+  it('waits for hardware account unlock before deletion and Agent cleanup', async () => {
+    const { removeAddress, setWalletUnlockRequester, mocks } =
+      loadAddressModule({ isUnlocked: false });
+    const account = createAccount({ type: KEYRING_TYPE.LedgerKeyring });
+    let finishUnlock!: () => void;
+    const unlockPromise = new Promise<void>(resolve => {
+      finishUnlock = resolve;
+    });
+    const requestUnlock = jest.fn(() => unlockPromise);
+    setWalletUnlockRequester(requestUnlock);
+
+    const removal = removeAddress(account);
+
+    expect(requestUnlock).toHaveBeenCalledTimes(1);
+    expect(mocks.mockRemoveAccount).not.toHaveBeenCalled();
+    expect(mocks.mockRemoveAgentWallet).not.toHaveBeenCalled();
+
+    mocks.mockIsUnlocked.mockReturnValue(true);
+    finishUnlock();
+    await expect(removal).resolves.toBeUndefined();
+
+    expect(mocks.mockRemoveAccount).toHaveBeenCalledWith(
+      account.address,
+      account.type,
+      account.brandName,
+      true,
+    );
+    expect(mocks.mockRemoveAgentWallet).toHaveBeenCalledWith(account.address);
+  });
+
+  it('keeps the hardware account and Agent data when unlock is cancelled', async () => {
+    const { removeAddress, setWalletUnlockRequester, mocks } =
+      loadAddressModule({ isUnlocked: false });
+    setWalletUnlockRequester(async () => {
+      throw new Error('Unlock cancelled');
     });
 
     await expect(
-      removeAddress(
-        createAccount({
-          type: KEYRING_TYPE.SimpleKeyring,
-        }),
-      ),
-    ).rejects.toThrow('background.error.unlock');
+      removeAddress(createAccount({ type: KEYRING_TYPE.LedgerKeyring })),
+    ).rejects.toThrow('Unlock cancelled');
 
     expect(mocks.mockRemoveAccount).not.toHaveBeenCalled();
-    expect(
-      mocks.mockDisconnectWalletConnectSessionsForRemovedAccount,
-    ).not.toHaveBeenCalled();
+    expect(mocks.mockRemoveAgentWallet).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/src/core/apis/address.ts
+++ b/apps/mobile/src/core/apis/address.ts
@@ -18,10 +18,7 @@ import { transactionHistoryServiceApi } from '@/core/serviceApi/transactionHisto
 import { getKeyring } from './keyring';
 import { BroadcastEvent } from '@/constant/event';
 import { removeTestnetAddressBalanceCache } from '@/utils/testnetAddressBalanceCache';
-import {
-  isSensitiveKeyringType,
-  withWalletUnlockIf,
-} from '@/utils/walletUnlockGuard';
+import { withWalletUnlock } from '@/utils/walletUnlockGuard';
 import { disconnectWalletConnectSessionsForRemovedAccount } from '../walletconnect/accountRemoval';
 
 export async function addWatchAddress(address: string) {
@@ -67,8 +64,7 @@ async function resetCurrentAccount() {
   }
 }
 
-export const removeAddress = withWalletUnlockIf(
-  account => isSensitiveKeyringType(account.type),
+export const removeAddress = withWalletUnlock(
   async (account: KeyringAccountWithAlias) => {
     const isRemoveEmptyKeyring =
       account.type !== KEYRING_TYPE.WalletConnectKeyring;

--- a/apps/mobile/src/screens/Address/useDeleteAccountModal.test.ts
+++ b/apps/mobile/src/screens/Address/useDeleteAccountModal.test.ts
@@ -1,0 +1,101 @@
+import { renderHook } from '@testing-library/react-native';
+import { KEYRING_TYPE } from '@rabby-wallet/keyring-utils';
+import { WalletUnlockCancelledError } from '@/utils/walletUnlockError';
+import { useDeleteAccountModal } from './useDeleteAccountModal';
+
+const mockShow = jest.fn();
+const mockRemoveAccount = jest.fn();
+const mockRefreshBalance = jest.fn();
+const mockRefreshAccountFlags = jest.fn();
+const mockRedirect = jest.fn();
+
+jest.mock('@/components/AuthenticationModal/AuthenticationModal', () => ({
+  AuthenticationModal: { show: (...args: unknown[]) => mockShow(...args) },
+}));
+jest.mock('@/core/apis', () => ({ apisLock: {} }));
+jest.mock('@/core/serviceApi/keyring', () => ({ keyringServiceApi: {} }));
+jest.mock('@/hooks/account', () => ({
+  storeApiAccounts: {
+    removeAccount: (...args: unknown[]) => mockRemoveAccount(...args),
+  },
+}));
+jest.mock('@/hooks/useEnterPassphraseModal', () => ({
+  useEnterPassphraseModal: () => jest.fn(),
+}));
+jest.mock('@/store/homeBalanceRefresh', () => ({
+  refreshHomeBalanceAfterAccountMutation: () => mockRefreshBalance(),
+}));
+jest.mock('@/utils/navigation', () => ({
+  redirectToAddAddressEntry: (...args: unknown[]) => mockRedirect(...args),
+}));
+jest.mock('@/hooks/useLock', () => ({
+  refreshAppLockAccountFlags: () => mockRefreshAccountFlags(),
+}));
+jest.mock('react-native-haptic-feedback', () => ({ trigger: jest.fn() }));
+jest.mock('@/utils/walletUnlock', () => ({
+  ...jest.requireActual('@/utils/walletUnlockError'),
+  ensureWalletUnlockedForAction: jest.fn(async () => true),
+}));
+jest.mock('@/utils/i18n', () => ({
+  __esModule: true,
+  default: { t: (key: string) => key },
+}));
+
+const account = {
+  address: '0xabcd000000000000000000000000000000001234',
+  type: KEYRING_TYPE.LedgerKeyring,
+  brandName: KEYRING_TYPE.LedgerKeyring,
+};
+
+describe('delete account modal completion', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRemoveAccount.mockResolvedValue(undefined);
+    mockRefreshBalance.mockResolvedValue(undefined);
+    mockRefreshAccountFlags.mockResolvedValue({ accountState: 'empty' });
+  });
+
+  async function confirmDeletion() {
+    const onFinished = jest.fn();
+    const { result } = renderHook(() => useDeleteAccountModal());
+    await result.current({ account, onFinished });
+    const modal = mockShow.mock.calls[0][0];
+    expect(modal.authType).toEqual(['none']);
+    return { finish: () => modal.onFinished(), onFinished };
+  }
+
+  it('handles unlock cancellation without continuing deletion completion', async () => {
+    mockRemoveAccount.mockRejectedValue(new WalletUnlockCancelledError());
+    const { finish, onFinished } = await confirmDeletion();
+
+    await expect(finish()).resolves.toBeUndefined();
+
+    expect(mockRemoveAccount).toHaveBeenCalledWith(account);
+    expect(mockRefreshBalance).not.toHaveBeenCalled();
+    expect(mockRefreshAccountFlags).not.toHaveBeenCalled();
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(onFinished).not.toHaveBeenCalled();
+  });
+
+  it('preserves actual deletion failures', async () => {
+    const error = new Error('Account removal failed');
+    mockRemoveAccount.mockRejectedValue(error);
+    const { finish, onFinished } = await confirmDeletion();
+
+    await expect(finish()).rejects.toBe(error);
+
+    expect(mockRefreshBalance).not.toHaveBeenCalled();
+    expect(onFinished).not.toHaveBeenCalled();
+  });
+
+  it('refreshes and navigates after successful removal', async () => {
+    const { finish, onFinished } = await confirmDeletion();
+
+    await expect(finish()).resolves.toBeUndefined();
+
+    expect(mockRefreshBalance).toHaveBeenCalledTimes(1);
+    expect(mockRefreshAccountFlags).toHaveBeenCalledTimes(1);
+    expect(mockRedirect).toHaveBeenCalledWith({ action: 'resetTo' });
+    expect(onFinished).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/screens/Address/useDeleteAccountModal.ts
+++ b/apps/mobile/src/screens/Address/useDeleteAccountModal.ts
@@ -11,7 +11,10 @@ import { redirectToAddAddressEntry } from '@/utils/navigation';
 import { KEYRING_TYPE } from '@rabby-wallet/keyring-utils';
 import { useCallback } from 'react';
 import { trigger } from 'react-native-haptic-feedback';
-import { ensureWalletUnlockedForAction } from '@/utils/walletUnlock';
+import {
+  ensureWalletUnlockedForAction,
+  isWalletUnlockCancelled,
+} from '@/utils/walletUnlock';
 import { isSameAddress } from '@rabby-wallet/base-utils/dist/isomorphic/address';
 import i18n from '@/utils/i18n';
 import { refreshAppLockAccountFlags } from '@/hooks/useLock';
@@ -96,7 +99,14 @@ export const useDeleteAccountModal = () => {
           ) {
             return;
           }
-          await storeApiAccounts.removeAccount(account);
+          try {
+            await storeApiAccounts.removeAccount(account);
+          } catch (error) {
+            if (isWalletUnlockCancelled(error)) {
+              return;
+            }
+            throw error;
+          }
           void refreshHomeBalanceAfterAccountMutation().catch(error => {
             console.error(
               '[useDeleteAccountModal] failed to refresh Home balance after deleting account',

--- a/apps/mobile/src/store/account.ts
+++ b/apps/mobile/src/store/account.ts
@@ -227,8 +227,8 @@ class AccountStore extends BaseStore<AccountStoreState> {
   removeAccount = async (account: KeyringAccountWithAlias) => {
     const accounts = await getAllAccounts();
 
-    await this.togglePinAddressAsync({ ...account, nextPinned: false });
     await removeAddress(account);
+    await this.togglePinAddressAsync({ ...account, nextPinned: false });
     invalidateFetchAllAccountsCache();
     await this.fetchAccounts({ force: true });
 

--- a/apps/mobile/src/store/accountPinnedAddresses.test.ts
+++ b/apps/mobile/src/store/accountPinnedAddresses.test.ts
@@ -1,3 +1,5 @@
+import { WalletUnlockCancelledError } from '@/utils/walletUnlockError';
+
 describe('accountStore pinned address hydration', () => {
   const persistedAddress = {
     address: '0xAbCd000000000000000000000000000000001234',
@@ -6,6 +8,9 @@ describe('accountStore pinned address hydration', () => {
 
   const mockGetPinnedAddresses = jest.fn();
   const mockUpdatePinnedAddresses = jest.fn();
+  const mockGetAllAccounts = jest.fn();
+  const mockRemoveAddress = jest.fn();
+  const mockFetchAllAccounts = jest.fn();
   let resolvePinnedAddresses:
     | ((addresses: (typeof persistedAddress)[]) => void)
     | null;
@@ -23,6 +28,8 @@ describe('accountStore pinned address hydration', () => {
         }),
     );
     mockUpdatePinnedAddresses.mockResolvedValue(undefined);
+    mockRemoveAddress.mockResolvedValue(undefined);
+    mockFetchAllAccounts.mockResolvedValue([]);
 
     jest.doMock('react-native', () => ({
       InteractionManager: {
@@ -39,15 +46,15 @@ describe('accountStore pinned address hydration', () => {
     });
     jest.doMock('@/core/apis/account', () => ({
       accountEvents: { emit: jest.fn(), on: jest.fn() },
-      fetchAllAccounts: jest.fn(),
+      fetchAllAccounts: (...args: unknown[]) => mockFetchAllAccounts(...args),
       invalidateFetchAllAccountsCache: jest.fn(),
     }));
     jest.doMock('@/core/apis/mnemonic', () => ({
       getMnemonicAddressInfo: jest.fn(),
     }));
     jest.doMock('@/core/apis/address', () => ({
-      getAllAccounts: jest.fn(),
-      removeAddress: jest.fn(),
+      getAllAccounts: () => mockGetAllAccounts(),
+      removeAddress: (...args: unknown[]) => mockRemoveAddress(...args),
     }));
     jest.doMock('@/databases/entities/accountInfo', () => ({
       AccountInfoEntity: {
@@ -133,5 +140,45 @@ describe('accountStore pinned address hydration', () => {
     expect(mockGetPinnedAddresses).toHaveBeenCalledTimes(1);
     expect(mockUpdatePinnedAddresses).toHaveBeenCalledWith([persistedAddress]);
     expect(accountStore.getState().pinnedAddresses).toEqual([persistedAddress]);
+  });
+
+  it.each([
+    new WalletUnlockCancelledError(),
+    new Error('Account removal failed'),
+  ])('preserves the pin and account when removal rejects: %s', async error => {
+    const account = { ...persistedAddress, type: 'Ledger Hardware' as const };
+    mockGetAllAccounts.mockResolvedValue([account]);
+    mockGetPinnedAddresses.mockResolvedValue([persistedAddress]);
+    mockRemoveAddress.mockRejectedValue(error);
+    await accountStore.ensurePinnedAddressesHydrated();
+    accountStore.setAccounts([account]);
+
+    await expect(accountStore.removeAccount(account)).rejects.toBe(error);
+
+    expect(accountStore.getState().accounts).toEqual([account]);
+    expect(accountStore.getState().pinnedAddresses).toEqual([persistedAddress]);
+    expect(mockUpdatePinnedAddresses).not.toHaveBeenCalled();
+    expect(mockFetchAllAccounts).not.toHaveBeenCalled();
+  });
+
+  it('unpins and refreshes the account list after successful removal', async () => {
+    const account = { ...persistedAddress, type: 'Ledger Hardware' as const };
+    mockGetAllAccounts.mockResolvedValue([account]);
+    mockGetPinnedAddresses.mockResolvedValue([persistedAddress]);
+    await accountStore.ensurePinnedAddressesHydrated();
+    accountStore.setAccounts([account]);
+    mockRemoveAddress.mockImplementationOnce(async () => {
+      expect(accountStore.getState().pinnedAddresses).toEqual([
+        persistedAddress,
+      ]);
+      expect(mockUpdatePinnedAddresses).not.toHaveBeenCalled();
+    });
+
+    await accountStore.removeAccount(account);
+
+    expect(mockUpdatePinnedAddresses).toHaveBeenCalledWith([]);
+    expect(accountStore.getState().pinnedAddresses).toEqual([]);
+    expect(mockFetchAllAccounts).toHaveBeenCalledWith({ force: true });
+    expect(accountStore.getState().accounts).toEqual([]);
   });
 });


### PR DESCRIPTION
Removing an address while Rabby was locked could delete the keyring account before Perps Agent cleanup failed with `password can not be null`, interrupting the remaining refresh and navigation. The shared `removeAddress` API now uses `withWalletUnlock` for every account type, waiting for unlock and keyring runtime readiness before removal starts.

Cancelling that unlock must also leave the account pinned. AccountStore now unpins only after `removeAddress` succeeds, and the delete modal handles `WalletUnlockCancelledError` as cancellation without running completion, balance refresh, or navigation. Actual deletion errors still propagate.

Validation:

- Focused API, unlock guard, Store, and modal unit tests: 4 suites / 26 tests passed. Restoring the pre-cancellation-fix implementation makes four Store/modal regression cases fail.
- Full mobile unit suite: 497 suites / 3366 tests passed (`--runInBand --watchman=false`).
- A diagnostic harness executing the actual modal callback, AccountStore, address API, unlock guard, and pin preference methods confirms that Ledger, Watch, Safe, and WalletConnect cancellation preserves the account and pin without an unhandled rejection. Native UI and storage boundaries were simulated; this is not device/E2E evidence.
- `lint:cycles`, `lint:cycles:eslint`, `typecheck`, touched-file ESLint, and `git diff --check` passed. Startup governance passed with its existing `appWin.ts` warning.
- `test:integration:ci --watchman=false`: the boundary check and all 26 main suites / 108 assertions passed, but the existing late Hyperliquid `SymbolConversion` error caused exit 1 before the isolated cold-start scenarios. This failure was also reproduced on unchanged `origin/develop` at `290f342c0fb467c2aeb6d0dc369d6db6fb5487c6` during the original fix.
- GitHub [Mobile Integration Tests](https://github.com/RabbyHub/rabby-mobile/actions/runs/34434028275) passed for `16bdbf20352752088ae849b6ca71697f6b1d92a2`.

This remains an explicit user-action path; it adds no startup work or subscriptions. Relocking during later deletion awaits and stale account-list requests remain separate issues. Device/E2E validation was not run.
