### PR TITLE
fix: preserve custom network transaction receipt status

### DIFF
--- a/apps/mobile/src/core/services/customTestnetService.test.ts
+++ b/apps/mobile/src/core/services/customTestnetService.test.ts
@@ -1,0 +1,85 @@
+jest.mock('@/utils/chain', () => ({
+  findChain: jest.fn(),
+}));
+
+jest.mock('@/utils/token', () => ({
+  customTestnetTokenToTokenItem: jest.fn(token => token),
+}));
+
+jest.mock('@/constant/chains', () => ({
+  updateChainStore: jest.fn(),
+}));
+
+jest.mock('@/store/customTestnet', () => ({
+  syncCustomTestnetStore: jest.fn(),
+}));
+
+jest.mock('../storage/mmkv', () => ({ appStorage: undefined }));
+
+jest.mock('viem/actions', () => ({
+  getTransactionReceipt: jest.fn(),
+}));
+
+import { createClient, http } from 'viem';
+import type { TransactionReceipt } from 'viem';
+import { getTransactionReceipt } from 'viem/actions';
+import { findChain } from '@/utils/chain';
+import { createTestnetChain } from '@/core/utils/customTestnetChain';
+import { CustomTestnetService } from './customTestnetService';
+
+const hash = `0x${'ab'.repeat(32)}` as const;
+const chain = createTestnetChain({
+  id: 123456,
+  name: 'Custom network',
+  nativeTokenSymbol: 'ETH',
+  rpcUrl: 'https://rpc.example',
+});
+
+describe('CustomTestnetService.getTx receipt status', () => {
+  let service: CustomTestnetService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(findChain).mockReturnValue(chain);
+    service = new CustomTestnetService();
+    service.chains[chain.id] = createClient({ transport: http(chain.rpcUrl) });
+  });
+
+  it.each([
+    ['success', 1],
+    ['reverted', 0],
+  ] as const)(
+    'preserves a mined %s receipt as status %i',
+    async (status, expectedStatus) => {
+      jest.mocked(getTransactionReceipt).mockResolvedValue({
+        transactionHash: hash,
+        status,
+        gasUsed: 21000n,
+      } as TransactionReceipt);
+
+      await expect(
+        service.getTx({ chainId: chain.id, hash }),
+      ).resolves.toMatchObject({
+        hash,
+        code: 0,
+        status: expectedStatus,
+        gas_used: 21000,
+      });
+    },
+  );
+
+  it('keeps an unavailable receipt unresolved instead of completing the transaction', async () => {
+    jest
+      .mocked(getTransactionReceipt)
+      .mockRejectedValue(new Error('Receipt unavailable'));
+
+    await expect(
+      service.getTx({ chainId: chain.id, hash }),
+    ).resolves.toMatchObject({
+      hash,
+      code: -1,
+      status: 0,
+      gas_used: 0,
+    });
+  });
+});

--- a/apps/mobile/src/core/services/customTestnetService.ts
+++ b/apps/mobile/src/core/services/customTestnetService.ts
@@ -246,7 +246,7 @@ export class CustomTestnetService extends StoreServiceBase<
           ...res,
           hash: res.transactionHash,
           code: 0,
-          status: 1,
+          status: parseInt(res.status, 16),
           gas_used: Number(res.gasUsed),
           token: customTestnetTokenToTokenItem({
             amount: 0,


### PR DESCRIPTION
## Summary

- Map custom network receipt status from the RPC response instead of always marking transactions as successful.
- Add coverage for successful, reverted, and unavailable transaction receipts.

## Testing

- Added Jest coverage for mined success/reverted receipts and unresolved receipts.
- Not run (not requested).