### PR TITLE
fix: render multi-address assets on initial viewport

### DIFF
--- a/apps/mobile/src/screens/Address/components/MultiAssets/TokenList.tsx
+++ b/apps/mobile/src/screens/Address/components/MultiAssets/TokenList.tsx
@@ -93,7 +93,10 @@ const MemoizedScamTokenHeader = React.memo(ScamTokenHeader);
 const MemoizedTokenRowSectionHeader = React.memo(TokenRowSectionLpTokenHeader);
 
 const MemoizedItemLoader = React.memo(ItemLoader);
-const TOKEN_LIST_INITIAL_RENDER_COUNT = 8;
+// SectionList counts its synthetic section cells against initialNumToRender.
+// Inside the collapsible tab, follow-up batches can wait for the first scroll
+// event, so cover one tall-device viewport (plus section overhead) up front.
+const TOKEN_LIST_INITIAL_RENDER_COUNT = 16;
 const TOKEN_LIST_RENDER_BATCH_SIZE = 6;
 const TOKEN_LIST_WINDOW_SIZE = 7;
 const TOKEN_LIST_BATCHING_PERIOD_MS = 32;


### PR DESCRIPTION
## Summary

- increase the Token SectionList initial render budget to cover section cells and a tall-device viewport
- avoid waiting for the first scroll event before follow-up rows or LP assets render
- address QA issues 983 and 988

## Validation

- Android regression build installed and validated on Pixel, Samsung, and Huawei P30
- iPhone 13 mini: 4/4 untouched cold launches rendered more than seven rows
- Pixel LP section rendered its first item immediately without a follow-up scroll
- Android and iOS regression builds completed successfully
- lint-staged and diff check passed