### PR TITLE
fix: retry CocoaPods CDN over HTTP/1.1

### DIFF
--- a/apps/mobile/scripts/ci/cocoapods-force-http1.rb
+++ b/apps/mobile/scripts/ci/cocoapods-force-http1.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# CocoaPods' CDN client explicitly requests HTTP/2 through Typhoeus. Some
+# build-network paths consistently fail those requests with CURLE_HTTP2 while
+# the same CDN is reachable over HTTP/1.1. This hook is loaded only for the
+# bounded fallback attempt after a normal `pod install` has failed.
+require 'typhoeus'
+
+module RabbyCocoaPodsForceHttp1
+  def initialize(base_url, options = {})
+    if options[:http_version] == :httpv2_0
+      options = options.merge(:http_version => :httpv1_1)
+    end
+
+    super(base_url, options)
+  end
+end
+
+Typhoeus::Request.prepend(RabbyCocoaPodsForceHttp1)

--- a/apps/mobile/scripts/turbo-build/_fns.sh
+++ b/apps/mobile/scripts/turbo-build/_fns.sh
@@ -438,7 +438,13 @@ turbo_bundle_exec() {
 }
 
 turbo_bundle_pod() {
-  turbo_bundle_exec exec ruby -e 'load Gem.bin_path("cocoapods", "pod")' -- "$@"
+  if [ "${RABBY_MOBILE_COCOAPODS_FORCE_HTTP1:-false}" = "true" ]; then
+    turbo_bundle_exec exec ruby \
+      -e 'require ARGV.shift; load Gem.bin_path("cocoapods", "pod")' -- \
+      "$script_dir/ci/cocoapods-force-http1.rb" "$@"
+  else
+    turbo_bundle_exec exec ruby -e 'load Gem.bin_path("cocoapods", "pod")' -- "$@"
+  fi
 }
 
 turbo_log() {
@@ -1226,11 +1232,25 @@ turbo_prepare_cocoapods() {
       return 0
     fi
 
-    (cd "$project_dir/ios" && turbo_bundle_pod install) || return $?
+    turbo_install_cocoapods || return $?
     turbo_save_layer cocoapods "$cache_key" apps/mobile/ios/Pods
   else
-    (cd "$project_dir/ios" && turbo_bundle_pod install --repo-update) || return $?
+    turbo_install_cocoapods --repo-update || return $?
   fi
+}
+
+turbo_install_cocoapods() {
+  if (cd "$project_dir/ios" && turbo_bundle_pod install "$@"); then
+    return 0
+  else
+    tb_cocoapods_status=$?
+  fi
+
+  turbo_log "CocoaPods install failed with status $tb_cocoapods_status; retrying once with CDN requests forced to HTTP/1.1"
+  (
+    cd "$project_dir/ios" &&
+      RABBY_MOBILE_COCOAPODS_FORCE_HTTP1=true turbo_bundle_pod install "$@"
+  )
 }
 
 turbo_restore_gradle_state() {


### PR DESCRIPTION
## Summary

- keep the normal CocoaPods CDN request path as the first attempt
- retry once with Typhoeus forced to HTTP/1.1 when the normal install fails
- apply the fallback to both cached and uncached iOS preparation paths

## Validation

- reproduced the jsDelivr HTTP/2 framing failure locally
- verified the HTTP/1.1 fallback completes pod installation
- completed a local iOS regression ad-hoc build through archive and IPA export
- `bash -n apps/mobile/scripts/turbo-build/_fns.sh`
- `ruby -c apps/mobile/scripts/ci/cocoapods-force-http1.rb`